### PR TITLE
Add render-foundation subsystem (spf/render)

### DIFF
--- a/v3/.gitignore
+++ b/v3/.gitignore
@@ -1,3 +1,6 @@
 
 # Session scratch (uncommitted working notes)
 .scratch/
+
+# Rendered output
+output/

--- a/v3/configs/spf.toml
+++ b/v3/configs/spf.toml
@@ -4,3 +4,7 @@ armies = "{project_path}/armies"
 races = "{project_path}/races"
 rules = "{project_path}/rules"
 templates = "{project_path}/templates"
+output = "{project_path}/output"
+
+[render.latex]
+engine = "pdflatex"

--- a/v3/docs/adr/0005-rendering-pipeline.md
+++ b/v3/docs/adr/0005-rendering-pipeline.md
@@ -36,3 +36,10 @@ the prose layout, so one source cannot serve both well.
   seam to inline them; deferred.
 - Multi-Unit and multi-Army aggregation into one Rendering is a future concern;
   the placeholder is concatenating PDFs at the end.
+- The Markdown Jinja environment runs with `autoescape=False`, **not** HTML
+  autoescape as one might assume. Markdown templates emit Markdown text, not
+  HTML — Jinja HTML-escaping would corrupt the raw `.md` (a `&` becomes `&amp;`)
+  and does nothing for Markdown-special characters anyway. HTML-escaping is
+  deferred to the Markdown→HTML derivation, where `markdown-it-py` escapes text
+  correctly. (Source data is designer-authored TOML, so injection risk is low
+  regardless.)

--- a/v3/openspec/changes/archive/2026-07-08-render-foundation/.openspec.yaml
+++ b/v3/openspec/changes/archive/2026-07-08-render-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/v3/openspec/changes/archive/2026-07-08-render-foundation/design.md
+++ b/v3/openspec/changes/archive/2026-07-08-render-foundation/design.md
@@ -1,0 +1,102 @@
+## Context
+
+SteamPunkFantasy needs to turn resolved data into gameplay-reference Renderings
+(Order Card, Army Reference, Race Overview, Rulebook) in four Formats (markdown,
+html, latex, pdf). v2 tangled data-prep and LaTeX emission in one 38 KB,
+LaTeX-only module. The architecture is settled in ADR 0005: resolved data is the
+view-model, two authored template families (Markdown, LaTeX), HTML derived from
+Markdown and PDF from LaTeX, a `Format` as a registered record. This change is the
+**foundation only** — no Product templates. It sits below the CLI and above the
+data layer (`races.py`/`armies/`/`rules.py`). Vocabulary lives in `CONTEXT.md`;
+sources of truth are the resolved `Army` (`spf.armies.army.Army`, frozen
+dataclass), the unresolved `RaceConfig`, and the `rules/*.toml` configs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One generic `render()` seam the four product issues build against, with products
+  contributing templates only (no Python).
+- Data-driven registries (Formats, Products) so a new Format or Product is
+  additive.
+- Two Jinja environments and two derivations, each formatting rule in exactly one
+  place.
+- Config, CLI scaffold, and a test strategy that proves the pipeline without any
+  Product.
+
+**Non-Goals:**
+- Product templates and their CLI subcommands (the four child issues).
+- Terminal/Rich output, `Race.resolve()`, multi-Unit/Army aggregation, rich
+  per-product HTML styling.
+
+## Decisions
+
+**Generic pipeline over registries, not per-product renderers.**
+`render(product, source, fmt, *, name, out=None)` looks up the family environment
+(`ENVIRONMENTS[fmt.family]`), loads `<product>/main.<ext>.jinja`, renders the whole
+source object into a dumb template, applies `fmt.post_step` if present, and writes
+the file. *Alternative rejected:* a `Renderer` subclass per product — it invites
+lookup/computation logic back into the renderer, the exact v2 tangle. Registries
+are plain module-level dicts populated at import; no entry-point/plugin machinery
+for a single-codebase set of four.
+
+**Foundation registers 4 Formats, 0 Products.** Formats are complete and
+family-generic, and `--format`'s choices derive from the Format registry. Products
+are half-defined without templates, so each child issue owns its `Product(...)`
+record end-to-end; foundation ships only the type + registry mechanism, and tests
+use a throwaway test-only Product. *Alternative rejected:* pre-registering the four
+Product records now — leaves half-defined products in the foundation.
+
+**Product is not bound to a family; missing combos fail lazily.** Order Card needs
+both Markdown and LaTeX templates (to reach html and pdf), so the `(product,
+family)` pair locates templates. We do not pre-validate the matrix; Jinja's
+`TemplateNotFound` surfaces only for the combination actually requested.
+
+**Markdown environment `autoescape=False`** — a deliberate deviation from the
+issue's "autoescape for HTML". Markdown templates emit Markdown, not HTML; Jinja
+HTML-escaping would corrupt the raw `.md` (`&`→`&amp;`) and does nothing for
+Markdown-special chars. HTML-escaping is deferred to `markdown-it-py` at
+derivation time. Source data is designer-authored TOML, so injection risk is low.
+Recorded in ADR 0005.
+
+**LaTeX environment** uses `\VAR{}`/`\BLOCK{}` delimiters to avoid brace clashes
+with LaTeX's own `{}`, plus `trim_blocks`/`lstrip_blocks` for clean output.
+
+**`md_to_html` uses `markdown-it-py`** (already transitive via `rich`; promoted to
+direct) with table support, wrapping the fragment in a minimal standalone HTML5
+document so the `.html` is double-clickable. *Alternative rejected:*
+`python-markdown` — a new dependency for no gain.
+
+**`latex_to_pdf` compiles in a temp dir, twice, `nonstopmode -halt-on-error`,**
+copying only the `.pdf` out. Twice is the standard "just works" default (stable
+page numbers/refs) and cheap for tiny docs. The engine is
+`config.render.latex.engine` (default `pdflatex`), so switching to xelatex/lualatex
+later — same flags — is one config line. Missing binary and non-zero exit raise
+clear, diagnosable errors (the latter includes the engine log tail).
+
+**Config**: `paths.output` (honoring the issue's `config.paths.output` wording) and
+a nested `[render.latex].engine` so `[render.markdown]`/`[render.pdf]` can join
+later; `output/` gitignored.
+
+**CLI**: an empty `spf render` group wired like `army`/`race`/`rules`, plus a
+reusable `RenderOpts(--format/--out)` parameter set the product subcommands will
+accept. No dummy command — the pipeline is proven by tests.
+
+**Injectable roots as the test seam.** `make_environments(templates_root)` and
+`render(..., output_root=...)` default to `config.paths.*` but accept overrides, so
+tests point at fixture templates and a tmp output dir. Fan-out (Order Card is
+per-Unit) lives in product subcommands; `render` renders one source to one file and
+takes `name` explicitly rather than sniffing `.nick`/race-name off the source.
+
+## Risks / Trade-offs
+
+- **PDF tests need a LaTeX install** → `@pytest.mark.skipif(shutil.which(engine))`
+  so CI without LaTeX passes; env/text-format paths stay fully covered.
+- **Foundation ships nothing a user can run end-to-end** (empty CLI group until the
+  first product) → acceptable for a foundation; the seam is verified by an
+  end-to-end `render()` test over a fixture template.
+- **`jinja2`/`markdown-it-py` currently only transitive** (via `streamlit`/`rich`)
+  → promote to direct deps so we don't rely on that staying true.
+- **Two-pass pdflatex doubles compile time** → negligible for these tiny reference
+  docs; buys robustness against stale page numbers.
+- **Legacy `templates/*.tex` left in place** → invisible to the new family-rooted
+  loaders; product issues cannibalize them to bootstrap, avoiding churn now.

--- a/v3/openspec/changes/archive/2026-07-08-render-foundation/proposal.md
+++ b/v3/openspec/changes/archive/2026-07-08-render-foundation/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The four planned gameplay-reference Products (Order Card, Army Reference, Race
+Overview, Rulebook) all need the same rendering machinery: turn a resolved data
+object into a file in one of several Formats. v2 tangled data-prep and LaTeX
+emission in one 38 KB, LaTeX-only module. Before any Product is built we need the
+shared `spf/render/` foundation the four child issues plug into — the seam,
+environments, derivations, config, and CLI scaffold. (GitHub #17, child of #16;
+architecture settled in ADR 0005.)
+
+## What Changes
+
+- New package `spf/render/` (below the CLI, above `races.py`/`armies/`/`rules.py`)
+  exposing one seam: `render(product, source, fmt, *, name, out=None) -> Path` — a
+  generic pipeline driven by data records, not per-product/per-format code.
+- **Format registry**: `Format(name, extension, family, post_step)`; register all
+  four — `markdown`, `html` (markdown family + `md_to_html`), `latex`, `pdf`
+  (latex family + `latex_to_pdf`).
+- **Product registry**: the `Product` record type + registry mechanism only —
+  **zero** concrete Products registered (each child issue adds its own).
+- **Two Jinja2 environments**: Markdown (stock delimiters, `autoescape=False`) and
+  LaTeX (`\VAR{}`/`\BLOCK{}`, `autoescape=False`, trim/lstrip blocks), built by an
+  injectable factory.
+- **Two derivations**: `md_to_html` (markdown-it-py → standalone HTML doc) and
+  `latex_to_pdf` (compile twice in a temp dir, copy only the `.pdf`).
+- **Template layout** `templates/<family>/<product>/main.<ext>.jinja`; legacy
+  top-level `templates/*.tex` left untouched.
+- **Config**: add `paths.output` (default `{project_path}/output`, gitignored) and
+  a `[render.latex].engine` setting (default `pdflatex`).
+- **CLI**: an empty `spf render` group + a reusable `--format`/`--out` parameter
+  set; product subcommands land in the child issues.
+- **Dependencies**: promote `jinja2` and `markdown-it-py` to direct deps.
+
+## Non-goals
+
+- Any actual Product template or its CLI subcommand (the four child issues).
+- Terminal/Rich output (authoring/inspection, not a Rendering).
+- `Race.resolve()` to inline full special text (Race Overview stays unresolved).
+- Multi-Unit / multi-Army aggregation into one Rendering.
+- Rich per-product HTML styling.
+
+## Capabilities
+
+### New Capabilities
+- `render-foundation`: the shared rendering subsystem — the `render()` seam, the
+  Format and Product record types and registries, the two Jinja environments, the
+  two derivations (Markdown→HTML, LaTeX→PDF), output-path resolution and write
+  behavior, config additions, and the `spf render` CLI scaffold.
+
+### Modified Capabilities
+
+None — no existing spec's requirements change.
+
+## Impact
+
+- **New code**: `src/spf/render/` (`pipeline`, `formats`, `products`,
+  `environments`, `derivations`, `__init__`).
+- **CLI**: `src/spf/frontends/cli/main.py` gains the `render` group; new
+  `cli/render.py` for the `RenderOpts` parameter set.
+- **Config**: `configs/spf.toml` + `src/spf/schemas/config.py` (`PathsConfig.output`,
+  new `RenderConfig`/`LatexConfig`); `.gitignore` gains `output/`.
+- **Dependencies**: `pyproject.toml` — `jinja2`, `markdown-it-py` become direct.
+- **System prerequisite**: `pdflatex`/`xelatex` needed only for the `pdf` Format
+  (tests `skipif`-gate on it).
+- **Templates**: new `templates/markdown/` and `templates/latex/` subtrees; legacy
+  `.tex` files untouched.

--- a/v3/openspec/changes/archive/2026-07-08-render-foundation/specs/render-foundation/spec.md
+++ b/v3/openspec/changes/archive/2026-07-08-render-foundation/specs/render-foundation/spec.md
@@ -1,0 +1,205 @@
+## ADDED Requirements
+
+### Requirement: Render seam
+
+The system SHALL expose a single entry point
+`render(product, source, fmt, *, name, out=None) -> Path` that renders exactly
+one source object to exactly one file and returns the written path. It SHALL be a
+generic pipeline parameterized by the Format and Product records — it MUST NOT
+contain per-product or per-format branching code.
+
+#### Scenario: Render one source to one file
+
+- **WHEN** `render` is called with a registered Product, a source object, a
+  registered Format, and a `name`
+- **THEN** the source is rendered through the Format's family environment and the
+  written file path is returned
+
+#### Scenario: Source passed to a dumb template
+
+- **WHEN** a template is rendered
+- **THEN** the resolved source object is passed in whole under a fixed variable
+  and the template performs no lookups or computation
+
+### Requirement: Format registry
+
+The system SHALL provide a `Format(name, extension, family, post_step)` record and
+register exactly four Formats: `markdown` (ext `md`, family `markdown`, no
+post-step), `html` (ext `html`, family `markdown`, post-step `md_to_html`),
+`latex` (ext `tex`, family `latex`, no post-step), and `pdf` (ext `pdf`, family
+`latex`, post-step `latex_to_pdf`). Formats SHALL be looked up by name.
+
+#### Scenario: Look up a registered Format
+
+- **WHEN** a Format is requested by one of the four names
+- **THEN** its extension, family, and optional post-step are returned
+
+#### Scenario: Unknown Format name
+
+- **WHEN** a Format is requested by a name that is not registered
+- **THEN** the system raises a clear error
+
+### Requirement: Product registry
+
+The system SHALL provide a `Product` record type and a registry mechanism, and
+SHALL register **zero** concrete Products in this foundation. A Product SHALL NOT
+be bound to a single template family; the `(product, family)` pair locates
+templates.
+
+#### Scenario: Registry mechanism present, no products registered
+
+- **WHEN** the foundation is loaded
+- **THEN** the Product registry exists and is empty, ready for product issues to
+  register their own records
+
+### Requirement: Missing template combinations fail lazily
+
+The system SHALL NOT pre-validate the product-by-family matrix. A missing
+`(product, family)` template combination SHALL surface only when that combination
+is rendered.
+
+#### Scenario: Requesting an unauthored format
+
+- **WHEN** `render` is called for a `(product, family)` pair that has no template
+- **THEN** a `TemplateNotFound`-style error is raised at render time only
+
+### Requirement: Two Jinja environments
+
+The system SHALL provide two Jinja2 environments built by an injectable factory
+`make_environments(templates_root)` that defaults `templates_root` to
+`config.paths.templates` but accepts an override. The **Markdown** environment
+SHALL use stock delimiters and `autoescape=False`. The **LaTeX** environment SHALL
+use `\VAR{}` / `\BLOCK{}` delimiters, `autoescape=False`, with `trim_blocks` and
+`lstrip_blocks` enabled. Both SHALL load templates from `templates/<family>/` with
+entry template `<product>/main.<ext>.jinja`.
+
+#### Scenario: Markdown environment does not HTML-escape
+
+- **WHEN** a value containing HTML-special characters is interpolated by a
+  Markdown-family template
+- **THEN** the characters appear unescaped in the emitted Markdown text
+
+#### Scenario: LaTeX environment uses custom delimiters
+
+- **WHEN** a LaTeX-family template uses `\VAR{}` and `\BLOCK{}`
+- **THEN** they are interpreted as expression and statement delimiters and stock
+  `{{ }}` braces are left literal
+
+#### Scenario: Injected templates root
+
+- **WHEN** `make_environments` is called with an explicit `templates_root`
+- **THEN** the environments load templates from that root instead of the config
+  default
+
+### Requirement: Markdown-to-HTML derivation
+
+The system SHALL provide `md_to_html` that converts Markdown text to HTML using
+`markdown-it-py` with table support enabled, and wraps the result in a minimal
+standalone HTML5 document (doctype, `<meta charset>`, `<title>`, a small embedded
+default stylesheet).
+
+#### Scenario: Tables render
+
+- **WHEN** the Markdown input contains a GFM table
+- **THEN** the output contains an HTML `<table>`
+
+#### Scenario: Standalone document
+
+- **WHEN** `md_to_html` runs
+- **THEN** the output is a full HTML document with a doctype and charset, not a
+  bare fragment
+
+### Requirement: LaTeX-to-PDF derivation
+
+The system SHALL provide `latex_to_pdf` that compiles LaTeX to PDF using the
+engine named by `config.render.latex.engine`, running the engine twice in a
+temporary directory with `-interaction=nonstopmode -halt-on-error`, and copying
+only the resulting `.pdf` to the output path. No transient files SHALL touch the
+repository or the output tree.
+
+#### Scenario: Only the PDF survives
+
+- **WHEN** compilation succeeds
+- **THEN** only the `.pdf` is copied to the output path and the temporary
+  directory (with its `.aux`/`.log`) is removed
+
+#### Scenario: Engine binary missing
+
+- **WHEN** the configured engine binary is not on `PATH`
+- **THEN** a clear error names the missing tool and notes that only the `pdf`
+  Format requires it
+
+#### Scenario: Compilation fails
+
+- **WHEN** the engine exits non-zero
+- **THEN** an error is raised that includes the tail of the engine log
+
+### Requirement: Output path resolution and write behavior
+
+The system SHALL resolve the default output path as
+`output_root / product / f"{name}.{extension}"`, where `output_root` is an
+overridable argument defaulting to `config.paths.output`. An explicit `out`
+argument SHALL override the full file path. `render` SHALL create parent
+directories and overwrite any existing file silently.
+
+#### Scenario: Default path layout
+
+- **WHEN** `render` is called without `out`
+- **THEN** the file is written to `output_root/<product>/<name>.<ext>` with parent
+  directories created
+
+#### Scenario: Explicit out override
+
+- **WHEN** `render` is called with an explicit `out` file path
+- **THEN** the file is written exactly there, ignoring the default layout
+
+#### Scenario: Silent overwrite
+
+- **WHEN** the target file already exists
+- **THEN** it is overwritten without prompting
+
+### Requirement: Configuration additions
+
+The system SHALL add `paths.output` (default `{project_path}/output`) to the paths
+config and a nested `[render.latex].engine` setting (default `pdflatex`) exposed
+as `config.render.latex.engine`. The `output/` directory SHALL be gitignored.
+
+#### Scenario: Output path available
+
+- **WHEN** the configuration is loaded
+- **THEN** `config.paths.output` resolves to the configured output directory
+
+#### Scenario: Engine configurable
+
+- **WHEN** `config.render.latex.engine` is set to another engine name
+- **THEN** `latex_to_pdf` invokes that binary
+
+### Requirement: CLI render scaffold
+
+The system SHALL register an empty `spf render` command group wired like the
+existing `army`/`race`/`rules` groups, and provide a reusable `--format` /
+`--out` parameter set whose `--format` choices derive from the Format registry
+(default `pdf`). No product subcommand and no dummy command SHALL be added in this
+foundation.
+
+#### Scenario: Empty render group present
+
+- **WHEN** `spf render` is invoked with no subcommand
+- **THEN** help is shown and no product subcommands are listed
+
+#### Scenario: Format choices come from the registry
+
+- **WHEN** the `--format` option is offered
+- **THEN** its allowed values are exactly the registered Format names with `pdf`
+  as default
+
+### Requirement: Direct dependencies
+
+The system SHALL declare `jinja2` and `markdown-it-py` as direct project
+dependencies. `pdflatex`/`xelatex` SHALL remain an external system prerequisite,
+not a Python dependency.
+
+#### Scenario: Libraries are direct dependencies
+
+- **WHEN** the project dependencies are inspected
+- **THEN** `jinja2` and `markdown-it-py` appear as direct dependencies

--- a/v3/openspec/changes/archive/2026-07-08-render-foundation/tasks.md
+++ b/v3/openspec/changes/archive/2026-07-08-render-foundation/tasks.md
@@ -1,0 +1,57 @@
+## 1. Dependencies & config
+
+- [x] 1.1 Use `uv add` to promote `jinja2` and `markdown-it-py` to direct `[project.dependencies]` in `pyproject.toml`. Do not manually edit the file
+- [x] 1.2 Add `output = "{project_path}/output"` under `[paths]` in `configs/spf.toml`
+- [x] 1.3 Add `[render.latex]` with `engine = "pdflatex"` in `configs/spf.toml`
+- [x] 1.4 Add `output: Path` to `PathsConfig` in `src/spf/schemas/config.py`
+- [x] 1.5 Add `RenderConfig` → `LatexConfig(engine: str = "pdflatex")` and wire `render` onto `SteamPunkFantasyConfig`
+- [x] 1.6 Add `output/` to `.gitignore`
+
+## 2. Format & Product registries
+
+- [x] 2.1 Create `src/spf/render/__init__.py` exposing `render`, `Format`, `Product`
+- [x] 2.2 Implement `Format(name, extension, family, post_step)` record + `FORMATS` dict + register/lookup helper in `formats.py`
+- [x] 2.3 Register the four Formats (`markdown`, `html`→`md_to_html`, `latex`, `pdf`→`latex_to_pdf`) — leave post-steps as forward references until section 4
+- [x] 2.4 Implement `Product` record type + `PRODUCTS` dict + register/lookup helper in `products.py`; register zero concrete products
+
+## 3. Jinja environments
+
+- [x] 3.1 Implement `make_environments(templates_root=config.paths.templates)` in `environments.py` returning `{family: Environment}`
+- [x] 3.2 Configure the Markdown env: stock delimiters, `autoescape=False`, `FileSystemLoader` rooted at `templates/markdown/`
+- [x] 3.3 Configure the LaTeX env: `\VAR{}`/`\BLOCK{}` delimiters, `autoescape=False`, `trim_blocks` + `lstrip_blocks`, loader rooted at `templates/latex/`
+- [x] 3.4 Create empty `templates/markdown/` and `templates/latex/` subtrees (leave legacy `templates/*.tex` untouched)
+
+## 4. Derivations
+
+- [x] 4.1 Implement `md_to_html` in `derivations.py`: `markdown-it-py` with tables enabled, wrapping output in a minimal standalone HTML5 document
+- [x] 4.2 Implement `latex_to_pdf`: compile in a `tempfile.TemporaryDirectory()` with the configured engine, `-interaction=nonstopmode -halt-on-error`, run twice, copy only the `.pdf`
+- [x] 4.3 Add missing-binary handling (clear error naming the tool, noting only `pdf` needs it)
+- [x] 4.4 Add non-zero-exit handling (raise with the tail of the engine log)
+- [x] 4.5 Wire the two post-steps into the Format registry from section 2
+
+## 5. Render pipeline
+
+- [x] 5.1 Implement `render(product, source, fmt, *, name, out=None, templates_root=None, output_root=None) -> Path` in `pipeline.py`
+- [x] 5.2 Resolve the environment by `fmt.family`, load `<product>/main.<ext>.jinja`, render the source under a fixed variable
+- [x] 5.3 Apply `fmt.post_step` when present; otherwise use the rendered text directly
+- [x] 5.4 Resolve the output path (`output_root/<product>/<name>.<ext>` or explicit `out`), `mkdir(parents=True, exist_ok=True)`, write with silent overwrite, return the path
+
+## 6. CLI scaffold
+
+- [x] 6.1 Register an empty `spf render` cyclopts sub-App in `cli/main.py`, wired like `army`/`race`/`rules`
+- [x] 6.2 Add `cli/render.py` with an `add_commands(app)` hook and a reusable `RenderOpts(format, out)` parameter set
+- [x] 6.3 Derive `--format` choices from the Format registry with `pdf` as default
+
+## 7. Tests
+
+- [x] 7.1 Unit-test both environments: Markdown non-escaping, LaTeX `\VAR{}`/`\BLOCK{}` delimiters, injected `templates_root`
+- [x] 7.2 Unit-test `md_to_html`: table renders, output is a standalone document
+- [x] 7.3 Unit-test `latex_to_pdf` behavior (missing-binary error; compile-failure log tail) with `skipif` where the engine is required
+- [x] 7.4 Add fixture templates under `tests/fixtures/templates/<family>/_test/main.*.jinja` and a fake source
+- [x] 7.5 End-to-end `render()` test through markdown and latex asserting the file lands at the expected `output/...` path
+- [x] 7.6 PDF end-to-end test gated by `@pytest.mark.skipif(shutil.which(engine) is None)`; assert non-empty `.pdf` and temp-dir cleanup
+- [x] 7.7 Test that `config.paths.output` and `config.render.latex.engine` resolve
+
+## 8. Quality gates
+
+- [x] 8.1 Run `just check` (format, lint, type-check, spell-check) and the test suite; fix any failures

--- a/v3/openspec/specs/render-foundation/spec.md
+++ b/v3/openspec/specs/render-foundation/spec.md
@@ -1,0 +1,216 @@
+# Spec: Render Foundation
+
+## Purpose
+
+Provides the shared rendering subsystem that turns a resolved data object (the
+source) into a file in one of several Formats. It sits below the CLI and above the
+data layer, exposing one generic `render()` seam driven by data records — the
+Format and Product registries, two Jinja environments, and two derivations
+(Markdown→HTML, LaTeX→PDF) — so each gameplay-reference Product plugs in by
+contributing templates only.
+
+## Requirements
+
+### Requirement: Render seam
+
+The system SHALL expose a single entry point
+`render(product, source, fmt, *, name, out=None) -> Path` that renders exactly
+one source object to exactly one file and returns the written path. It SHALL be a
+generic pipeline parameterized by the Format and Product records — it MUST NOT
+contain per-product or per-format branching code.
+
+#### Scenario: Render one source to one file
+
+- **WHEN** `render` is called with a registered Product, a source object, a
+  registered Format, and a `name`
+- **THEN** the source is rendered through the Format's family environment and the
+  written file path is returned
+
+#### Scenario: Source passed to a dumb template
+
+- **WHEN** a template is rendered
+- **THEN** the resolved source object is passed in whole under a fixed variable
+  and the template performs no lookups or computation
+
+### Requirement: Format registry
+
+The system SHALL provide a `Format(name, extension, family, post_step)` record and
+register exactly four Formats: `markdown` (ext `md`, family `markdown`, no
+post-step), `html` (ext `html`, family `markdown`, post-step `md_to_html`),
+`latex` (ext `tex`, family `latex`, no post-step), and `pdf` (ext `pdf`, family
+`latex`, post-step `latex_to_pdf`). Formats SHALL be looked up by name.
+
+#### Scenario: Look up a registered Format
+
+- **WHEN** a Format is requested by one of the four names
+- **THEN** its extension, family, and optional post-step are returned
+
+#### Scenario: Unknown Format name
+
+- **WHEN** a Format is requested by a name that is not registered
+- **THEN** the system raises a clear error
+
+### Requirement: Product registry
+
+The system SHALL provide a `Product` record type and a registry mechanism, and
+SHALL register **zero** concrete Products in this foundation. A Product SHALL NOT
+be bound to a single template family; the `(product, family)` pair locates
+templates.
+
+#### Scenario: Registry mechanism present, no products registered
+
+- **WHEN** the foundation is loaded
+- **THEN** the Product registry exists and is empty, ready for product issues to
+  register their own records
+
+### Requirement: Missing template combinations fail lazily
+
+The system SHALL NOT pre-validate the product-by-family matrix. A missing
+`(product, family)` template combination SHALL surface only when that combination
+is rendered.
+
+#### Scenario: Requesting an unauthored format
+
+- **WHEN** `render` is called for a `(product, family)` pair that has no template
+- **THEN** a `TemplateNotFound`-style error is raised at render time only
+
+### Requirement: Two Jinja environments
+
+The system SHALL provide two Jinja2 environments built by an injectable factory
+`make_environments(templates_root)` that defaults `templates_root` to
+`config.paths.templates` but accepts an override. The **Markdown** environment
+SHALL use stock delimiters and `autoescape=False`. The **LaTeX** environment SHALL
+use `\VAR{}` / `\BLOCK{}` delimiters, `autoescape=False`, with `trim_blocks` and
+`lstrip_blocks` enabled. Both SHALL load templates from `templates/<family>/` with
+entry template `<product>/main.<ext>.jinja`.
+
+#### Scenario: Markdown environment does not HTML-escape
+
+- **WHEN** a value containing HTML-special characters is interpolated by a
+  Markdown-family template
+- **THEN** the characters appear unescaped in the emitted Markdown text
+
+#### Scenario: LaTeX environment uses custom delimiters
+
+- **WHEN** a LaTeX-family template uses `\VAR{}` and `\BLOCK{}`
+- **THEN** they are interpreted as expression and statement delimiters and stock
+  `{{ }}` braces are left literal
+
+#### Scenario: Injected templates root
+
+- **WHEN** `make_environments` is called with an explicit `templates_root`
+- **THEN** the environments load templates from that root instead of the config
+  default
+
+### Requirement: Markdown-to-HTML derivation
+
+The system SHALL provide `md_to_html` that converts Markdown text to HTML using
+`markdown-it-py` with table support enabled, and wraps the result in a minimal
+standalone HTML5 document (doctype, `<meta charset>`, `<title>`, a small embedded
+default stylesheet).
+
+#### Scenario: Tables render
+
+- **WHEN** the Markdown input contains a GFM table
+- **THEN** the output contains an HTML `<table>`
+
+#### Scenario: Standalone document
+
+- **WHEN** `md_to_html` runs
+- **THEN** the output is a full HTML document with a doctype and charset, not a
+  bare fragment
+
+### Requirement: LaTeX-to-PDF derivation
+
+The system SHALL provide `latex_to_pdf` that compiles LaTeX to PDF using the
+engine named by `config.render.latex.engine`, running the engine twice in a
+temporary directory with `-interaction=nonstopmode -halt-on-error`, and copying
+only the resulting `.pdf` to the output path. No transient files SHALL touch the
+repository or the output tree.
+
+#### Scenario: Only the PDF survives
+
+- **WHEN** compilation succeeds
+- **THEN** only the `.pdf` is copied to the output path and the temporary
+  directory (with its `.aux`/`.log`) is removed
+
+#### Scenario: Engine binary missing
+
+- **WHEN** the configured engine binary is not on `PATH`
+- **THEN** a clear error names the missing tool and notes that only the `pdf`
+  Format requires it
+
+#### Scenario: Compilation fails
+
+- **WHEN** the engine exits non-zero
+- **THEN** an error is raised that includes the tail of the engine log
+
+### Requirement: Output path resolution and write behavior
+
+The system SHALL resolve the default output path as
+`output_root / product / f"{name}.{extension}"`, where `output_root` is an
+overridable argument defaulting to `config.paths.output`. An explicit `out`
+argument SHALL override the full file path. `render` SHALL create parent
+directories and overwrite any existing file silently.
+
+#### Scenario: Default path layout
+
+- **WHEN** `render` is called without `out`
+- **THEN** the file is written to `output_root/<product>/<name>.<ext>` with parent
+  directories created
+
+#### Scenario: Explicit out override
+
+- **WHEN** `render` is called with an explicit `out` file path
+- **THEN** the file is written exactly there, ignoring the default layout
+
+#### Scenario: Silent overwrite
+
+- **WHEN** the target file already exists
+- **THEN** it is overwritten without prompting
+
+### Requirement: Configuration additions
+
+The system SHALL add `paths.output` (default `{project_path}/output`) to the paths
+config and a nested `[render.latex].engine` setting (default `pdflatex`) exposed
+as `config.render.latex.engine`. The `output/` directory SHALL be gitignored.
+
+#### Scenario: Output path available
+
+- **WHEN** the configuration is loaded
+- **THEN** `config.paths.output` resolves to the configured output directory
+
+#### Scenario: Engine configurable
+
+- **WHEN** `config.render.latex.engine` is set to another engine name
+- **THEN** `latex_to_pdf` invokes that binary
+
+### Requirement: CLI render scaffold
+
+The system SHALL register an empty `spf render` command group wired like the
+existing `army`/`race`/`rules` groups, and provide a reusable `--format` /
+`--out` parameter set whose `--format` choices derive from the Format registry
+(default `pdf`). No product subcommand and no dummy command SHALL be added in this
+foundation.
+
+#### Scenario: Empty render group present
+
+- **WHEN** `spf render` is invoked with no subcommand
+- **THEN** help is shown and no product subcommands are listed
+
+#### Scenario: Format choices come from the registry
+
+- **WHEN** the `--format` option is offered
+- **THEN** its allowed values are exactly the registered Format names with `pdf`
+  as default
+
+### Requirement: Direct dependencies
+
+The system SHALL declare `jinja2` and `markdown-it-py` as direct project
+dependencies. `pdflatex`/`xelatex` SHALL remain an external system prerequisite,
+not a Python dependency.
+
+#### Scenario: Libraries are direct dependencies
+
+- **WHEN** the project dependencies are inspected
+- **THEN** `jinja2` and `markdown-it-py` appear as direct dependencies

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -15,6 +15,8 @@ requires-python = ">=3.12"
 dependencies = [
     "configaroo>=0.6.1",
     "cyclopts>=4.10.1",
+    "jinja2>=3.1.6",
+    "markdown-it-py>=4.2.0",
     "pydantic>=2.12.5",
     "rich>=13",
     "streamlit>=1.57.0",

--- a/v3/src/spf/frontends/cli/__init__.py
+++ b/v3/src/spf/frontends/cli/__init__.py
@@ -1,6 +1,6 @@
 """Command line interface for SteamPunkFantasy."""
 
-from spf.frontends.cli import army, race, rules, special
+from spf.frontends.cli import army, race, render, rules, special
 from spf.frontends.cli.main import app
 
-__all__ = ["app", "army", "race", "rules", "special"]
+__all__ = ["app", "army", "race", "render", "rules", "special"]

--- a/v3/src/spf/frontends/cli/main.py
+++ b/v3/src/spf/frontends/cli/main.py
@@ -19,6 +19,8 @@ race_app = app.command(cyclopts.App(name="race", help="Work with a specific race
 cli.race.add_commands(race_app)
 rules_app = app.command(cyclopts.App(name="rules", help="Work with rules."))
 cli.rules.add_commands(rules_app)
+render_app = app.command(cyclopts.App(name="render", help="Render products to files."))
+cli.render.add_commands(render_app)
 special_app = app.command(cyclopts.App(name="special", help="Work with special rules."))
 cli.special.add_commands(special_app)
 

--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -1,0 +1,49 @@
+"""Render commands for the SteamPunkFantasy CLI.
+
+This foundation registers the empty ``spf render`` group and provides the
+reusable ``RenderOpts`` parameter set that product subcommands will accept. No
+product subcommand is added here — those land in the product issues.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+
+from spf.render.formats import FORMATS
+
+DEFAULT_FORMAT = "pdf"
+
+
+def _validate_format(_type: type, value: str) -> None:
+    """Reject a ``--format`` value not registered in the Format registry."""
+    if value not in FORMATS:
+        known = ", ".join(FORMATS)
+        msg = f"Unknown format {value!r}; choose from: {known}"
+        raise ValueError(msg)
+
+
+@dataclass
+class RenderOpts:
+    """Reusable options for render subcommands."""
+
+    format: Annotated[
+        str,
+        cyclopts.Parameter(
+            validator=_validate_format,
+            help="Output format (one of the registered Formats).",
+        ),
+    ] = DEFAULT_FORMAT
+    out: Annotated[
+        Path | None,
+        cyclopts.Parameter(help="Explicit output path, overriding the default layout."),
+    ] = None
+
+
+def add_commands(app: cyclopts.App) -> None:
+    """Add render commands to the CLI.
+
+    No product subcommands exist in the foundation; each product issue registers
+    its own here.
+    """

--- a/v3/src/spf/render/__init__.py
+++ b/v3/src/spf/render/__init__.py
@@ -1,0 +1,13 @@
+"""The shared rendering subsystem for SteamPunkFantasy.
+
+Turns a resolved data object (the source) into a file in one of several Formats,
+driven by data records rather than per-product or per-format code. The single
+seam is :func:`render`; :class:`Format` and :class:`Product` are the record types
+product issues plug into.
+"""
+
+from spf.render.formats import Format
+from spf.render.pipeline import render
+from spf.render.products import Product
+
+__all__ = ["Format", "Product", "render"]

--- a/v3/src/spf/render/derivations.py
+++ b/v3/src/spf/render/derivations.py
@@ -1,0 +1,101 @@
+"""Format derivations: post-render steps that transform rendered text.
+
+A derivation takes the text produced by a template and turns it into the final
+content for its Format: Markdown into a standalone HTML document, or LaTeX into a
+compiled PDF. Each formatting rule lives here in exactly one place.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+
+from spf.config import config
+
+_LOG_TAIL_LINES = 30
+
+_HTML_DOCUMENT = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SteamPunkFantasy</title>
+<style>
+body {{ font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 48rem; }}
+table {{ border-collapse: collapse; }}
+th, td {{ border: 1px solid #ccc; padding: 0.25rem 0.5rem; }}
+</style>
+</head>
+<body>
+{body}</body>
+</html>
+"""
+
+
+class RenderError(Exception):
+    """Raised when a derivation cannot produce its output."""
+
+
+def md_to_html(text: str) -> str:
+    """Convert Markdown text into a standalone HTML5 document.
+
+    Tables are enabled and the rendered fragment is wrapped in a minimal
+    document (doctype, charset, title, embedded stylesheet) so the ``.html`` is
+    double-clickable.
+    """
+    markdown = MarkdownIt("commonmark").enable("table")
+    body = markdown.render(text)
+    return _HTML_DOCUMENT.format(body=body)
+
+
+def latex_to_pdf(text: str) -> bytes:
+    """Compile LaTeX text to PDF and return the PDF bytes.
+
+    Compilation runs the configured engine twice in a temporary directory with
+    ``-interaction=nonstopmode -halt-on-error`` so cross-references and page
+    numbers stabilize. Only the resulting ``.pdf`` is read back out; every
+    transient file stays inside the temporary directory.
+    """
+    engine = config.render.latex.engine
+    if shutil.which(engine) is None:
+        msg = (
+            f"LaTeX engine {engine!r} was not found on PATH. "
+            "Only the 'pdf' format requires it; install a LaTeX distribution "
+            "or configure another engine under [render.latex]."
+        )
+        raise RenderError(msg)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "main.tex").write_text(text, encoding="utf-8")
+        for _ in range(2):
+            result = subprocess.run(  # noqa: S603
+                [
+                    engine,
+                    "-interaction=nonstopmode",
+                    "-halt-on-error",
+                    "main.tex",
+                ],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                raise RenderError(_compile_error(engine, tmp_path, result.stdout))
+        return (tmp_path / "main.pdf").read_bytes()
+
+
+def _compile_error(engine: str, tmp_path: Path, stdout: str) -> str:
+    """Build a compile-failure message ending with the tail of the engine log."""
+    log_path = tmp_path / "main.log"
+    log = (
+        log_path.read_text(encoding="utf-8", errors="replace")
+        if log_path.exists()
+        else stdout
+    )
+    tail = "\n".join(log.splitlines()[-_LOG_TAIL_LINES:])
+    return f"{engine} failed to compile the document:\n{tail}"

--- a/v3/src/spf/render/environments.py
+++ b/v3/src/spf/render/environments.py
@@ -1,0 +1,43 @@
+r"""Jinja2 environments, one per template family.
+
+The Markdown environment uses stock delimiters; the LaTeX environment uses
+``\\VAR{}`` / ``\\BLOCK{}`` so template markup does not clash with LaTeX's own
+braces. Neither environment HTML-escapes: Markdown templates emit Markdown (any
+escaping happens later in :func:`spf.render.derivations.md_to_html`) and LaTeX
+templates emit LaTeX. The factory takes an injectable ``templates_root`` so tests
+can point it at fixture templates.
+"""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from spf.config import config
+from spf.render.formats import Family
+
+
+def make_environments(templates_root: Path | None = None) -> dict[Family, Environment]:
+    """Build the per-family Jinja2 environments.
+
+    ``templates_root`` defaults to ``config.paths.templates`` but may be
+    overridden. Each family loads from ``templates_root/<family>/``.
+    """
+    root = templates_root if templates_root is not None else config.paths.templates
+    return {
+        "markdown": Environment(
+            loader=FileSystemLoader(root / "markdown"),
+            autoescape=False,  # noqa: S701  templates emit Markdown/LaTeX, not HTML (ADR 0005)
+            keep_trailing_newline=True,
+        ),
+        "latex": Environment(
+            loader=FileSystemLoader(root / "latex"),
+            variable_start_string=r"\VAR{",
+            variable_end_string="}",
+            block_start_string=r"\BLOCK{",
+            block_end_string="}",
+            autoescape=False,  # noqa: S701  templates emit Markdown/LaTeX, not HTML (ADR 0005)
+            trim_blocks=True,
+            lstrip_blocks=True,
+            keep_trailing_newline=True,
+        ),
+    }

--- a/v3/src/spf/render/formats.py
+++ b/v3/src/spf/render/formats.py
@@ -1,0 +1,61 @@
+"""The Format registry.
+
+A :class:`Format` is a target output shape: a file extension, the template
+*family* it renders from, and an optional post-step (a derivation) that turns the
+rendered text into the final content. Formats are plain records registered in a
+module-level dict at import time and looked up by name.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from spf.render.derivations import latex_to_pdf, md_to_html
+
+type Family = Literal["markdown", "latex"]
+type PostStep = Callable[[str], str | bytes]
+
+# The authored-template extension for each family. A Format renders from its
+# family's source template (`main.<ext>.jinja`); its own `extension` names only
+# the output file. So `html` and `pdf` render from `main.md.jinja` /
+# `main.tex.jinja` respectively.
+FAMILY_TEMPLATE_EXT: dict[Family, str] = {"markdown": "md", "latex": "tex"}
+
+
+@dataclass(frozen=True)
+class Format:
+    """A registered output format."""
+
+    name: str
+    extension: str
+    family: Family
+    post_step: PostStep | None = None
+
+
+FORMATS: dict[str, Format] = {}
+
+
+def register_format(fmt: Format) -> Format:
+    """Register a Format under its name and return it."""
+    FORMATS[fmt.name] = fmt
+    return fmt
+
+
+def get_format(name: str) -> Format:
+    """Look up a registered Format by name."""
+    try:
+        return FORMATS[name]
+    except KeyError:
+        known = ", ".join(FORMATS) or "(none registered)"
+        msg = f"Unknown format {name!r}; known formats: {known}"
+        raise ValueError(msg) from None
+
+
+register_format(Format(name="markdown", extension="md", family="markdown"))
+register_format(
+    Format(name="html", extension="html", family="markdown", post_step=md_to_html)
+)
+register_format(Format(name="latex", extension="tex", family="latex"))
+register_format(
+    Format(name="pdf", extension="pdf", family="latex", post_step=latex_to_pdf)
+)

--- a/v3/src/spf/render/pipeline.py
+++ b/v3/src/spf/render/pipeline.py
@@ -1,0 +1,59 @@
+"""The render seam: one generic pipeline for every Product and Format.
+
+``render`` looks up the family environment for the Format, loads the Product's
+``main.<ext>.jinja`` template, renders the whole source object into it, applies
+the Format's post-step if any, and writes exactly one file. It contains no
+per-product or per-format branching — behavior comes entirely from the Format and
+Product records.
+"""
+
+from pathlib import Path
+
+from spf.config import config
+from spf.render.environments import make_environments
+from spf.render.formats import FAMILY_TEMPLATE_EXT, Format
+from spf.render.products import Product
+
+# The fixed variable name the source object is bound to inside every template.
+SOURCE_VAR = "source"
+
+
+def render(  # noqa: PLR0913  the seam's parameters are fixed by the render-foundation spec
+    product: Product,
+    source: object,
+    fmt: Format,
+    *,
+    name: str,
+    out: Path | None = None,
+    templates_root: Path | None = None,
+    output_root: Path | None = None,
+) -> Path:
+    """Render one ``source`` to one file and return the written path.
+
+    The template ``<product>/main.<ext>.jinja`` from the Format's family is
+    rendered with ``source`` bound to :data:`SOURCE_VAR`. A missing template for
+    the requested ``(product, family)`` pair surfaces as Jinja's
+    ``TemplateNotFound`` here, at render time only. The Format's post-step, when
+    present, produces the final content; otherwise the rendered text is written
+    directly. The output path is ``out`` when given, else
+    ``output_root/<product>/<name>.<ext>``. Parent directories are created and any
+    existing file is overwritten silently.
+    """
+    environments = make_environments(templates_root)
+    template_ext = FAMILY_TEMPLATE_EXT[fmt.family]
+    template = environments[fmt.family].get_template(
+        f"{product.name}/main.{template_ext}.jinja"
+    )
+    rendered = template.render({SOURCE_VAR: source})
+    content = fmt.post_step(rendered) if fmt.post_step is not None else rendered
+
+    if out is None:
+        root = output_root if output_root is not None else config.paths.output
+        out = root / product.name / f"{name}.{fmt.extension}"
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        out.write_bytes(content)
+    else:
+        out.write_text(content, encoding="utf-8")
+    return out

--- a/v3/src/spf/render/products.py
+++ b/v3/src/spf/render/products.py
@@ -1,0 +1,39 @@
+"""The Product registry.
+
+A :class:`Product` is a kind of Rendering (Order Card, Army Reference, ...). Its
+``name`` locates templates as ``<family>/<name>/main.<ext>.jinja`` and names the
+output subdirectory. A Product is *not* bound to a single family — the
+``(product, family)`` pair locates a template, so the same Product can reach both
+HTML (via the markdown family) and PDF (via the latex family).
+
+This foundation ships the record type and the registry mechanism only. **Zero**
+concrete Products are registered here; each product issue registers its own.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Product:
+    """A registered kind of Rendering."""
+
+    name: str
+
+
+PRODUCTS: dict[str, Product] = {}
+
+
+def register_product(product: Product) -> Product:
+    """Register a Product under its name and return it."""
+    PRODUCTS[product.name] = product
+    return product
+
+
+def get_product(name: str) -> Product:
+    """Look up a registered Product by name."""
+    try:
+        return PRODUCTS[name]
+    except KeyError:
+        known = ", ".join(PRODUCTS) or "(none registered)"
+        msg = f"Unknown product {name!r}; known products: {known}"
+        raise ValueError(msg) from None

--- a/v3/src/spf/schemas/config.py
+++ b/v3/src/spf/schemas/config.py
@@ -11,7 +11,17 @@ class PathsConfig(StrictModel):
     races: Path
     rules: Path
     templates: Path
+    output: Path
+
+
+class LatexConfig(StrictModel):
+    engine: str = "pdflatex"
+
+
+class RenderConfig(StrictModel):
+    latex: LatexConfig = LatexConfig()
 
 
 class SteamPunkFantasyConfig(StrictModel):
     paths: PathsConfig
+    render: RenderConfig = RenderConfig()

--- a/v3/tests/fixtures/templates/latex/_test/main.tex.jinja
+++ b/v3/tests/fixtures/templates/latex/_test/main.tex.jinja
@@ -1,0 +1,9 @@
+\documentclass{article}
+\begin{document}
+\section*{\VAR{source.title}}
+\begin{itemize}
+\BLOCK{ for key, value in source.rows }
+\item \VAR{key}: \VAR{value}
+\BLOCK{ endfor }
+\end{itemize}
+\end{document}

--- a/v3/tests/fixtures/templates/markdown/_test/main.md.jinja
+++ b/v3/tests/fixtures/templates/markdown/_test/main.md.jinja
@@ -1,0 +1,9 @@
+# {{ source.title }}
+
+{{ source.note }}
+
+| Name | Value |
+| ---- | ----- |
+{% for key, value in source.rows -%}
+| {{ key }} | {{ value }} |
+{% endfor -%}

--- a/v3/tests/render/__init__.py
+++ b/v3/tests/render/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spf.render subsystem."""

--- a/v3/tests/render/test_render.py
+++ b/v3/tests/render/test_render.py
@@ -1,0 +1,242 @@
+"""Tests for the spf.render foundation."""
+
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from jinja2 import TemplateNotFound
+
+from spf.config import config
+from spf.frontends.cli.render import DEFAULT_FORMAT, RenderOpts
+from spf.render import Product, render
+from spf.render.derivations import RenderError, latex_to_pdf, md_to_html
+from spf.render.environments import make_environments
+from spf.render.formats import FORMATS, get_format
+from spf.render.products import PRODUCTS, get_product, register_product
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "templates"
+ENGINE = config.render.latex.engine
+
+
+@dataclass
+class FakeSource:
+    """A stand-in source object for exercising the pipeline."""
+
+    title: str = "Test Rendering"
+    note: str = "A & B < C"
+    rows: list[tuple[str, str]] = field(
+        default_factory=lambda: [("Speed", "fast"), ("Size", "Small")]
+    )
+
+
+# --- 7.1 Environments -------------------------------------------------------
+
+
+def test_markdown_environment_does_not_escape() -> None:
+    envs = make_environments(templates_root=FIXTURES)
+    result = envs["markdown"].from_string("{{ value }}").render(value="a & b <c>")
+    assert result == "a & b <c>"
+
+
+def test_latex_environment_custom_delimiters() -> None:
+    envs = make_environments(templates_root=FIXTURES)
+    template = envs["latex"].from_string(r"\VAR{x} then {{ y }}")
+    result = template.render(x=1, y=2)
+    assert result == "1 then {{ y }}"
+
+
+def test_latex_environment_block_delimiter() -> None:
+    envs = make_environments(templates_root=FIXTURES)
+    template = envs["latex"].from_string(
+        r"\BLOCK{ for n in nums }\VAR{n}\BLOCK{ endfor }"
+    )
+    assert template.render(nums=[1, 2, 3]) == "123"
+
+
+def test_injected_templates_root_loads_fixture() -> None:
+    envs = make_environments(templates_root=FIXTURES)
+    template = envs["markdown"].get_template("_test/main.md.jinja")
+    assert "Name" in template.render(source=FakeSource())
+
+
+# --- 7.2 md_to_html ---------------------------------------------------------
+
+
+def test_md_to_html_renders_table() -> None:
+    markdown = "| A | B |\n| - | - |\n| 1 | 2 |\n"
+    assert "<table>" in md_to_html(markdown)
+
+
+def test_md_to_html_is_standalone_document() -> None:
+    html = md_to_html("# Title\n")
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert 'charset="utf-8"' in html
+
+
+# --- 7.3 latex_to_pdf behavior ---------------------------------------------
+
+
+def test_latex_to_pdf_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.render.latex, "engine", "definitely-not-a-real-engine")
+    with pytest.raises(RenderError) as excinfo:
+        latex_to_pdf(r"\documentclass{article}\begin{document}x\end{document}")
+    message = str(excinfo.value)
+    assert "definitely-not-a-real-engine" in message
+    assert "pdf" in message
+
+
+@pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
+def test_latex_to_pdf_compile_failure_includes_log_tail() -> None:
+    with pytest.raises(RenderError) as excinfo:
+        latex_to_pdf(r"\documentclass{article}\begin{document}\undefinedmacro")
+    assert ENGINE in str(excinfo.value)
+
+
+# --- 7.5 End-to-end text formats -------------------------------------------
+
+
+@pytest.fixture
+def product() -> Product:
+    return Product(name="_test")
+
+
+def test_render_markdown_to_expected_path(tmp_path: Path, product: Product) -> None:
+    out = render(
+        product,
+        FakeSource(),
+        get_format("markdown"),
+        name="sample",
+        templates_root=FIXTURES,
+        output_root=tmp_path,
+    )
+    assert out == tmp_path / "_test" / "sample.md"
+    assert out.exists()
+    assert "Test Rendering" in out.read_text(encoding="utf-8")
+
+
+def test_render_latex_to_expected_path(tmp_path: Path, product: Product) -> None:
+    out = render(
+        product,
+        FakeSource(),
+        get_format("latex"),
+        name="sample",
+        templates_root=FIXTURES,
+        output_root=tmp_path,
+    )
+    assert out == tmp_path / "_test" / "sample.tex"
+    assert r"\section*{Test Rendering}" in out.read_text(encoding="utf-8")
+
+
+def test_render_explicit_out_overrides_layout(tmp_path: Path, product: Product) -> None:
+    target = tmp_path / "custom" / "file.md"
+    out = render(
+        product,
+        FakeSource(),
+        get_format("markdown"),
+        name="ignored",
+        out=target,
+        templates_root=FIXTURES,
+    )
+    assert out == target
+    assert target.exists()
+
+
+def test_render_silently_overwrites(tmp_path: Path, product: Product) -> None:
+    target = tmp_path / "file.md"
+    target.write_text("stale", encoding="utf-8")
+    render(
+        product,
+        FakeSource(),
+        get_format("markdown"),
+        name="ignored",
+        out=target,
+        templates_root=FIXTURES,
+    )
+    assert "stale" not in target.read_text(encoding="utf-8")
+
+
+def test_render_missing_template_fails_lazily(tmp_path: Path) -> None:
+    with pytest.raises(TemplateNotFound):
+        render(
+            Product(name="_absent"),
+            FakeSource(),
+            get_format("markdown"),
+            name="sample",
+            templates_root=FIXTURES,
+            output_root=tmp_path,
+        )
+
+
+# --- 7.6 PDF end-to-end (gated) --------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
+def test_render_pdf_end_to_end(
+    tmp_path: Path, product: Product, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[Path] = []
+    real_tempdir = tempfile.TemporaryDirectory
+
+    def tracking_tempdir() -> tempfile.TemporaryDirectory[str]:
+        temp = real_tempdir()
+        captured.append(Path(temp.name))
+        return temp
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", tracking_tempdir)
+
+    out = render(
+        product,
+        FakeSource(),
+        get_format("pdf"),
+        name="sample",
+        templates_root=FIXTURES,
+        output_root=tmp_path,
+    )
+    assert out == tmp_path / "_test" / "sample.pdf"
+    assert out.stat().st_size > 0
+    assert captured
+    assert not captured[0].exists()
+
+
+# --- Registries -------------------------------------------------------------
+
+
+def test_format_registry_has_four_formats() -> None:
+    assert set(FORMATS) == {"markdown", "html", "latex", "pdf"}
+    assert get_format("html").post_step is md_to_html
+    assert get_format("markdown").post_step is None
+
+
+def test_unknown_format_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown format"):
+        get_format("nope")
+
+
+def test_product_registry_starts_empty() -> None:
+    assert PRODUCTS == {}
+
+
+def test_product_registry_registers_and_looks_up() -> None:
+    try:
+        registered = register_product(Product(name="_probe"))
+        assert get_product("_probe") is registered
+    finally:
+        PRODUCTS.pop("_probe", None)
+
+
+# --- 7.7 Config resolves ----------------------------------------------------
+
+
+def test_config_output_and_engine_resolve() -> None:
+    assert isinstance(config.paths.output, Path)
+    assert config.paths.output.name == "output"
+    assert isinstance(config.render.latex.engine, str)
+    assert config.render.latex.engine
+
+
+def test_format_choices_derive_from_registry() -> None:
+    assert DEFAULT_FORMAT == "pdf"
+    assert RenderOpts().format == "pdf"
+    assert DEFAULT_FORMAT in FORMATS

--- a/v3/uv.lock
+++ b/v3/uv.lock
@@ -1257,6 +1257,8 @@ source = { editable = "." }
 dependencies = [
     { name = "configaroo" },
     { name = "cyclopts" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "streamlit" },
@@ -1276,6 +1278,8 @@ dev = [
 requires-dist = [
     { name = "configaroo", specifier = ">=0.6.1" },
     { name = "cyclopts", specifier = ">=4.10.1" },
+    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "rich", specifier = ">=13" },
     { name = "streamlit", specifier = ">=1.57.0" },


### PR DESCRIPTION
## Summary

Introduces the shared **render-foundation** subsystem (GitHub #17, child of #16; architecture per ADR 0005) — the machinery the four planned gameplay-reference products (Order Card, Army Reference, Race Overview, Rulebook) will build against. It turns a resolved source object into a file in one of four Formats through a single generic seam, driven by data records rather than per-product/per-format code.

## What's included

- **`src/spf/render/`** — the `render()` seam (`pipeline.py`), the `Format` and `Product` record types + registries, two Jinja environments (Markdown with stock delimiters; LaTeX with `\VAR{}`/`\BLOCK{}`, `trim_blocks`/`lstrip_blocks`), and two derivations: `md_to_html` (markdown-it-py → standalone HTML5) and `latex_to_pdf` (twice-compiled in a temp dir, returns PDF bytes).
- **Format registry** — four formats: `markdown`, `html` (→`md_to_html`), `latex`, `pdf` (→`latex_to_pdf`).
- **Product registry** — record type + mechanism only; **zero** products registered (each child issue adds its own).
- **Config** — `paths.output` (gitignored) and `[render.latex].engine` (default `pdflatex`); `PathsConfig.output`, `RenderConfig`/`LatexConfig`.
- **CLI** — empty `spf render` group wired like `army`/`race`/`rules`, plus a reusable `RenderOpts` (`--format`/`--out`) whose `--format` values derive from the Format registry (default `pdf`).
- **Dependencies** — `jinja2` and `markdown-it-py` promoted to direct deps.
- **Templates** — new `templates/{markdown,latex}/` subtrees; legacy top-level `.tex` files untouched.
- **Docs** — ADR 0005 records the Markdown `autoescape=False` decision.
- **OpenSpec** — `render-foundation` capability synced to `openspec/specs/`; change archived under `openspec/changes/archive/`.

## Non-goals

Product templates and their CLI subcommands (the four child issues), terminal/Rich output, `Race.resolve()`, multi-Unit/Army aggregation, and rich per-product HTML styling.

## Testing

- `just check` (format, lint, type-check, spell-check) passes.
- Full suite: **162 passed**, including a real (not skipped) PDF end-to-end since `pdflatex` is installed locally.
- PDF-dependent tests are gated with `@pytest.mark.skipif(shutil.which(engine) is None)` so CI without LaTeX stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)