### PR TITLE
Only jump into IPython when running data.py as script

### DIFF
--- a/data.py
+++ b/data.py
@@ -576,5 +576,5 @@ class Unit():
         self.team.append_unit(self)            
                 
                 
-        
-import IPython; IPython.embed()
+if __name__ == "__main__":        
+    import IPython; IPython.embed()


### PR DESCRIPTION
Not when importing from build.py

This makes it easier to run `build.py` and other scripts using `data.py`