### PR TITLE
Normalize casing, spelling, and spacing across race TOML files

### DIFF
--- a/v3/races/abomination.toml
+++ b/v3/races/abomination.toml
@@ -44,23 +44,23 @@ fast = [["-", "Load"], ["-", "Fire"]]
 still = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 [units.squid.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: as below, shaken",
 	"5-8: as below, d6 critical damage",
 	"9: Unit destroyed",
 ]
-critical = [
+Critical = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Cannot rotate",
-	"5: Unit cannot Move ",
+	"5: Unit cannot move",
 	"6: set on fire",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12: Unit destroyed",
 ]
 
@@ -107,23 +107,23 @@ slow = [["Load", "-"], ["Fire", "-"], ["Aim", "-"]]
 still = [["Load", "-"], ["Fire", "-"], ["Aim", "-"]]
 
 [units.mothership.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: +2 to future damage",
 	"5-11: as below, d6 critical damage",
 	"12: Unit destroyed",
 ]
-critical = ["1: Shaken",
+Critical = ["1: shaken",
 	 "2: +2 extra to future damage",
-	"3-4: Unit cannot Move. Speed set to still",
+	"3-4: Unit cannot move. Speed set to still",
 	"5-6: set on fire",
 ]
 
-crew = [
-	"4-5: If already shaken double initial crew damage",
+Crew = [
+	"4-5: If already shaken double initial Crew damage",
 	"6-7: As 4-5, and Crippled Crew",
 	"8-9: as 6-7, shaken",
-	"10-17: as 8-9, +3 to future crew damage",
+	"10-17: as 8-9, +3 to future Crew damage",
 	"18: Unit destroyed",
 ]
 
@@ -174,23 +174,23 @@ still = [
 ]
 
 [units.frost88.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: as below, shaken",
 	"5-8: as below, d6 critical damage",
 	"9: Unit destroyed",
 ]
-critical = [
+Critical = [
 	"1: +3 to future damage",
 	"2: +1 to be hit, -1 to hit",
 	"3: Cannot rotate",
-	"4-5: Unit cannot Move ",
+	"4-5: Unit cannot move",
 	"6: set on fire",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12: Unit destroyed",
 ]
 
@@ -229,13 +229,13 @@ slow = [["360°", "F", "360°"], ["360°", "F", "B"]]
 still = [["360°", "360°", "360°"], ["360°", "A ", "F"]]
 
 [units.abomination_infantry.damage_tables]
-regular = [
+Regular = [
 	"1-6: Kill 1 model",
-	"7-8: Kill 1 model, psychic damage[d6]",
+	"7-8: Kill 1 model, Psychic damage[d6]",
 	"9+: Unit destroyed",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 [units.horror]
 race = "abomination"
@@ -256,7 +256,7 @@ movement_order = ["-", "-", "-"]
 "Resistance" = "Poison[12]"
 "Immunity" = "acid and fire"
 "Forward Position" = "[3]"
-"Note" = "Looses terror, poison cloud when standing in water"
+"Note" = "loses terror, poison cloud when standing in water"
 
 
 [units.horror.orders.movement]
@@ -264,7 +264,7 @@ slow = [["360°", "F", "360°"], ["360°", "F", "B"]]
 still = [["360°", "360°", "360°"], ["360°", "A ", "F"]]
 
 [units.horror.damage_tables]
-regular = [
+Regular = [
 	"1-3: Bleed[6]",
 	"4-5: As below, +1 to future damage",
 	"6-8: As below, if caused by bleeding, amplify bleeding",
@@ -272,7 +272,7 @@ regular = [
 	"{{\\it Note:  Amplify bleeding: Bleed[4] becomes Bleed[6], Bleed[6] becomes Bleed[8] etc up to max Bleed[12]}}",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.shriek_monstrosity]
 race = "abomination"
@@ -298,14 +298,14 @@ slow_flying = [["-", "Load"], ["-", "Fire"]]
 fast_flying = [["-", "Load"], ["-", "Fire"]]
 
 [units.shriek_monstrosity.damage_tables]
-regular = [
+Regular = [
 	"1-3: Bleed[4]",
 	"4-5: Bleed[6], +1 to future damage",
 	"6-7: Bleed[8], +2 to future damage",
 	"8+: Unit destroyed",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.water_elemental]
 race = "abomination"
@@ -338,7 +338,7 @@ still = [["360°", "-", "360°"], ["360°", "A", "F"]]
 slow = [["-", "Load"], ["-", "Fire"]]
 
 [units.water_elemental.damage_tables]
-regular = [
+Regular = [
 	"1-2: +1 to future damage",
 	"3-4: +2 to future damage",
 	"5+:  shaken, Destroy one model",
@@ -375,7 +375,7 @@ movement_order = ["-", "-", "-"]
 fast = [["chase", "chase", "chase"]]
 
 [units.robot_crab.damage_tables]
-regular = ["1-8: Kill 1 model", "9+: Unit destroyed"]
+Regular = ["1-8: Kill 1 model", "9+: Unit destroyed"]
 
 [units.giant_frog_riders]
 race = "abomination"
@@ -409,12 +409,12 @@ slow = [["360°", "A", "F"], ["B", "360°", "-"], ["360°", "F", "360°"]]
 still = [["360°", "A", "F"], ["360°", "360°", "360°"]]
 
 [units.giant_frog_riders.damage_tables]
-regular = [
-	"2-3: bleed[4]",
+Regular = [
+	"2-3: Bleed[4]",
 	"4+: kill 1 model",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.hippopotamus_riders]
 race = "abomination"
@@ -451,14 +451,14 @@ slow = [["360°", "A", "F"], ["B", "360°", "-"], ["360°", "F", "360°"]]
 still = [["360°", "A", "F"], ["360°", "360°", "360°"]]
 
 [units.hippopotamus_riders.damage_tables]
-regular = [
-	"2-3: bleed[4]",
+Regular = [
+	"2-3: Bleed[4]",
 	"4-6: as below, +1 to future damage",
-	"7-8: as below, Shaken",
+	"7-8: as below, shaken",
 	"9+: unit destroyed",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 
 
@@ -472,7 +472,7 @@ equipment = ["multipurpose_gun"]
 type = ["Bio", "Infantry", "Walking", "Amphibian"]
 
 [models.abomination_infantry.special]
-"Fog" = "Double to-hit penalties in smoke/fog and ignore to-hit penalty for enemies in smoke/fog. (however does not ignore line of sight through smoke/fog) hexes. "
+"Fog" = "Double to-hit penalties in smoke/fog and ignore to-hit penalty for enemies in smoke/fog. (however does not ignore line of sight through smoke/fog) hexes."
 
 [models.abomination_infantry.assault]
 strength = [1, 1, 1, 1]
@@ -602,7 +602,7 @@ ap = 2
 
 [models.squid.assault.special]
 "Bonus" = "+100\\% strength and deflections versus shaken units"
-"Cunning Assault Defence" = "[6][6+]"
+"Cunning Assault Defense" = "[6][6+]"
 
 [models.mothership]
 name = "MotherShip"
@@ -621,7 +621,7 @@ ap = 2
 
 [models.mothership.assault.special]
 "Bonus" = "+100\\% strength and deflections versus shaken units"
-"Cunning Assault Defence" = "[12](6+)"
+"Cunning Assault Defense" = "[12](6+)"
 
 [models.frost88]
 name = "Frost 88"
@@ -659,7 +659,7 @@ replaces = "abomination_infantry"
 "To Hit" = "Good shot: +1 to hit"
 
 [models.elite_abomination_infantry.unit_special]
-"Vulnerability" = "All enemies within range 2 gets psychic vulnerability of 1: Increase psychic damage they take by 1. This ability does not stack"
+"Vulnerability" = "All enemies within range 2 gets Psychic vulnerability of 1: Increase Psychic damage they take by 1. This ability does not stack"
 
 [models.elite_abomination_infantry.assault]
 strength = [2, 1, 1, 1]
@@ -709,7 +709,7 @@ race = "abomination"
 [equipment.confusion_stinger.range]
 range = 4
 angle = [true, true, false, false]
-damage = "d6 psychic + d4 crew damage"
+damage = "d6 Psychic + d4 Crew damage"
 ap = "N/A"
 
 
@@ -726,7 +726,7 @@ requires = []
 [equipment.greater_confusion_stinger.range]
 range = 4
 angle = [true, true, false, false]
-damage = "d8 psychic + d6 crew damage"
+damage = "d8 Psychic + d6 Crew damage"
 ap = "N/A"
 
 
@@ -758,13 +758,13 @@ requires = []
 [equipment.greater_insanity_stinger.range]
 range = 4
 angle = [true, true, false, false]
-damage = "d6 psychic"
+damage = "d6 Psychic"
 ap = "N/A"
 
 
 [equipment.greater_insanity_stinger.range.special]
 "Multiple Shots" = "Fires 6 shot per fire order."
-"Insanity" = "Only effects bio units.  If you either inflict damage two times with this weapon on the same unit in the same gunnery phase, or inflict damage to a unit which is already shaken, the enemy unit gains an Insanity token in addition to the regular effect of psychic damage."
+"Insanity" = "Only effects bio units.  If you either inflict damage two times with this weapon on the same unit in the same gunnery phase, or inflict damage to a unit which is already shaken, the enemy unit gains an Insanity token in addition to the regular effect of Psychic damage."
 
 
 
@@ -779,12 +779,12 @@ requires = []
 [equipment.insanity_contraption.range]
 range = 2
 angle = [true, true, false, false]
-damage = "d6 psychic"
+damage = "d6 Psychic"
 ap = "N/A"
 
 [equipment.insanity_contraption.range.special]
 
-"Insanity" = "Only effects bio units which are already shaken. If you inflict damage with this weapon, the enemy unit gains an Insanity token in addition to the regular effect of psychic damage."
+"Insanity" = "Only effects bio units which are already shaken. If you inflict damage with this weapon, the enemy unit gains an Insanity token in addition to the regular effect of Psychic damage."
 "Ammo" =	"Track ammo separately from other ammo and start game with no ammo. When you use melee contraption in an assault, Load the insanity contraption with 4 ammo. This is the only way to load the weapon. Once it is loaded, you may spend one ammo in any gunnery phase to fire the weapon."
 
 
@@ -796,11 +796,11 @@ requires = [["Hands:2"]]
 [equipment.multipurpose_gun.range]
 range = 5
 angle = [true, true, true, true]
-damage = "d6 psychic"
+damage = "d6 Psychic"
 ap = "N/A"
 
 [equipment.multipurpose_gun.range.special]
-"Multipurpose" = "Has two settings. Scare and blow gun. Scare do the regular psychic damage, used by Fire orders. Blow gun is used by Fire(b) orders and only effect shaken bio units. All other units are immune. However, if you manage to cause psychic damage the unit gets an insanity token, in addition to the normal effects of the psychic damage table"
+"Multipurpose" = "Has two settings. Scare and blow gun. Scare do the regular Psychic damage, used by Fire orders. Blow gun is used by Fire(b) orders and only effect shaken bio units. All other units are immune. However, if you manage to cause Psychic damage the unit gets an insanity token, in addition to the normal effects of the Psychic damage table"
 
 [equipment.tentacle_craclespears]
 name = "Tentacle CrackleSpears"
@@ -816,7 +816,7 @@ deflection.add = [1, 0, 0, 0]
 deflection_die.replace = "6+" # TODO: use max and add "max" to data.py, line 1120ish
 
 [equipment.tentacle_craclespears.assault.special]
-"Improved Extra Damage" = "If assault in a hex with fog (smoke token), each hit by this model does an d6 psychic damage in addition to the regular damage. This ability does not stack with more spears."
+"Improved Extra Damage" = "If assault in a hex with fog (smoke token), each hit by this model does an d6 Psychic damage in addition to the regular damage. This ability does not stack with more spears."
 
 [equipment.tentacle_axes]
 name = "Tentacle Axes"
@@ -957,11 +957,11 @@ Loading represent preparing for a horrible roar next turn"""
 [equipment.shriek.range]
 range = 2
 angle = [true, false, false, false]
-damage = "d6 -1 psychic damage"
+damage = "d6 -1 Psychic damage"
 ap = "N/A"
 
 [equipment.shriek.range.special]
-"Area" = "Target enemies in all hexes within front arch (not including the hexes on the edge of firing angle) and long range. At point blank Area[4+], within normal range Area[5+] and all other hexes Area[6+]"
+"Area" = "Target enemies in all hexes within front arc (not including the hexes on the edge of firing angle) and long range. At point blank Area[4+], within normal range Area[5+] and all other hexes Area[6+]"
 "Ammo" = "If it has ammo, you must use it. If you have no valid target, the ammo is still wasted. You may choose to start without ammo"
 
 [equipment.fog_poisonizer]
@@ -1008,7 +1008,7 @@ requires = []
 [equipment.twin_frost_ray.range]
 range = 4
 angle = [true, false, false, false]
-damage = "d4-2+d6 psychic damage + d4 crew damage"
+damage = "d4-2+d6 Psychic damage + d4 Crew damage"
 ap = 0
 
 [equipment.twin_frost_ray.range.special]
@@ -1024,7 +1024,7 @@ requires = []
 [equipment.water_jet.range]
 range = 4
 angle = [true, false, false, false]
-damage = "d6 (+d8 crew damage if penetrating all armor)"
+damage = "d6 (+d8 Crew damage if penetrating all armor)"
 ap = 6
 
 [equipment.water_jet.range.special]

--- a/v3/races/darkelf.toml
+++ b/v3/races/darkelf.toml
@@ -35,7 +35,7 @@ still = [
 	["360°", "A ", "F"]]
 
 [units.mechahydra.damage_tables]
-regular = ["1-3: +1 to future damage",
+Regular = ["1-3: +1 to future damage",
 	   "4-5: +2 to future damage",
 	   "6-17: +2 to future damage, destroy one minor head. If all minor heads are destroyed, add additional +3 to future damage instead. Set unit on fire",
 	   "18: Unit destroyed"]
@@ -69,7 +69,7 @@ slow = [["-", "Breath(fire)"], ["Breath(fire)", "-"], ["-", "Load"]]
 fast = [["-", "-"], ["-", "-"], ["-", "Load"]]
 
 [units.mechanical_red_dragon.damage_tables]
-regular = [
+Regular = [
     "1-4: +1 on future damage",
     "5-10: +1 on future damage, shaken",
     "13+: Unit destroyed",
@@ -112,7 +112,7 @@ fast_flying = [
 ]
 
 [units.mechanical_iron_dragon.damage_tables]
-regular = [
+Regular = [
     "1-4: +1 on future damage",
     "5-10: +1 on future damage, shaken",
     "13+: Unit destroyed",
@@ -166,13 +166,13 @@ slow = [["-", "aim"], ["-", "load"], ["-", "fire"], ["-", "Release"]]
 fast = [["-", "fire"], ["-", "fire"], ["-", "fire"], ["-", "Release"]]
 
 [units.queen_yy.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4-5: as 1-3, shaken",
     "6-8: as 4-5, Critical damage[d6]",
     "9+: Unit destroyed",
 ]
-critical = [
+Critical = [
     "1: -1 to-hit, +1 to-be-hit",
     "2: Rotates right in agony 0 step",
     "3: Rotates left in agony 1 and in agony 3",
@@ -180,10 +180,10 @@ critical = [
     "5: unit is covered in acid",
     "6: unit is set on fire",
 ]
-crew = [
-    "4-7: Double initial crew damage if already shaken",
+Crew = [
+    "4-7: Double initial Crew damage if already shaken",
     "8-10: As below, Crippled Crew",
-    "11-12: as 10, +3 to future crew damage",
+    "11-12: as 10, +3 to future Crew damage",
     "13: Crew Killed, unit destroyed",
 ]
 
@@ -234,13 +234,13 @@ slow = [["-", "Release"]]
 fast = [["-", "Release"]]
 
 [units.queen_xy.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4-5:as 1-4, shaken",
     "6-8: 4-5, Critical damage[d6]",
     "9+: Unit destroyed",
 ]
-critical = [
+Critical = [
     "1: -1 to-hit, +1 to-be-hit",
     "2: Rotates right in agony 0 step",
     "3: rotates left in agony 1 and in agony 3",
@@ -248,10 +248,10 @@ critical = [
     "5: unit is covered in acid",
     "6: unit is set on fire",
 ]
-crew = [
-    "4-7: double initial crew damage if already shaken",
+Crew = [
+    "4-7: double initial Crew damage if already shaken",
     "9-10: As below, Crippled Crew",
-    "11-12: As below, +3 to future crew damage",
+    "11-12: As below, +3 to future Crew damage",
     "13: Crew Killed, unit destroyed",
 ]
 
@@ -285,14 +285,14 @@ slow = [["360°", "F", "360°"], ["360°", "A", "F"], ["360°", "F+B", "360°"]]
 still = [["360°", "360°", "360°"], ["360°", "A", "F"]]
 
 [units.nightmare_mechanical_cavalry.damage_tables]
-regular = [
+Regular = [
     "2-3: +1 on future damage",
     "4: +2 on future damage",
     "5-6: Kill 1 model",
-    "7+: Kill 1 model, d6 psychic damage",
+    "7+: Kill 1 model, d6 Psychic damage",
     "{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by poison, remove that poison token}}",
 ]
-psychic = ["6+: unit shaken"]
+Psychic = ["6+: unit shaken"]
 
 [units.elite_mechanical_cavalry]
 race = "darkelf"
@@ -327,13 +327,13 @@ still = [["360°", "360°", "360°"], ["360°", "A", "F"]]
 all = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 [units.elite_mechanical_cavalry.damage_tables]
-regular = [
+Regular = [
     "2-3: +1 on future damage",
     "4: +2 on future damage",
     "5-6: kill 1 model",
     "{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by poison, remove that poison token}}",
 ]
-psychic = ["5+: unit shaken"]
+Psychic = ["5+: unit shaken"]
 
 [units.mechanical_assault_spider]
 race = "darkelf"
@@ -356,13 +356,13 @@ still = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 slow = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 [units.mechanical_assault_spider.damage_tables]
-regular = [
+Regular = [
     "1-2: +1 to future damage",
     "3: as below, shaken",
     "4-6: as below, critical damage[d6]",
     "7+: Destroy unit",
 ]
-critical = [
+Critical = [
     "1: -1 to-hit, +1 to-be-hit (ranged and assault)",
     "2: Cannot move",
     "3: Cannot rotate",
@@ -393,15 +393,15 @@ still = [["-", "Load"], ["-", "Fire"], ["Load", "Aim"]]
 slow = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 [units.mechanical_scorpion.damage_tables]
-regular = [
+Regular = [
     "1-2: +1 to future damage",
     "3: as below, shaken",
     "4-6: as below, critical damage[d6]",
     "7+: Destroy unit",
 ]
-critical = [
+Critical = [
     "1: -1 to-hit, +1 to-be-hit (ranged and assault)",
-    "2: Cannot move, looses fear",
+    "2: Cannot move, loses fear",
     "3: Cannot rotate",
     "4-5: x3 Light damage[d6]",
     "6: Unit set on Fire",
@@ -454,14 +454,14 @@ still = [
 ]
 
 [units.darkelf_infantry.damage_tables]
-regular = [
+Regular = [
     "0-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
     "{{\\it When one model is killed, half all +1 to future damage rounded down}}",
     "{{\\it If killed by poison, remove that instance}}",
 ]
-psychic = ["4+: Unit Shaken"]
+Psychic = ["4+: Unit shaken"]
 
 [units.multicultural_infantry]
 race = "darkelf"
@@ -485,7 +485,7 @@ cost.xp = 24
 
 [units.multicultural_infantry.special]
 "Transfer" = "If number of alive models in this unit is less than 10, you may transfer models from multicultural trainee from a unit in this hex in aftermath phase, such that you have a maximum of 10 models in this unit"
-"Darkelf Officer" = "If there are no darkelf_officers on the battlefield, all multicultural infantry and multicultural trainee units which have more generic multicultural infantry models compared to other models rebel and switch sides. If so, you gain victory points for killing this unit, and enemy get victory points for it surviving. "
+"Darkelf Officer" = "If there are no darkelf_officers on the battlefield, all multicultural infantry and multicultural trainee units which have more generic multicultural infantry models compared to other models rebel and switch sides. If so, you gain victory points for killing this unit, and enemy get victory points for it surviving."
 "Spawn" = "At start of battle, place two Multicultural Trainee units directly in front of this unit"
 "Forward Position" = "[2]"
 "Fire Order" = "Activate order only available while officer is alive"
@@ -506,16 +506,16 @@ slow = [
 slow = [["Activate", "-"]]
 
 [units.multicultural_infantry.damage_tables]
-regular = [
+Regular = [
     "0-1: If number of alive models is more than 2, Kill 1 model",
     "2-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
-    "9: Kill 4 Models, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
+    "9: Kill 4 models, d6 Psychic damage",
     "{{\\it When one model is killed, half all +1 to future damage rounded down}}",
     "{{\\it If killed by poison, remove that instance}}",
     "{{\\it Count the number of alive models before the apply damage step}}",
 ]
-psychic = ["5+: Unit Shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.multicultural_trainee]
 race = "darkelf"
@@ -544,8 +544,8 @@ movement_order = ["-", "-", "Flee"]
 slow = [["-", "-", "Chase"]]
 
 [units.multicultural_trainee.damage_tables]
-regular = ["1-8: Kill 1 model", "9: Destroy Unit"]
-psychic = ["3+: Unit Shaken"]
+Regular = ["1-8: Kill 1 model", "9: Destroy unit"]
+Psychic = ["3+: Unit shaken"]
 
 [units.roboprosthetic_darkelf]
 race = "darkelf"
@@ -595,14 +595,14 @@ still = [
 ]
 
 [units.roboprosthetic_darkelf.damage_tables]
-regular = [
+Regular = [
     "0-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
     "{{\\it When one model is killed, half all +1 to future damage rounded down}}",
     "{{\\it If killed by poison, remove that instance}}",
 ]
-psychic = ["5+: Unit Shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.assassin]
 race = "darkelf"
@@ -647,8 +647,8 @@ still = [
 ]
 
 [units.assassin.damage_tables]
-regular = ["1+: unit killed"]
-psychic = ["6+: Unit Shaken"]
+Regular = ["1+: unit killed"]
+Psychic = ["6+: Unit shaken"]
 
 [units.roboprosthetic_assassin]
 race = "darkelf"
@@ -694,8 +694,8 @@ still = [
 slow = [["-", "Fire"], ["Fire", "-"]]
 
 [units.roboprosthetic_assassin.damage_tables]
-regular = ["1+: unit killed"]
-psychic = ["6+: Unit Shaken"]
+Regular = ["1+: unit killed"]
+Psychic = ["6+: Unit shaken"]
 
 [units.scout]
 race = "darkelf"
@@ -742,8 +742,8 @@ still = [
 slow = [["Spot", "Spot"]]
 
 [units.scout.damage_tables]
-regular = ["0+: unit killed"]
-psychic = ["3+: Unit Shaken"]
+Regular = ["0+: unit killed"]
+Psychic = ["3+: Unit shaken"]
 
 #
 # Models
@@ -768,7 +768,7 @@ ap = 2
 [models.mechahydra.assault.special]
 "Bonus" = "+3 assault strength  and +1 assault deflection per alive head"
 "Extra Damage" = "Poison[6][1 for 2]"
-"Cunning Assault Defence" = "[3][5+]"
+"Cunning Assault Defense" = "[3][5+]"
 
 [models.mechanical_red_dragon]
 name = "Mechanical Red Dragon"
@@ -1300,7 +1300,7 @@ requires = []
 [equipment.acid_cannon.range]
 range = 4
 angle = [true, true, false, false]
-damage = "d6+d8 Psychic damage + d6 crew damage"
+damage = "d6+d8 Psychic damage + d6 Crew damage"
 ap = 3
 
 [equipment.acid_cannon.range.special]
@@ -1409,7 +1409,7 @@ requires = []
 [equipment.nightmare_breath.range]
 range = 2
 angle = [true, false, false, false]
-damage = "d8 crew damage"
+damage = "d8 Crew damage"
 ap = 0
 
 [equipment.nightmare_breath.range.special]
@@ -1518,7 +1518,7 @@ upgrade_all = true
 requires = [["Hands:2"], ["type:Roboprosthetic", "type:Infantry"]]
 
 [equipment.poison_spray.assault]
-damage.replace = "d6-2 + d6 crew damage"
+damage.replace = "d6-2 + d6 Crew damage"
 
 [equipment.poison_spray.assault.special]
 "Improved Extra Damage" = "Poison[4][1 for 2]"
@@ -1526,7 +1526,7 @@ damage.replace = "d6-2 + d6 crew damage"
 [equipment.poison_spray.range]
 range = 2
 angle = [true, true, true, true]
-damage = "d6 crew damage"
+damage = "d6 Crew damage"
 ap = 0
 
 [equipment.poison_spray.range.special]
@@ -1637,13 +1637,13 @@ damage = "d6-2"
 ap = 2
 
 [equipment.shrapnel_breath.range.special]
-"Range" = "Target one hex within front ark and within long range"
+"Range" = "Target one hex within front arc and within long range"
 "Area" = "[4+] at point blank range, Area[6+] at normal and long range. Single model large units are hit d4 times and single model huge units are hit d8 times."
 "Ammo" =  "Always treated as loaded"
 
 
 [equipment.gasmask]
-name = "GasMask assault training"
+name = "Gas mask assault training"
 race = "darkelf"
 cost.xp = 4
 upgrade_all = true
@@ -1786,4 +1786,4 @@ ap = 1
 "Ammo" = "Always treated as loaded."
 "Multiple Shots" = "Fires two times each time it is fired"
 "Extra Damage" = "Minor Acid"
-"Fumble" = "Unit Gains one minor acid token (per fumble) "
+"Fumble" = "Unit Gains one minor acid token (per fumble)"

--- a/v3/races/dwarf.toml
+++ b/v3/races/dwarf.toml
@@ -41,16 +41,16 @@ still = [
 ]
 
 [units.dwarf_infantry.damage_tables]
-regular = [
+Regular = [
     "1-5: Kill 1 model",
-    "6-9: Kill 1 model, roll d6 psychic damage",
+    "6-9: Kill 1 model, roll d6 Psychic damage",
     "10+: Unit killed",
 ]
-psychic = ["4+: Unit shaken"]
+Psychic = ["4+: Unit shaken"]
 
 [units.dwarf_brothersinarms]
 race = "dwarf"
-name = "Dwarf Brother in arms"
+name = "Dwarf Brother in Arms"
 models = ["dwarf_brotherinarms", "dwarf_brotherinarms"]
 size = "Medium"
 armor = [0, 0, 0, 0]
@@ -79,12 +79,12 @@ still = [
 ]
 
 [units.dwarf_brothersinarms.damage_tables]
-regular = [
+Regular = [
     "2-6: kill 1 model",
-    "7-9: Kill 1 model, roll d6 psychic damage",
+    "7-9: Kill 1 model, roll d6 Psychic damage",
     "10+: Unit killed",
 ]
-psychic = ["5+: Unit shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.steampowerarmor]
 race = "dwarf"
@@ -126,16 +126,16 @@ still = [
 ]
 
 [units.steampowerarmor.damage_tables]
-regular = [
-    "1-2: bleed[4]",
+Regular = [
+    "1-2: Bleed[4]",
     "3-5: Kill 1 model",
-    "6-9: Kill 1 model, roll d6 psychic damage",
+    "6-9: Kill 1 model, roll d6 Psychic damage",
     "10+: Unit killed",
     "{{\\it Note: bleeding does not cause more bleeding}}",
     "{{\\it If one model is killed by bleeding/poison, remove that bleeding/poison token}}",
     "{{\\it and remove half of the +1 future damage tokens}}",
 ]
-psychic = ["5+: Unit shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.mini_zeppelin]
 race = "dwarf"
@@ -165,8 +165,8 @@ slow = [["360°", "F", "360°"], ["360°", "360°", "360°"], ["360°", "A", "F"
 still = [["Fire", "-"], ["Load", "-"], ["Throw", "Throw"]]
 
 [units.mini_zeppelin.damage_tables]
-regular = ["2-3: shaken", "4+: kill 1 model"]
-psychic = ["6+: Unit shaken"]
+Regular = ["2-3: shaken", "4+: kill 1 model"]
+Psychic = ["6+: Unit shaken"]
 
 [units.transport_zeppelin]
 race = "dwarf"
@@ -196,15 +196,15 @@ fast_flying = [
 ]
 
 [units.transport_zeppelin.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 on future damage",
     "4-8:as below, d6-2 damage to each unit transported by this unit.",
     "9: unit and all transported units killed",
 ]
-crew = [
-    "4-5: All transported units gain Poison[4] and takes d6 psychic damage. Shaken transported units may not be deployed. Double initial crew damage if already shaken",
+Crew = [
+    "4-5: All transported units gain Poison[4] and takes d6 Psychic damage. Shaken transported units may not be deployed. Double initial Crew damage if already shaken",
     "6-7: As 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12: unit destroyed",
 ]
 
@@ -234,14 +234,14 @@ rest = [["-", "-", "A[slow]"], ["-", "-", "A[still]"]]
 still = [["Fire", "-"], ["Load", "-"], ["Aim", "-"]]
 
 [units.dwarf_at_gun.damage_tables]
-regular = [
-    "1-3: kill 1 crew, +1 to future damage",
+Regular = [
+    "1-3: kill 1 Crew, +1 to future damage",
     "4-6: as 1-3, shaken",
-    "7-8: kill 2 crew, +3 to future damage, shaken",
+    "7-8: kill 2 Crew, +3 to future damage, shaken",
     "9+: Unit destroyed",
-    "Destroyed when 4 crew are killed",
+    "Destroyed when 4 Crew are killed",
 ]
-psychic = ["5+: Unit shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.gunblasterwagon]
 race = "dwarf"
@@ -295,23 +295,23 @@ slow =  [["Load", "-"], ["Load", "-"]]
 fast =  [["Load", "-"], ["Load", "-"]]
 
 [units.gunblasterwagon.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as 1-3, shaken",
     "5-8: as 4, Critical damage[d6]",
     "9+: Destroyed",
 ]
-critical = [
+Critical = [
     "1: -1 to-hit, +1 to-be-hit",
     "2: Cannot Rotate",
-    "3: Cannot Move",
+    "3: Cannot move",
     "4-5: +3 to future damage",
     "6: set on Fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-12: as 6-7, +3 to future crew damage",
+    "8-12: as 6-7, +3 to future Crew damage",
     "13: Unit destroyed",
 ]
 
@@ -366,17 +366,17 @@ slow = [["Fire", "-"]]
 still = [["Fire", "-"], ["Load", "-"], ["Aim", "-"], ["Load Unstable", "-"]]
 
 [units.dw42.damage_tables]
-critical = ["1-4: +3 to future damage", "5: Cannot Move", "6: set on Fire"]
-regular = [
+Critical = ["1-4: +3 to future damage", "5: Cannot move", "6: set on Fire"]
+Regular = [
     "1-3: +1 on future damage",
     "4: as below, shaken",
     "5-8: Critical damage[d6], +1 on future damage",
     "9+: Destroyed",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-12: as 6-7, +3 to future crew damage",
+    "8-12: as 6-7, +3 to future Crew damage",
     "13: Unit destroyed",
 ]
 
@@ -429,23 +429,23 @@ slow = [["Fire", "-"], ["Load", "Aim"]]
 still = [["Fire", "-"], ["Load", "Aim"]]
 
 [units.zap.damage_tables]
-critical = [
+Critical = [
     "1-2: -1 to hit, +1 to-be-hit",
     "3: Cannot Rotate",
-    "4: Cannot Move",
+    "4: Cannot move",
     "5: +3 to future damage",
     "6: set on fire",
 ]
-regular = [
+Regular = [
     "1-4: +1 to future damage",
     "5: as below, shaken",
     "6-9: as below, d6 critical damage",
     "10+: Destroyed",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-12: as 6-7, +3 to future crew damage",
+    "8-12: as 6-7, +3 to future Crew damage",
     "13: Unit destroyed",
 ]
 
@@ -462,7 +462,7 @@ cost.xp = 48
 speed = "slow_flying"
 movement_order = ["-", "-", "F"]
 fire_order = "Fire one less weapon system per shaken token."
-comment = "Each Shaken token counts as +1 to future damage token."
+comment = "Each shaken token counts as +1 to future damage token."
 
 [units.zeppelin.special]
 "Steady" = "+1 to hit, +1 to be hit."
@@ -482,16 +482,16 @@ slow_flying = [
 slow = [["Fire", "-"], ["Load", "-"], ["Aim", "-"]]
 
 [units.zeppelin.damage_tables]
-regular = [
+Regular = [
     "1-4: +1 on future damage,",
     "5-8: +1 to future damage, shaken",
     "9-13: +2 to future damage, unit shaken, set on fire",
     "14+: Unit destroyed",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-12: as 6-7, +1 to future crew damage",
+    "8-12: as 6-7, +1 to future Crew damage",
     "13: Unit destroyed",
 ]
 
@@ -527,13 +527,13 @@ rest = [["-", "-", "A"]]
 still = [["Fire", "-"], ["-", "Fire"]]
 
 [units.tamed_balrog.damage_tables]
-regular = [
+Regular = [
     "1-9: +1 on future damage",
     "10-11: +2 on future damage",
-    "12: +3 on future damage, assault -3, Loses Terror, Shaken",
+    "12: +3 on future damage, assault -3, Loses Terror, shaken",
     "13+: Unit Destroyed",
 ]
-psychic = ["9+: Unit shaken"]
+Psychic = ["9+: Unit shaken"]
 
 #
 # Models
@@ -589,7 +589,7 @@ replaces = "dwarf_infantry"
 "To Hit" = "good shot: +1 to hit"
 
 [models.elite_dwarf_infantry.unit_special]
-"Improved Resistance" = "unit gains psychic resistance 2 as long as 1 elite model is alive"
+"Improved Resistance" = "unit gains Psychic resistance 2 as long as 1 elite model is alive"
 
 [models.elite_dwarf_infantry.assault]
 strength = [2, 2, 1, 1]
@@ -616,7 +616,7 @@ replaces = "steampowerarmor"
 "To Hit" = "good shot: +1 to hit"
 
 [models.elite_steampowerarmor.unit_special]
-"Improved Resistance" = "unit gains psychic resistance 1 as long as 1 elite model is alive"
+"Improved Resistance" = "unit gains Psychic resistance 1 as long as 1 elite model is alive"
 "Protection" = "Unit gains 1 endurance token per elite in unit. See general rules for effect"
 
 [models.elite_steampowerarmor.assault]
@@ -629,7 +629,7 @@ ap = 2
 
 [models.elite_steampowerarmor.assault.special]
 "Cunning Assault" = "[1 for 2]"
-"Cunning Assault Defence" = "[1][4+]"
+"Cunning Assault Defense" = "[1][4+]"
 
 [models.battle_medic]
 name = "Dwarf Battle Medic"
@@ -641,7 +641,7 @@ cost.xp = 24
 replaces = "steampowerarmor"
 
 [models.battle_medic.unit_special]
-"Improved Resistance" = "unit gains psychic resistance 2 as long as 1 battle medic is alive"
+"Improved Resistance" = "unit gains Psychic resistance 2 as long as 1 battle medic is alive"
 "Heal" = "Unit gains: Heal[1, any, Healing 1]"
 "Protection" = "Unit gains 1 endurance token and this model counts as elites for life of vest support. See general rules for effect"
 
@@ -736,7 +736,7 @@ damage = "d6-2"
 ap = 2
 
 [models.mini_zeppelin.assault.special]
-"Cunning Assault Defence" = "[1][4+]"
+"Cunning Assault Defense" = "[1][4+]"
 
 [models.engineer_mini_zeppelin]
 name = "Engineer Mini Zeppelin"
@@ -759,7 +759,7 @@ damage = "d6-2"
 ap = 2
 
 [models.engineer_mini_zeppelin.assault.special]
-"Cunning Assault Defence" = "[2][4+]"
+"Cunning Assault Defense" = "[2][4+]"
 
 
 [models.transport_zeppelin]
@@ -924,7 +924,7 @@ ap = 2
 
 [equipment.musket_with_springloaded_axe.assault]
 strength.add = [1, 1, 1, 1]
-damage.replace = "d6-2 + d6 psychic damage"
+damage.replace = "d6-2 + d6 Psychic damage"
 
 [equipment.musket_with_springloaded_axe.orders_gained.fire]
 slow = [["-", "load"], ["load", "-"], ["fire", "-"], ["-", "fire"]]
@@ -948,7 +948,7 @@ ap = 2
 
 [equipment.double_barreled_musket_with_springloaded_axe.assault]
 strength.add = [1, 1, 1, 1]
-damage.replace = "d6-2 + d6 psychic damage"
+damage.replace = "d6-2 + d6 Psychic damage"
 
 [equipment.double_barreled_musket_with_springloaded_axe.orders_gained.fire]
 slow = [["-", "Load"], ["Load", "-"], ["Fire", "-"], ["-", "Fire"]]
@@ -987,7 +987,7 @@ requires = [["Independent:1"], ["type:Vehicle"]]
 strength.add = [4, 2, 2, 0]
 deflection.add = [2, 1, 1, 0]
 deflection_die.replace = "4+"
-damage.replace = "d6-2 + d6 psychic damage"
+damage.replace = "d6-2 + d6 Psychic damage"
 
 [equipment.wheeled_shieldwall]
 name = "Wheeled ShieldWall"
@@ -1127,7 +1127,7 @@ requires = [["type:Steampowerarmor"], ["Hands:2"]]
 [equipment.steamblower.range]
 range = 2
 angle = [true, true, true, true]
-damage = "d6-2+d4 crew damage"
+damage = "d6-2+d4 Crew damage"
 ap = 2
 
 [equipment.steamblower.range.special]
@@ -1198,7 +1198,7 @@ requires = [["type:Steampowerarmor"], ["Hands:2"]]
 [equipment.fear_ray.range]
 range = 16
 angle = [true, false, false, false]
-damage = "d6 psychic damage"
+damage = "d6 Psychic damage"
 ap = 0
 
 [equipment.zeppelin_gun]

--- a/v3/races/elf.toml
+++ b/v3/races/elf.toml
@@ -32,15 +32,15 @@ slow = [["360°", "F", "360°"], ["360°", "F", "B"]]
 still = [["360°", "360°", "360°"], ["360°", "A ", "F"]]
 
 [units.elf_hydra.damage_tables]
-regular = [
+Regular = [
 	"1-2: Bleed[4]",
 	"3-5: +1 to future damage, Bleed[4]",
 	"6-10: +1 to future damage, Bleed[6], destroy one minor head. If all minor heads are destroyed, add additional +3 to future damage instead. Amplify all bleeding one step. (4 to 6, 6 to 8, 8 to 10 and 10 to 12)",
-	"10-17: As below, d6 psychic damage",
+	"10-17: As below, d6 Psychic damage",
 	"18: Unit destroyed",
 	"{{\\it Note: Bleed does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.elf_infantry]
 race = "elf"
@@ -76,13 +76,13 @@ still = [
 fast = [["360°", "F", "B"], [" 360°", " F", "B+B"]]
 
 [units.elf_infantry.damage_tables]
-regular = [
+Regular = [
 	"0-6: Kill 1 model",
-	"7-8: Kill 1 model, psychic damage[d6]",
+	"7-8: Kill 1 model, Psychic damage[d6]",
 	"9+: Unit destroyed",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 [units.elf_archer]
 race = "elf"
@@ -117,13 +117,13 @@ still = [
 fast = [["360°", "F", "B"], [" 360°", " F", "B+B"]]
 
 [units.elf_archer.damage_tables]
-regular = [
+Regular = [
 	"0-6: Kill 1 model",
-	"7-8: Kill 1 model, psychic damage[d6]",
+	"7-8: Kill 1 model, Psychic damage[d6]",
 	"9+: Unit destroyed",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["5+: shaken"]
+Psychic = ["5+: shaken"]
 
 [units.illusion]
 race = "elf"
@@ -133,7 +133,7 @@ size = "Medium"
 cost.cp = 8
 
 [units.illusion.special]
-"Illusion" = "When fired at, you may pretend to look at normal infantry damage table unless the damage is 4 or above, for which the illusion is given away and is removed from play. Further, if the illusion is matched with one real infantry base, it may mimic the orders of that infantry, and may follow it wherever the infantry goes. The illusion have the exact same modifiers and abilities with regard to being hit as the infantry it is mimicking. Thus, the illusion has Take Cover[still][-2], Take Cover[still][-3], and camouflage[forest][-1] as appropriate. Thus the enemy do not know which are illusions and which are real. However if, for any reason, the enemy gets information which gives the illusion away, the illusion is not removed from play, but must be identified by an illusion marker. For example if the illusion was fired at by something which does psychic damage, it would require you to tell the enemy that this unit does not have a psychic damage table, which would give the illusion away."
+"Illusion" = "When fired at, you may pretend to look at normal infantry damage table unless the damage is 4 or above, for which the illusion is given away and is removed from play. Further, if the illusion is matched with one real infantry base, it may mimic the orders of that infantry, and may follow it wherever the infantry goes. The illusion have the exact same modifiers and abilities with regard to being hit as the infantry it is mimicking. Thus, the illusion has Take Cover[still][-2], Take Cover[still][-3], and camouflage[forest][-1] as appropriate. Thus the enemy do not know which are illusions and which are real. However if, for any reason, the enemy gets information which gives the illusion away, the illusion is not removed from play, but must be identified by an illusion marker. For example if the illusion was fired at by something which does Psychic damage, it would require you to tell the enemy that this unit does not have a Psychic damage table, which would give the illusion away."
 "Movement" = "If the illusion is not in a hex with a friendly infantry, it has only chase order available"
 "Forward Position" = "[2]"
 
@@ -145,7 +145,7 @@ movement_order = ["-", "-", "flee"]
 slow = [["-", "-", "chase"]]
 
 [units.illusion.damage_tables]
-regular = ["0-4: kill 1 model", "4+: destroy unit", "Note: immune to poison"]
+Regular = ["0-4: kill 1 model", "4+: destroy unit", "Note: immune to poison"]
 
 [units.elf_scout]
 race = "elf"
@@ -182,8 +182,8 @@ still = [
 fast = [["360°", "F", "B"], [" 360°", " F", "B+B"]]
 
 [units.elf_scout.damage_tables]
-regular = ["0+: unit killed"]
-psychic = ["3+: shaken"]
+Regular = ["0+: unit killed"]
+Psychic = ["3+: shaken"]
 
 [units.elite_elf_scout]
 race = "elf"
@@ -222,8 +222,8 @@ still = [
 fast = [["360°", "F", "B"], [" 360°", " F", "B+B"]]
 
 [units.elite_elf_scout.damage_tables]
-regular = ["0+: unit killed"]
-psychic = ["3+: shaken"]
+Regular = ["0+: unit killed"]
+Psychic = ["3+: shaken"]
 
 [units.e34]
 race = "elf"
@@ -270,13 +270,13 @@ still = [
 ]
 
 [units.e34.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 on future damage",
 	"4: as below, shaken",
 	"5-8: as below, Critical Damage",
 	"9+: Destroyed",
 ]
-critical = [
+Critical = [
 	"1: Cannot move",
 	"2: -1 to hit, +1 to be hit(ranged and assault)",
 	"3: Cannot Rotate",
@@ -284,10 +284,10 @@ critical = [
 	"5: Stuck turret: firing angle is now only forward",
 	"6: Unit is set on Fire",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12+: Unit destroyed",
 ]
 
@@ -345,24 +345,24 @@ still = [
 ]
 
 [units.tattoo_ink.damage_tables]
-critical = [
-	"1: Shaken",
+Critical = [
+	"1: shaken",
 	"2: -1 to hit, +1 to be hit",
 	"3: Cannot rotate",
 	"4: +3 on future damage",
 	"5: unit cannot change speed.",
 	"6: Set unit on Fire!",
 ]
-regular = [
+Regular = [
 	"1-2: +1 on future damage",
 	"3-4 as below, shaken",
 	"5-7: as below, d6 Critical Damage",
 	"8+ Destroyed",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12+: Unit destroyed",
 ]
 
@@ -392,14 +392,14 @@ slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 still = [["360°", "A", "F"]]
 
 [units.bear_rider.damage_tables]
-regular = [
-	"2-7: +1 to future damage, bleed[4]",
-	"8:10: +2 to future damage, bleed[6], psychic damage[d6]",
+Regular = [
+	"2-7: +1 to future damage, Bleed[4]",
+	"8:10: +2 to future damage, Bleed[6], Psychic damage[d6]",
 	"11+: killed",
 	"Note: bleeding does not cause more bleeding",
 	"Note: if one model is killed by bleeding/poison, remove that instance \\\\ bleeding/poison and remove up to half + to future token",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.polar_bear_riders]
 race = "elf"
@@ -428,14 +428,14 @@ slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 still = [["360°", "A", "F"]]
 
 [units.polar_bear_riders.damage_tables]
-regular = [
-	"2-7: +1 to future damage, bleed[4]",
-	"8:10: +2 to future damage, bleed[6], psychic damage[d6]",
+Regular = [
+	"2-7: +1 to future damage, Bleed[4]",
+	"8:10: +2 to future damage, Bleed[6], Psychic damage[d6]",
 	"11+: killed",
 	"Note: bleeding does not cause more bleeding",
 	"Note: if one model is killed by bleeding/poison, remove that instance \\\\ bleeding/poison and remove up to half + to future token",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.armored_unicorn_rider]
 race = "elf"
@@ -455,7 +455,7 @@ movement_order = ["-", "-", "flee"]
 [units.armored_unicorn_rider.special]
 "Resistance" = "Poison[12], Fire[3], Acid[1]"
 "Fire Order" = "Autoloader: any time unit does not fire it's shriek SMG in any gunnery phase, load the gun with 1 ammo."
-"Officer" = "Grants psychic resistance 1 to the other unit in this hex"
+"Officer" = "Grants Psychic resistance 1 to the other unit in this hex"
 "Officer 2" = "remove one shaken token on any biological unit in the same hex in 2nd healing  phase"
 "Heal" = "Either: heal[3, self, 1st healing] or heal[2, any, 1st healing]"
 "Stacking Limit" = "May share a hex with a huge unit"
@@ -482,12 +482,12 @@ fast = [
 ]
 
 [units.armored_unicorn_rider.damage_tables]
-regular = [
+Regular = [
 	"2-5: Bleed[6]",
 	"6+: killed",
 	"Note: bleeding does not cause more bleeding"
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.pachyephalosaurus_riders]
 race = "elf"
@@ -530,13 +530,13 @@ slow = [["360°", "A", "F"], ["B", "360°", "-"]]
 still = [["360°", "A", "F"], ["A+A", "360°+F", "F"], ["A+A", "360°", "F"]]
 
 [units.pachyephalosaurus_riders.damage_tables]
-regular = [
-	"2-3: bleed[6]",
-	"6+: kill 1 model, d4 psychic damage",
+Regular = [
+	"2-3: Bleed[6]",
+	"6+: kill 1 model, d4 Psychic damage",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 # Elk removed. Elf had to many cavalry and elk did not find it's correct place.
 #[units.elk_cavalery]
@@ -565,11 +565,11 @@ psychic = ["4+: shaken"]
 #[units.elk_cavalery.damage_tables]
 #regular = [
 #	"2-3: Bleed[4]",
-#	"4+: kill 1 model, d4 psychic damage",
+#	"4+: kill 1 model, d4 Psychic damage",
 #	"{{\\it Note: bleeding does not cause more bleeding}}",
 #	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 #]
-#psychic = ["4+: shaken"]
+#Psychic = ["4+: shaken"]
 [units.pegasus_rider]
 race = "elf"
 name = "Pegasus Rider"
@@ -637,13 +637,13 @@ fast_flying = [
 ]
 
 [units.pegasus_rider.damage_tables]
-regular = [
+Regular = [
 	"2-3: Bleed[4]",
 	"4+: kill 1 model",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["5+: shaken"]
+Psychic = ["5+: shaken"]
 
 [models]
 
@@ -817,7 +817,7 @@ strength = [1, 0, 0, 0]
 strength_die = "5+"
 deflection = [0, 0, 0, 0]
 deflection_die = "5+"
-damage = "d6 psychic damage"
+damage = "d6 Psychic damage"
 ap = 'N/A'
 
 [models.superelite_elf_infantry]
@@ -1104,7 +1104,7 @@ slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 still = [["360°", "A", "F"]]
 
 [units.sauropod_riders.damage_tables]
-regular = [
+Regular = [
 	"2-3: Bleed[4]",
 	"4-8: As below, If caused by bleeding, amplify bleeding",
 	"9-11: as below, +1 to future damage",
@@ -1113,7 +1113,7 @@ regular = [
 	"{{\\it Note: Amplify bleeding: Bleed[4] becomes Bleed[6], Bleed[6] becomes Bleed[8] etc up to max Bleed[12]}}",
 	"{{\\it Note: bleeding does not cause more bleeding}}",
 ]
-psychic = ["8+: shaken"]
+Psychic = ["8+: shaken"]
 
 [units.armored_oliphant_riders]
 race = "elf"
@@ -1127,7 +1127,7 @@ armor = [8, 6, 4, 3]
 
 [units.armored_oliphant_riders.special]
 "Resistance" = "Poison[2]"
-"Fire Order" = "The crew fires a bow or Throw grenade, while Fire(g), aim(g) and load(g) orders are for the gatling guns only. Only the gatling gun needs to be reloaded"
+"Fire Order" = "The Crew fires a bow or Throw grenade, while Fire(g), aim(g) and load(g) orders are for the gatling guns only. Only the gatling gun needs to be reloaded"
 
 [units.armored_oliphant_riders.shaken]
 speed = 'slow'
@@ -1160,13 +1160,13 @@ fast = [
 ]
 
 [units.armored_oliphant_riders.damage_tables]
-regular = [
-	"2-6: Bleed[8] ",
-	"7: As below, d6 psychic damage",
+Regular = [
+	"2-6: Bleed[8]",
+	"7: As below, d6 Psychic damage",
 	"8+: Unit killed",
 	"Note: bleeding does not cause more bleeding",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.eagle_rider]
 race = "elf"
@@ -1198,13 +1198,13 @@ slow = [
 ]
 
 [units.eagle_rider.damage_tables]
-regular = [
+Regular = [
 	"2-3: +1 to future damage, Bleed[4]",
-	"4-6: +2 to future damage, bleed[6], psychic damage[d6]",
+	"4-6: +2 to future damage, Bleed[6], Psychic damage[d6]",
 	"7+: killed",
 	"Note: bleeding does not cause more bleeding",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [models.armored_unicorn_rider]
 name = "Armored Unicorn Rider"
@@ -1265,7 +1265,7 @@ requires = []
 [equipment.thunderroar.range]
 range = 5
 angle = [false, true, false, false]
-damage = "d6 psychic"
+damage = "d6 Psychic"
 ap = "N/A"
 
 [equipment.thunderroar.range.special]
@@ -1301,7 +1301,7 @@ ap = 5
 "Fire Order" = "May be load up to 5 shots, fire them one at a time"
 
 [equipment.teslaburstlaser]
-name = "TeslaBurstLaster"
+name = "TeslaBurstLaser"
 race = "elf"
 requires = [["type:Vehicle"], ["Minor Gun:1"]]
 cost.cp = 8
@@ -1378,7 +1378,7 @@ damage = "-"
 ap = "N/A"
 
 [equipment.acid_breath.range.special]
-"Extra Damage" = "Choose one hex within normal range. Automatically consider all units in the hex hit. Give all units in the hex acid if it is at point blank range, and minor acid otherwise. "
+"Extra Damage" = "Choose one hex within normal range. Automatically consider all units in the hex hit. Give all units in the hex acid if it is at point blank range, and minor acid otherwise."
 
 [equipment.poison_spit]
 name = "Poison Spit"
@@ -1396,7 +1396,7 @@ ap = "N/A"
 "Multiple Shots" = "Fire one time per alive minor head"
 
 [equipment.gatling_gun]
-name = "GatlingGun"
+name = "Gatling Gun"
 race = "elf"
 requires = []
 
@@ -1418,14 +1418,14 @@ requires = []
 [equipment.shriek_smg_free.range]
 range = 3
 angle = [true, true, false, false]
-damage = "d4 -2 + d6 psychic damage"
+damage = "d4 -2 + d6 Psychic damage"
 ap = 2
 
 [equipment.shriek_smg_free.range.special]
 "Burst" = "[5]: Must have loaded 5 ammo to be fired, but each time it is fired, its fired 5 times (per model)"
 
 [equipment.oliphant_gatling_guns]
-name = "Oliphant GatlingGuns"
+name = "Oliphant Gatling Guns"
 race = "elf"
 requires = []
 description = "Represent one gatling gun firing to the left and one firing to the right."
@@ -1565,7 +1565,7 @@ upgrade_all = true
 [equipment.illusion_weapon.range]
 range = 2
 angle = [true, true, true, true]
-damage = "d6 psychic damage"
+damage = "d6 Psychic damage"
 ap = "N/A"
 
 [equipment.illusion_weapon.range.special]
@@ -1675,7 +1675,7 @@ damage = "d6-2"
 ap = "3"
 
 [equipment.sniper_rifle.range.special]
-"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d6 psychic damage and +d4 crew damage when aiming"
+"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d6 Psychic damage and +d4 Crew damage when aiming"
 "Sniper" = "After eliminating one model with the use of aim, you get to choose which model to destroy"
 
 [equipment.sniper_rifle_free]
@@ -1690,7 +1690,7 @@ damage = "d6-2"
 ap = "3"
 
 [equipment.sniper_rifle_free.range.special]
-"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d6 psychic damage and +d4 crew damage when aiming"
+"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d6 Psychic damage and +d4 Crew damage when aiming"
 "Sniper" = "After eliminating one model with the use of aim, you get to choose which model to destroy"
 
 [equipment.grenade]
@@ -1737,7 +1737,7 @@ fast = [["-", "Throw"]]
 name = "Crew Hand Grenade"
 race = "elf"
 requires = []
-description = "All crew target one hex with hand grenades"
+description = "All Crew target one hex with hand grenades"
 
 [equipment.crew_hand_grenade.range]
 range = 1

--- a/v3/races/gnome.toml
+++ b/v3/races/gnome.toml
@@ -48,12 +48,12 @@ still = [
 slow = [["Fire(res)", "Fire(res)"]]
 
 [units.gnome_infantry.damage_tables]
-regular = [
+Regular = [
     "1-5: Kill 1 model",
     "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
 ]
-psychic = ["4+: Unit Shaken"]
+Psychic = ["4+: Unit shaken"]
 
 [units.quad_bike]
 race = "gnome"
@@ -99,12 +99,12 @@ slow = [["Fire(res)", "Fire(res)"]]
 fast = [["Fire(res)", "Fire(res)"]]
 
 [units.quad_bike.damage_tables]
-regular = [
+Regular = [
     "1-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
 ]
-psychic = ["6+: Unit Shaken"]
+Psychic = ["6+: Unit shaken"]
 
 [units.assault_bots]
 race = "gnome"
@@ -121,7 +121,7 @@ movement_order = ["-", "-", "flee"]
 slow = [["-", "-", "Chase"]]
 
 [units.assault_bots.damage_tables]
-regular = ["0-7: Kill 1 model", "8: Destroy Unit"]
+Regular = ["0-7: Kill 1 model", "8: Destroy unit"]
 
 [units.mechanical_rat]
 race = "gnome"
@@ -138,7 +138,7 @@ movement_order = ["-", "-", "flee"]
 slow = [["-", "-", "Chase"]]
 
 [units.mechanical_rat.damage_tables]
-regular = ["0+: Destroy Unit"]
+Regular = ["0+: Destroy unit"]
 
 [units.gnome_motorcycle]
 race = "gnome"
@@ -178,8 +178,8 @@ slow = [["-", "Fire"], ["-", "Load"]]
 fast = [["-", "Fire"]]
 
 [units.gnome_motorcycle.damage_tables]
-regular = ["2-3: +1 on future damage", "4+: Kill 1 model"]
-psychic = ["6+: Unit Shaken"]
+Regular = ["2-3: +1 on future damage", "4+: Kill 1 model"]
+Psychic = ["6+: Unit shaken"]
 
 [units.ballista_drone]
 race = "gnome"
@@ -208,7 +208,7 @@ still = [
 ]
 
 [units.ballista_drone.damage_tables]
-regular = [
+Regular = [
     "2-3: +1 on future damage",
     "4-5: +1 on future damage, shaken",
     "6-7: as below, cannot move or rotate, speed set to still",
@@ -259,23 +259,23 @@ still = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 
 [units.ballista_tractor_markI.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as 1-3, shaken",
     "5-8: as 4, d6 critical damage",
     "9: Unit destroyed",
 ]
-critical = [
+Critical = [
     "1-2: +3 to future damage",
     "3: +1 to be hit, -1 to hit",
     "4: Rotate unit 180$^0$",
     "5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
     "6: set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12: Unit destroyed",
 ]
 
@@ -319,23 +319,23 @@ slow = [["-", "Load"], ["-", "Fire"]]
 still = [["-", "Load"], ["-", "Fire"], ["-", "Aim"]]
 
 [units.ballista_tractor_markII.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as below, shaken",
     "5-8: as below, d6 critical damage",
     "9: Unit destroyed",
 ]
-critical = [
+Critical = [
     "1-2: +3 to future damage",
     "3: +1 to be hit, -1 to hit",
     "4: Rotate unit 180$^0$",
     "5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
     "6: set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12: Unit destroyed",
 ]
 
@@ -381,23 +381,23 @@ slow = [["-", "Load"], ["-", "Fire"]]
 fast = [["-", "Load"], ["-", "Fire"]]
 
 [units.ballista_tractor_MarkIII.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as below, shaken",
     "5-8: +1 to future damage, d6 critical damage",
     "9: Unit destroyed",
 ]
-critical = [
+Critical = [
     "1-2: +3 to future damage",
     "3: +1 to be hit, -1 to hit",
     "4: Rotate unit 180$^0$",
     "5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
     "6: set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12: Unit destroyed",
 ]
 
@@ -466,13 +466,13 @@ still_flying = [
 ]
 
 [units.gnome_helicopter.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4-5: as below, shaken",
     "6-8: +3 to future damage, shaken",
     "9: Destroy unit",
 ]
-crew = ["as regular damage"]
+Crew = ["as regular damage"]
 
 #
 # Models
@@ -699,7 +699,7 @@ cost.xp = 4
 
 [models.gnome_elite_infantry.unit_special]
 "Fire Order" = "Treat any gunnery phase without any other order as fire(res) order instead (for this model only.)"
-"Resistance" = "Unit gains psychic[1] as long as at least one elite model is alive."
+"Resistance" = "Unit gains Psychic[1] as long as at least one elite model is alive."
 
 [models.gnome_elite_infantry.assault]
 strength = [1, 1, 1, 1]
@@ -938,7 +938,7 @@ requires = [["type:Infantry"], ["Hands:2"]]
 [equipment.frost_ray.range]
 range = 4
 angle = [true, true, true, true]
-damage = "d4-2+d6 psychic damage + d4 crew damage"
+damage = "d4-2+d6 Psychic damage + d4 Crew damage"
 ap = 0
 
 [equipment.frost_ray.range.special]
@@ -957,7 +957,7 @@ requires = [["type:Tinkerer", "type:Elite"], ["type:Infantry"], ["Reserve Ranged
 [equipment.green_gas_launcher.range]
 range = 3
 angle = [true, true, true, true]
-damage = "d6 psychic damage + d4 crew damage"
+damage = "d6 Psychic damage + d4 Crew damage"
 ap = 0
 
 [equipment.green_gas_launcher.range.special]
@@ -976,7 +976,7 @@ requires = [["type:Tinkerer"], ["type:Helicopter"], ["Helicopter Side:1"]]
 [equipment.helicopter_mounted_green_gas_launcher.range]
 range = 3
 angle = [true, true, true, true]
-damage = "d6 psychic damage + d4 crew damage"
+damage = "d6 Psychic damage + d4 Crew damage"
 ap = 0
 
 [equipment.helicopter_mounted_green_gas_launcher.range.special]
@@ -1123,7 +1123,7 @@ upgrade_all = true
 requires = [["type:Infantry"], ["Independent:1"]]
 
 [equipment.improved_medical_armor.unit_special]
-"Improved Resistance" = "Fire[6], Poison[6], acid[1] and Psychic[1] (improve by 1 if unit has psychic resistance from another source)"
+"Improved Resistance" = "Fire[6], Poison[6], acid[1] and Psychic[1] (improve by 1 if unit has Psychic resistance from another source)"
 
 [equipment.medical_armor]
 race = "gnome"
@@ -1133,7 +1133,7 @@ upgrade_all = true
 requires = [["type:Infantry"], ["Independent:1"]]
 
 [equipment.medical_armor.unit_special]
-"Improved Resistance" = "Fire[2], Poison[2], and Psychic[1] (improve by 1 if unit has psychic resistance from another source)"
+"Improved Resistance" = "Fire[2], Poison[2], and Psychic[1] (improve by 1 if unit has Psychic resistance from another source)"
 
 [equipment.plasma_shield_generator]
 race = "gnome"
@@ -1205,7 +1205,7 @@ requires = [["type:Tinkerer"], ["type:Helicopter"], ["Helicopter Side:1"]]
 [equipment.experimental_guided_missile.range]
 range = 0
 angle = [true, true, true, true]
-damage = "d6 + d6 psychic"
+damage = "d6 + d6 Psychic"
 ap = 5
 
 [equipment.experimental_guided_missile.range.special]

--- a/v3/races/goblin.toml
+++ b/v3/races/goblin.toml
@@ -36,25 +36,25 @@ still = [["360°", "360°", "360°"], ["360°", "F", "360°"]]
 slow  = [["360°", "F", "B"]]
 
 [units.goblin_infantry.damage_tables]
-regular = [
+Regular = [
 	"0-5: Kill 1 model",
-	"6-7: Kill 1 model, psychic damage[d6]",
+	"6-7: Kill 1 model, Psychic damage[d6]",
 	"8+: Unit destroyed",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 
 
 
 [units.gigant_snake_cavalry]
 race = "goblin"
-name = "Gigant Snake Cavalry"
+name = "Giant Snake Cavalry"
 models = ["gigant_snake_cavalry"]
 size = "Large"
 cost.mp = 4
 cost.xp = 24
-description = '''Two Goblin wielding a bow each riding one gigant snake. A terrifying view for all enemies, which is an unsuaualt treat for the goblin army. They also carry tiny snakes which are fired by special arrows carried by the goblin. Where applied in large numbers, the battlefield is littered with these tiny snakes, hiding in the grass below. For the light hearted, even the tiny snake can be scary.
+description = '''Two Goblin wielding a bow each riding one giant snake. A terrifying view for all enemies, which is an unsuaualt treat for the goblin army. They also carry tiny snakes which are fired by special arrows carried by the goblin. Where applied in large numbers, the battlefield is littered with these tiny snakes, hiding in the grass below. For the light hearted, even the tiny snake can be scary.
 
 Decent endurance, decent in assault with an devastating poison if they hit, and not to expensive. However their low speed, combined with low range limits the usefulness. The large number of tiny snakes are the real power of this unit.
 '''
@@ -77,12 +77,12 @@ still = [["360°", "360°", "360°"], ["360°", "A", "F"]]
 slow = [["360°", "F", "360°"], ["360°", "B", "-"], ["360°", "Chase", "-"]]
 
 [units.gigant_snake_cavalry.damage_tables]
-regular = ["1-6: Bleed[8]",
+Regular = ["1-6: Bleed[8]",
 	  "7-8: +1 to future damage, Bleed[8]",
 	  "9+: Unit destroyed",
 	"{{\\it Note: Bleeding does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 
 
@@ -104,10 +104,10 @@ movement_order = ["-", "-", "Flee"]
 slow = [["-", "-",  "Chase"], ["Reveal", "-", "-"]]
 
 [units.tiny_snake.damage_tables]
-regular = ["0-3: kill one model",
+Regular = ["0-3: kill one model",
 	   "4+ unit destroyed"]
 
-psychic = ["2+: shaken"]
+Psychic = ["2+: shaken"]
 
 
 
@@ -154,23 +154,23 @@ slow = [["-", "Load"], ["-", "Fire"]]
 still = [["-", "Load"], ["-", "Fire"]]
 
 [units.goblin_infantry_carrier.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: as below, shaken",
 	"5-8: as below, d6 critical damage",
 	"9: Unit destroyed",
 ]
-critical = [
+Critical = [
 	"1-2: 1d4 damage to all transported units",
 	"3: Forced Deploy (all units, empty hexes only)",
 	"4: Cannot rotate",
-	"5: Unit cannot Move ",
+	"5: Unit cannot move",
 	"6: set on fire",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12: Unit destroyed",
 ]
 
@@ -202,24 +202,24 @@ still = [["Load", "-"], ["Fire", "-"]]
 slow =  [["Load", "-"], ["Fire", "-"]]
 
 [units.bipedal_mech.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: as below, shaken",
 	"5-8: as below, d6 critical damage",
 	"9: Unit destroyed",
 ]
-critical = [
-	"1: Take d12 crew damage (note, it is not shaken before the apply damage step)",
+Critical = [
+	"1: Take d12 Crew damage (note, it is not shaken before the apply damage step)",
 	"2: Unit gets a minor acid token",
 	"3: +1 to be hit, -1 to hit",
 	"4: Cannot rotate",
-	"5: Unit cannot Move ",
+	"5: Unit cannot move",
 	"6: +1 to future damage and unit gets another shaken token",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12: Unit destroyed",
 ]
 
@@ -283,24 +283,24 @@ still = [["Load", "Load"]]
 
 
 [units.heavy_carrier.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4: as below, shaken",
 	"5-8: as below, d6 critical damage",
 	"9: Unit destroyed",
 ]
-critical = [
+Critical = [
 	"1: 1d4 damage to all transported units",
 	"2: Forced Deploy (empty hexes only)",
 	"3: +1 to be hit, -1 to hit",
 	"4: Cannot rotate",
-	"5: Unit cannot Move ",
+	"5: Unit cannot move",
 	"6: set on fire",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-11: as 6-7, +3 to future crew damage",
+	"8-11: as 6-7, +3 to future Crew damage",
 	"12: Unit destroyed",
 ]
 
@@ -368,23 +368,23 @@ still = [["Fire", "Fire"]]
 
 
 [units.modified_truck.damage_tables]
-regular = [
+Regular = [
 	"1-2: +1 to future damage",
 	"3: as below, shaken",
 	"4-7: as below, d6 critical damage",
 	"8: Unit destroyed",
 ]
-critical = [
+Critical = [
 	"1: 1d4 damage to all transported units",
 	"2: Forced Deploy (empty hexes only)",
 	"3: +1 to be hit, -1 to hit",
 	"4: Cannot rotate",
-	"5-6: Unit cannot Move ",
+	"5-6: Unit cannot move",
 ]
-crew = [
-	"3-4: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"3-4: Crippled Crew, if already shaken double initial Crew damage",
 	"5-6: as 4-5, shaken",
-	"7-9: as 6-7, +3 to future crew damage",
+	"7-9: as 6-7, +3 to future Crew damage",
 	"10: Unit destroyed",
 ]
 
@@ -415,7 +415,7 @@ fast_flying = [
 fast = [["-", "Load"], ["-", "Fire"]]
 
 [units.mechanical_fire_bird.damage_tables]
-regular = [
+Regular = [
 	"1-3: +1 to future damage",
 	"4-5: +2 to future damage",
 	"6+: As below, temporarily destroyed",
@@ -423,7 +423,7 @@ regular = [
 	"{{\\it Note: + to future damage does not apply to inner damage}}",
 	"{{\\it Note that it does not get the status temporarily destroyed before the apply damage step}}",
 ]
-inner = ["1-5: add one minor acid token", "6+: Remove reassemble token"]
+Inner = ["1-5: add one minor acid token", "6+: Remove reassemble token"]
 
 [models]
 
@@ -451,7 +451,7 @@ ap = 2
 
 
 [models.gigant_snake_cavalry]
-name = "Gigant Snake Cavalry"
+name = "Giant Snake Cavalry"
 race = "goblin"
 equipment_limit = ["Independent:∞", "Hands:2", "Special Arrows:3"]
 equipment = ["goblin_bow", "snake_arrow"]
@@ -581,7 +581,7 @@ replaces = "goblin_infantry"
 "To Hit" = "+2 to hit with thrown weapons"
 
 [models.elite_goblin_infantry.unit_special]
-"Improved Resistance" = "Unit gains psychic resistance 1 as long as at least one elite model is alive."
+"Improved Resistance" = "Unit gains Psychic resistance 1 as long as at least one elite model is alive."
 "Pre-Assault Retreat" = "[6+], +1 to pre-assault retreat (per elite in unit)"
 
 [models.elite_goblin_infantry.assault]
@@ -719,7 +719,7 @@ requires = [["Hands:2"], ["type:Infantry"]]
 [equipment.poison_bow.range]
 range = 2
 angle = [true, true, true, true]
-damage = "d4-2 + d4 crew damage"
+damage = "d4-2 + d4 Crew damage"
 ap = 1
 
 [equipment.poison_bow.range.special]
@@ -742,11 +742,11 @@ damage = "d8-2"
 ap = "2"
 
 [equipment.ogre_rifle.unit_special]
-"Movement" = "Unit is destroyed if trying to land in an impassible or overcrowded hex."
+"Movement" = "Unit is destroyed if trying to land in an impassable or overcrowded hex."
 
 [equipment.ogre_rifle.range.special]
 "Recoil"  = "After firing this weapon, set speed to slow flying"
-"Note" = "Remember to track ammo. "
+"Note" = "Remember to track ammo."
 
 [equipment.ogre_rifle.orders_gained.movement]
 slow_flying = [["rev", "-", "B[still]"]]
@@ -905,7 +905,7 @@ requires = [["Grenades:1"], ["type:Infantry"]]
 [equipment.poison_grenade.range]
 range = 1
 angle = [true, true, true, true]
-damage = "d4 crew damage"
+damage = "d4 Crew damage"
 ap = 0
 
 
@@ -936,7 +936,7 @@ race = "goblin"
 [equipment.light_mortar.range]
 range = 3
 angle = [true, true, true, true]
-damage = "d6 + d4 crew damage"
+damage = "d6 + d4 Crew damage"
 ap = 2
 
 [equipment.light_mortar.range.special]
@@ -990,7 +990,7 @@ requires = []
 [equipment.stinkbomb.range]
 range = 4
 angle = [true, true, true, false]
-damage = "d6 psychic damage + d6 crew damage"
+damage = "d6 Psychic damage + d6 Crew damage"
 ap = "N/A"
 
 [equipment.stinkbomb.range.special]
@@ -1011,7 +1011,7 @@ ap = 0
 
 
 [equipment.ring_of_fire.range.special]
-"Area" = "[6+] Targe at all enemies within exactly range 2"
+"Area" = "[6+] target at all enemies within exactly range 2"
 "Extra Damage" = "All units hit at least once is set on fire"
 
 [equipment.assault_archer]

--- a/v3/races/ogre.toml
+++ b/v3/races/ogre.toml
@@ -33,15 +33,15 @@ slow = [["360°", "F", "360°"], ["360°", "F", "B"]]
 still = [["360°", "360°", "360°"], ["360°", "A ", "F"]]
 
 [units.ogre_hydra.damage_tables]
-regular = [
+Regular = [
 	"1-2: Bleed[4]",
 	"3-5: +1 to future damage, Bleed[4]",
 	"6-10: +1 to future damage, Bleed[6], destroy one minor head. If all minor heads are destroyed, add additional +3 to future damage instead. Amplify all bleeding one step. (4 to 6, 6 to 8, 8 to 10 and 10 to 12)",
-	"10-17: As below, d6 psychic damage",
+	"10-17: As below, d6 Psychic damage",
 	"18: Unit destroyed",
 	"{{\\it Note: Bleed does not cause more bleeding}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.ogre_infantry]
 race = "ogre"
@@ -73,14 +73,14 @@ still = [["360°", "360°", "360°"], ["A+360°", "F", "360°"]]
 slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 
 [units.ogre_infantry.damage_tables]
-regular = [
+Regular = [
 	"2-3: Bleed[4]",
 	"4-6: Kill 1 model",
-	"7-10: Kill 1 model, psychic damage[d6]",
+	"7-10: Kill 1 model, Psychic damage[d6]",
 	"11+: Unit destroyed",
 	"{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.ogre_robot]
 race = "ogre"
@@ -113,7 +113,7 @@ still = [["360°", "360°", "360°"], ["A+360°", "F", "360°"]]
 slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 
 [units.ogre_robot.damage_tables]
-regular = [
+Regular = [
 	"2-3: +1 to future damage",
 	"4-6: +2 to future damage",
 	"7-10: Kill 1 model",
@@ -157,12 +157,12 @@ fast = [
 ]
 
 [units.pet_panther.damage_tables]
-regular = [
+Regular = [
 	"2-3: Bleed[4]",
 	"4-5: As below, +1 to future damage",
 	"6: unit destroyed"
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 [units.ogre_assault_scout]
 race = "ogre"
@@ -205,12 +205,12 @@ fast = [
 ]
 
 [units.ogre_assault_scout.damage_tables]
-regular = [
+Regular = [
 	"2-5: Bleed[8]",
 	"7-8: As below, +1 to future damage",
 	"9+: unit destroyed"
 ]
-psychic = ["6+: shaken"]
+Psychic = ["6+: shaken"]
 
 [units.drone_swarm]
 race = "ogre"
@@ -218,7 +218,7 @@ name = "Drone Swarm"
 models = ["drone_swarm", "drone_swarm", "drone_swarm", "drone_swarm"]
 size = "Tiny"
 cost.cp = 4
-description = "A drone swarm consists of 4 tiny floating drones, each carrying a tiny gear pistol. With deadly precision they cover any enemy that comes to close with minor acid. Although ogre themself are big and though, they are few in numbers and far from immune to enemy fire. This lead to the development of this cheap expendable unit"
+description = "A drone swarm consists of 4 tiny floating drones, each carrying a tiny gear pistol. With deadly precision they cover any enemy that comes to close with minor acid. Although ogre themselves are big and though, they are few in numbers and far from immune to enemy fire. This lead to the development of this cheap expendable unit"
 
 [units.drone_swarm.shaken]
 speed = "slow"
@@ -260,7 +260,7 @@ slow = [["360°", "F", "B"]]
 fast = [["Chase", "Chase", "Chase + B"]]
 
 [units.drone_swarm.damage_tables]
-regular = ["1+: Destroy one model"]
+Regular = ["1+: Destroy one model"]
 
 [units.industrial_drone_swarm]
 race = "ogre"
@@ -268,7 +268,7 @@ name = "Industrial Drone Swarm"
 models = ["drone_swarm", "drone_swarm", "drone_swarm", "drone_swarm"]
 size = "Tiny"
 cost.ip = 1
-description = "A drone swarm consists of 4 tiny floating drones, each carrying a tiny gear pistol. With deadly precision they cover any enemy that comes to close with minor acid. Although ogre themself are big and though, they are few in numbers and far from immune to enemy fire. This lead to the development of this cheap expendable unit"
+description = "A drone swarm consists of 4 tiny floating drones, each carrying a tiny gear pistol. With deadly precision they cover any enemy that comes to close with minor acid. Although ogre themselves are big and though, they are few in numbers and far from immune to enemy fire. This lead to the development of this cheap expendable unit"
 
 [units.industrial_drone_swarm.shaken]
 speed = "slow"
@@ -310,7 +310,7 @@ slow = [["360°", "F", "B"]]
 fast = [["Chase", "Chase", "Chase + B"]]
 
 [units.industrial_drone_swarm.damage_tables]
-regular = ["0+: Destroy one model"]
+Regular = ["0+: Destroy one model"]
 
 [units.repair_drone]
 race = "ogre"
@@ -333,7 +333,7 @@ movement_order = ["-", "-", "-"]
 slow = [["360°", "F", "360°"]]
 
 [units.repair_drone.damage_tables]
-regular = ["1+: destroy one model"]
+Regular = ["1+: destroy one model"]
 
 [units.medic_drone]
 race = "ogre"
@@ -357,7 +357,7 @@ movement_order = ["-", "-", "-"]
 fast = [["Help", "Help", "Help"]]
 
 [units.medic_drone.damage_tables]
-regular = ["1+: destroy one model"]
+Regular = ["1+: destroy one model"]
 
 [units.main_engine]
 race = "ogre"
@@ -406,22 +406,22 @@ fast = [
 ]
 
 [units.main_engine.damage_tables]
-critical = [
+Critical = [
 	"1-3: +3 to future damage",
 	"4: Cannot rotate",
-	"5: Cannot Move",
+	"5: Cannot move",
 	"6: set on Fire",
 ]
-regular = [
+Regular = [
 	"1-3: +1 on future damage",
 	"4: as below, shaken",
 	"5-8: Critical damage[d6], +1 on future damage",
 	"9+: Destroyed",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-12: as 6-7, +3 to future crew damage",
+	"8-12: as 6-7, +3 to future Crew damage",
 	"13: Unit destroyed",
 ]
 
@@ -446,17 +446,17 @@ slow =  [["Fire", "-"], ["-", "Fire"], ["Load", "-"], ["-", "Load"]]
 fast =  [["Fire", "-"], ["-", "Fire"], ["Load", "-"], ["-", "Load"]]
 
 [units.broadside_wagon.damage_tables]
-critical = ["1-5: +3 to future damage", "6: set on Fire"]
-regular = [
+Critical = ["1-5: +3 to future damage", "6: set on Fire"]
+Regular = [
 	"1-3: +1 on future damage",
 	"4: as below, shaken",
 	"5-8: Critical damage[d6], +1 on future damage",
 	"9+: Destroyed",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-12: as 6-7, +3 to future crew damage",
+	"8-12: as 6-7, +3 to future Crew damage",
 	"13: Unit destroyed",
 ]
 
@@ -502,17 +502,17 @@ fast = [
 ]
 
 [units.artillery_wagon.damage_tables]
-critical = ["1-5: +3 to future damage", "6: set on Fire"]
-regular = [
+Critical = ["1-5: +3 to future damage", "6: set on Fire"]
+Regular = [
 	"1-3: +1 on future damage",
 	"4: as below, shaken",
 	"5-8: Critical damage[d6], +1 on future damage",
 	"9+: Destroyed",
 ]
-crew = [
-	"4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+	"4-5: Crippled Crew, if already shaken double initial Crew damage",
 	"6-7: as 4-5, shaken",
-	"8-12: as 6-7, +3 to future crew damage",
+	"8-12: as 6-7, +3 to future Crew damage",
 	"13: Unit destroyed",
 ]
 
@@ -619,7 +619,7 @@ damage = "d8"
 ap = 3
 
 [models.ogre_scout_engineer.assault.special]
-"Extra Damage" = "Gear Disrutpin[4+]"
+"Extra Damage" = "Gear Disruption[4+]"
 
 [models.ogre_hydra]
 name = "Ogre Hydra"
@@ -876,7 +876,7 @@ damage = "d8-2"
 ap = 3
 
 [equipment.ogre_sniper_rifle.range.special]
-"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d8 psychic damage and +d6 crew damage when aiming"
+"Improved Aim" = "improved aim: +4 to hit instead of +2. Gain additional +2 regular damage, +d8 Psychic damage and +d6 Crew damage when aiming"
 "Sniper" = "After eliminating one model with the use of aim, you get to choose which model to destroy"
 
 [equipment.ogre_rifle]
@@ -1071,7 +1071,7 @@ upgrade_all = false
 requires = [["Reserve Melee:1"], ["type:Scout", "type:Infantry"]]
 
 [equipment.fancy_warhammer.assault]
-damage.replace = "d8 + d6 psychic damage"
+damage.replace = "d8 + d6 Psychic damage"
 ap.replace = 5
 
 [equipment.acid_breath]
@@ -1086,7 +1086,7 @@ damage = "-"
 ap = "N/A"
 
 [equipment.acid_breath.range.special]
-"Extra Damage" = "Choose one hex within normal range. Automatically consider all units in the hex hit. Give all units in the hex acid if it is at point blank range, and minor acid otherwise. "
+"Extra Damage" = "Choose one hex within normal range. Automatically consider all units in the hex hit. Give all units in the hex acid if it is at point blank range, and minor acid otherwise."
 
 [equipment.poison_spit]
 name = "Poison Spit"

--- a/v3/races/ork.toml
+++ b/v3/races/ork.toml
@@ -32,13 +32,13 @@ still = [["360°", "360°", "360°"], ["360°", "A+F", "360°"]]
 slow = [["360°", "F", "360°"], ["360°", "B", "360°"]]
 
 [units.ork_infantry.damage_tables]
-regular = [
+Regular = [
     "1-5: Kill 1 model",
-    "6-7: Kill 1 model, psychic damage[d6]",
+    "6-7: Kill 1 model, Psychic damage[d6]",
     "8+: Unit destroyed",
     "{{\\it Note: If one model is killed remove half of the +1 future damage tokens \\\\ and if killed by bleeding/poison, remove that bleeding/poison token}}",
 ]
-psychic = ["4+: shaken"]
+Psychic = ["4+: shaken"]
 
 [units]
 
@@ -67,9 +67,9 @@ movement_order = ["-", "-", "flee"]
 slow = [["Chase", "-", "-"], ["-", "-", "Chase"]]
 
 [units.troll.damage_tables]
-regular = [
+Regular = [
     "3-9: +1 on future damage",
-    "10-14: +1 for future damage, bleed[12]",
+    "10-14: +1 for future damage, Bleed[12]",
     "15-19: as 10-14 plus Troll unconscious",
     "20+: permanent dead",
 ]
@@ -89,7 +89,7 @@ movement_order = ["-", "-", "flee"]
 "Spawn" = "Has same orders available as the unit it awakened from, and the same weapons as the last surviving model of the unit"
 
 [units.champion.damage_tables]
-regular = ["2-3: Bleeding[4]", "4+ : Killed"]
+Regular = ["2-3: Bleeding[4]", "4+: Killed"]
 
 #to do... order of spawned champion= order of the infantry...
 [units.champion.orders.movement]
@@ -134,11 +134,11 @@ slow = [["Load", "-"], ["fire", "-"], ["-", "fire"]]
 fast = [["Load", "-"], ["fire", "-"], ["-", "fire"]]
 
 [units.warg_rider.damage_tables]
-psychic = ["5+: unit shaken"]
-regular = [
+Psychic = ["5+: unit shaken"]
+Regular = [
     "2-3: Bleeding[6]",
-    "4-6: Bleeding[6], +1 to future damage, psychic damage[d6]",
-    "7+: kill 1 model, psychic damage[d6]",
+    "4-6: Bleeding[6], +1 to future damage, Psychic damage[d6]",
+    "7+: kill 1 model, Psychic damage[d6]",
     "{{\\it When one model is killed, half all +1 to future damage rounded down}}",
     "{{\\it If killed by poison or bleeding, remove that instance}}",
 ]
@@ -174,22 +174,22 @@ slow = [["Load", "Load"], ["Load", "Fire Burst(5)"], ["Fire Burst(5)", "Load"]]
 fast = [["Load", "Load"], ["Load", "Fire Burst(5)"], ["Fire Burst(5)", "Load"]]
 
 [units.speedhead.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as 1-3, shaken",
     "5-8: 4, Critical Damage[d6]",
     "9+: unit destroyed",
 ]
-critical = [
+Critical = [
     "1-3: +3 to future damage",
     "4: Cannot rotate",
     "5: -1 to hit, +1 to be hit (ranged and assault)",
     "6: Unit set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12+: Unit destroyed",
 ]
 
@@ -206,22 +206,22 @@ speed = "still"
 movement_order = ["-", "-", "-"]
 
 [units.hammerhead.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: 1-3, shaken",
     "as 4, 5-8: Critical Damage",
     "9+: unit destroyed",
 ]
-critical = [
+Critical = [
     "1-3: +3 to future damage",
     "4: Unit cannot rotate",
-    "5: Unit Cannot Move",
+    "5: Unit Cannot move",
     "6: -5 to assault strength.",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12+: Unit destroyed",
 ]
 
@@ -267,25 +267,25 @@ speed = "still"
 movement_order = ["-", "-", "-"]
 
 [units.battlewagon.special]
-"Transport" = "May transport up to 2 infantry. Treat any movement in movementphase 3 order as including an optional +Deploy(range=1) order. May deploy directly in assault. If Battlewagon enters an assault, you may optionally deploy 1 infantry to join the assault."
+"Transport" = "May transport up to 2 infantry. Treat any movement in movement phase 3 order as including an optional +Deploy(range=1) order. May deploy directly in assault. If Battlewagon enters an assault, you may optionally deploy 1 infantry to join the assault."
 "Fire Order" = "Fire all weapons simultaneously"
 
 [units.battlewagon.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as 1-3, shaken",
     "5-8: as 4, Critical Damage",
     "9+: unit destroyed, any transported units takes d6 regular damage and exit the vehicle",
 ]
-critical = [
+Critical = [
     "1-3: +3 to future damage",
     "4-5: gain one extra shaken token",
     "6: Unit set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12+: Unit destroyed",
 ]
 
@@ -330,12 +330,12 @@ movement_order = ["-", "-", "flee"]
 slow = [["Chase", "-", "-"], ["-", "-", "Chase"]]
 
 [units.grunt.damage_tables]
-regular = [
+Regular = [
     "1-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
 ]
-psychic = ["4+: Unit Shaken"]
+Psychic = ["4+: Unit shaken"]
 
 [units.ork_werewarg]
 name = "Ork WereWarg"
@@ -378,15 +378,15 @@ still = [
 ]
 
 [units.ork_werewarg.damage_tables]
-regular = [
+Regular = [
     "1-3: Bleed[4]",
-    "4-9: Temporarily Kill 1 Model, d6 Psychic damage",
+    "4-9: Temporarily Kill 1 model, d6 Psychic damage",
     "10: Unit Permanently Destroyed, stops regenerating",
     "When all models are temporarily killed:",
     "replace kill 1 model with +1 on future damage and keep all remaining bleeding",
     "{{\\it If one model is temporarily killed by bleed or poison, remove that instance}}",
 ]
-psychic = ["6+: Unit Shaken"]
+Psychic = ["6+: Unit shaken"]
 
 [units.bioengineered_ork]
 name = "BioEngineered Ork"
@@ -432,15 +432,15 @@ slow = [
 ]
 
 [units.bioengineered_ork.damage_tables]
-regular = [
+Regular = [
     "1: Bleed[4]",
     "2-5: Kill 1 model",
-    "6-8: Kill 1 Model, d6 Psychic damage",
+    "6-8: Kill 1 model, d6 Psychic damage",
     "9: Destroy unit",
     "{{\\it When one model is killed, half all +1 to future damage rounded down}}",
     "{{\\it If killed by poison or bleeding, remove that instance}}",
 ]
-psychic = ["5+: Unit Shaken"]
+Psychic = ["5+: Unit shaken"]
 
 [units.ork_char_b1]
 race = "ork"
@@ -460,8 +460,8 @@ slow = [
     ["Load (h)", "Fire (p)"],
     ["Fire (h)", "Load (p)"],
     ["Load (p)", "Fire (h)"],
-    ["Aim(p)", " Load (h)"],
-    ["Aim(p)", " Fire (h)"],
+    ["Aim(p)", "Load (h)"],
+    ["Aim(p)", "Fire (h)"],
     ["Load (h)", "Aim (p)"],
     ["Fire (h)", "Aim (p)"],
 ]
@@ -507,23 +507,23 @@ still = [
 ]
 
 [units.ork_char_b1.damage_tables]
-regular = [
+Regular = [
     "1-3: +1 to future damage",
     "4: as 1-3, shaken",
     "5-8: as 4, Critical Damage[d6]",
     "9+: Unit Destroyed",
 ]
-critical = [
+Critical = [
     "1: Cannot Rotate",
     "2: Cannot move",
     "3: -1 to hit, +1 to be hit (ranged and assault)",
     "4-5: +3 to future damage",
     "6: Unit set on fire",
 ]
-crew = [
-    "4-5: Crippled Crew, if already shaken double initial crew damage",
+Crew = [
+    "4-5: Crippled Crew, if already shaken double initial Crew damage",
     "6-7: as 4-5, shaken",
-    "8-11: as 6-7, +3 to future crew damage",
+    "8-11: as 6-7, +3 to future Crew damage",
     "12+: Unit destroyed",
 ]
 
@@ -555,7 +555,7 @@ ap = 2
 
 [models.troll.assault.special]
 "Fear" = "[8]"
-"Troll Stench" = "Any unit entering assault with a troll gains one Poison[6] counter and takes d8 crew damage, regardless of the outcome of the assault. Note that poison only applies to biological units and crew damage only to units with a crew damage table"
+"Troll Stench" = "Any unit entering assault with a troll gains one Poison[6] counter and takes d8 Crew damage, regardless of the outcome of the assault. Note that poison only applies to biological units and Crew damage only to units with a Crew damage table"
 
 [models.grunt]
 name = "Grunt"
@@ -586,7 +586,7 @@ replaces = "ork_infantry"
 type = ["Elite", "Infantry", "Walking"]
 
 [models.ork_elite_infantry.special]
-"Not Yet Dead" = "after this model in the unit base is killed, this model is not yet dead after all. This model becomes a new unit and becomes an Champion with the same equipment as this model and orders available as the unit base this model is attached to . Champion does not retain any of the abilities from the unit base or the model, and has a separate model and unit base entry. See Champion. In the case this model is not the last model to be eliminated, it may be the case that you get an extra unit base in the hex. If this causes overcrowding (more than 2 units in a hex), the champion may spawn in one of the neighboring hex which is furthest from an enemy unit"
+"Not Yet Dead" = "after this model in the unit base is killed, this model is not yet dead after all. This model becomes a new unit and becomes an Champion with the same equipment as this model and orders available as the unit base this model is attached to. Champion does not retain any of the abilities from the unit base or the model, and has a separate model and unit base entry. See Champion. In the case this model is not the last model to be eliminated, it may be the case that you get an extra unit base in the hex. If this causes overcrowding (more than 2 units in a hex), the champion may spawn in one of the neighboring hex which is furthest from an enemy unit"
 
 [models.ork_elite_infantry.unit_special]
 "Improved Resistance" = "Unit gains Psychic resistance 1 while at least one elite is alive"
@@ -898,7 +898,7 @@ upgrade_all = false
 requires = [["type:Infantry", "type:Cavalry"], ["type:Elite"], ["Hands:1"]]
 
 [equipment.flame_covered_axe.assault]
-damage.replace = "d6+1 + d4 crew damage"
+damage.replace = "d6+1 + d4 Crew damage"
 
 [equipment.flame_covered_axe.assault.special]
 "Extra Damage" = "Fire, Minor Acid[1 for 2], Poison[4][1 for 2]"
@@ -909,7 +909,7 @@ race = "ork"
 requires = [["type:Infantry", "type:Cavalry"], ["type:Elite"], ["Hands:1"]]
 
 [equipment.flame_covered_axe_free.assault]
-damage.replace = "d6+1 + d4 crew damage"
+damage.replace = "d6+1 + d4 Crew damage"
 
 [equipment.flame_covered_axe_free.assault.special]
 "Extra Damage" = "Fire, Minor Acid[1 for 2], Poison[4][1 for 2]"
@@ -1102,7 +1102,7 @@ requires = []
 [equipment.shriek.range]
 range = 3
 angle = [false, false, true, true]
-damage = "d4-2+ d6 psychic damage"
+damage = "d4-2+ d6 Psychic damage"
 ap = 2
 
 [equipment.shriek.range.special]
@@ -1137,7 +1137,7 @@ damage = "N.A"
 ap = 0
 
 [equipment.flamethrower.range.special]
-"Area" = "Fire at all possible hexes possible simultaneously: Area(3+) at point blank range, Area(4+) in the hex at long range directly ahead, and Area(5+) for the two hexes which is on long range and on edge of firing arc. "
+"Area" = "Fire at all possible hexes possible simultaneously: Area(3+) at point blank range, Area(4+) in the hex at long range directly ahead, and Area(5+) for the two hexes which is on long range and on edge of firing arc."
 "Extra Damage" =     "set on Fire"
 "Ammo" =     "Limited Ammo[3]"
 
@@ -1150,7 +1150,7 @@ requires = []
 [equipment.rotating_pop_gun.range]
 range = 4
 angle = [true, true, true, true]
-damage = "d6 + (d8 crew damage when penetrating all armor)"
+damage = "d6 + (d8 Crew damage when penetrating all armor)"
 ap = 7
 
 [equipment.rotating_pop_gun.range.special]
@@ -1176,7 +1176,7 @@ upgrade_all = true
 requires = [["type:Infantry", "type:Grunt"], ["Hands:1"]]
 
 [equipment.tankscalper.assault.special]
-"Improved Extra Damage" = "May replace regular damage with d8 crew damage. Note: crew damage ignore armor"
+"Improved Extra Damage" = "May replace regular damage with d8 Crew damage. Note: Crew damage ignore armor"
 
 [equipment.healing_syringe]
 race = "ork"
@@ -1265,7 +1265,7 @@ ap = 2
 
 [equipment.assault_musket.range.special]
 "Ammo" = "May load up to 4 ammo. If you have 4 ammo stored, you may spend all 4 ammo to use the 'heavy shot' setting when firing a shot. If you do gain range: 4, AP:3 and damage:d6-1"
-"Note" = " ps! It is not recommended combining this with other ranged weapons as a ork pistol. However if you do, track ammo and loading actions etc. for the other gun and this weapon separately"
+"Note" = "ps! It is not recommended combining this with other ranged weapons as a ork pistol. However if you do, track ammo and loading actions etc. for the other gun and this weapon separately"
 
 
 

--- a/v3/src/spf/schemas/type_aliases.py
+++ b/v3/src/spf/schemas/type_aliases.py
@@ -36,7 +36,7 @@ type PhaseName = Literal[
 type RaceName = Literal[
     "abomination", "darkelf", "dwarf", "elf", "gnome", "goblin", "ogre", "ork"
 ]
-type DamageTableName = Literal["crew", "critical", "inner", "psychic", "regular"]
+type DamageTableName = Literal["Crew", "Critical", "Inner", "Psychic", "Regular"]
 type EquipmentHolder = Literal[
     "Independent",
     "Grenades",
@@ -133,7 +133,7 @@ type AssaultSpecial = Literal[
     "Improved Extra Damage",
     "Cunning Assault",
     "Cunning Deflection",
-    "Cunning Assault Defence",
+    "Cunning Assault Defense",
     "Damage on Deflect",
     "Overrun",
     "Counter Attack",

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -61,7 +61,7 @@ def simple_race() -> RaceConfig:
                 special={},
                 orders=OrdersConfig(),
                 armor=None,
-                damage_tables={"regular": ["Fine", "Dead"]},
+                damage_tables={"Regular": ["Fine", "Dead"]},
             )
         },
         models={
@@ -1042,7 +1042,7 @@ def test_validate_army_detects_invalid_model_replacement(
         special={},
         orders=OrdersConfig(),
         armor=None,
-        damage_tables={"regular": ["Fine", "Dead"]},
+        damage_tables={"Regular": ["Fine", "Dead"]},
     )
     illegal_unit = ArmyUnit(
         name="squad",
@@ -1072,7 +1072,7 @@ def test_validate_army_detects_multiple_violations(simple_race: RaceConfig) -> N
         special={},
         orders=OrdersConfig(),
         armor=None,
-        damage_tables={"regular": ["Fine", "Dead"]},
+        damage_tables={"Regular": ["Fine", "Dead"]},
     )
     illegal_unit = ArmyUnit(
         name="double_squad",
@@ -1572,7 +1572,7 @@ def test_unit_cost_upgrade_all_false_multiplies_by_unit_size(
         special={},
         orders=OrdersConfig(),
         armor=None,
-        damage_tables={"regular": ["Fine", "Dead"]},
+        damage_tables={"Regular": ["Fine", "Dead"]},
     )
     race = RaceConfig(
         races=simple_race.races,
@@ -1606,7 +1606,7 @@ def test_unit_cost_upgrade_all_true_flat(simple_race: RaceConfig) -> None:
         special={},
         orders=OrdersConfig(),
         armor=None,
-        damage_tables={"regular": ["Fine", "Dead"]},
+        damage_tables={"Regular": ["Fine", "Dead"]},
     )
     race = RaceConfig(
         races=simple_race.races,

--- a/v3/tests/armies/test_io.py
+++ b/v3/tests/armies/test_io.py
@@ -51,7 +51,7 @@ def simple_race() -> RaceConfig:
                 special={},
                 orders=OrdersConfig(),
                 armor=None,
-                damage_tables={"regular": ["Fine", "Dead"]},
+                damage_tables={"Regular": ["Fine", "Dead"]},
             )
         },
         models={

--- a/v3/tests/armies/test_rules_display.py
+++ b/v3/tests/armies/test_rules_display.py
@@ -47,7 +47,7 @@ def simple_race() -> RaceConfig:
                 special={"Terror": "causes fear"},
                 orders=OrdersConfig(),
                 armor=None,
-                damage_tables={"regular": ["Fine", "Dead"]},
+                damage_tables={"Regular": ["Fine", "Dead"]},
             )
         },
         models={
@@ -146,7 +146,7 @@ def test_unit_with_no_specials_omits_specials_line(capture: Console) -> None:
                 special={},
                 orders=OrdersConfig(),
                 armor=None,
-                damage_tables={"regular": ["Fine", "Dead"]},
+                damage_tables={"Regular": ["Fine", "Dead"]},
             )
         },
         models={

--- a/v3/tests/test_display.py
+++ b/v3/tests/test_display.py
@@ -43,7 +43,7 @@ def simple_race() -> RaceConfig:
                 special={},
                 orders=OrdersConfig(),
                 armor=None,
-                damage_tables={"regular": ["Fine", "Dead"]},
+                damage_tables={"Regular": ["Fine", "Dead"]},
             )
         },
         models={


### PR DESCRIPTION
## Summary

A typo/consistency pass over `races/*.toml` (the changes that `typos`/`typos.toml` can't express — casing, spacing, hyphenation, American/British variants, ambiguous real-word misspellings, and phrasing).

### Schema
- `DamageTableName` → `Literal["Crew", "Critical", "Inner", "Psychic", "Regular"]` (Title Case); all **196** damage-table keys across the 8 race files renamed to match.
- `AssaultSpecial`: `"Cunning Assault Defence"` → `"Cunning Assault Defense"` (American, matching `armor`).

### Prose normalizations (scoped to string values — keys, ids, and order-tokens like `Load(crew)` / `[models.crew]` / `"A "` left untouched)
- `psychic` → `Psychic` and `crew` → `Crew` capitalized as game terms.
- `Shaken` → `shaken` (except one sentence-initial case), mid-sentence `Model`/`Models` and `Unit` lowercased.
- `bleed[N]` tokens unified to `Bleed[N]`.
- `cannot Move` → `cannot move` (imperative `Move …` left capital).

### Bounded fixes
- Spelling: `loses`, `impassable`, `themselves`, `movement phase`, `TeslaBurstLaser`; `front arch`/`front ark` → `front arc`; `Brother in arms` → `Brother in Arms`.
- Ambiguous names (per maintainer decision): `Giant`, `gas mask`, `Gatling Gun`, `target`, `Disruption`.
- Spacing: collapsed prose double-spaces and stripped trailing/leading spaces, without disturbing order-string alignment.
- Test fixtures updated to the new damage-table key casing.

## Verification
- `just validate` ✅ (every race file loads through the schema with the new keys and `Defense`)
- `just lint` ✅ · `just spell` (typos) ✅ · `just test` ✅ **162 passed** · `ruff format` ✅

## Notes
- Single-token misspellings (`typos.toml` / `just spell-fix`) are intentionally **out of scope** here — a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)