### PR TITLE
Add assets foundation subsystem (spf/assets) (#23)

### DIFF
--- a/v3/.gitignore
+++ b/v3/.gitignore
@@ -4,3 +4,6 @@
 
 # Rendered output
 output/
+
+# Uncurated Asset candidates (Assets themselves are committed)
+candidates/

--- a/v3/configs/spf.toml
+++ b/v3/configs/spf.toml
@@ -5,6 +5,17 @@ races = "{project_path}/races"
 rules = "{project_path}/rules"
 templates = "{project_path}/templates"
 output = "{project_path}/output"
+candidates = "{project_path}/candidates"
+assets = "{project_path}/assets"
 
 [render.latex]
 engine = "pdflatex"
+
+[assets.lore]
+count = 1
+
+[assets.image]
+count = 3
+
+[assets.model]
+count = 2

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -57,3 +57,5 @@ ignore = [
 "src/spf/schemas/*.py" = ["D101"]
 "tests/**/test_*.py" = ["D103", "PLR2004", "S101", "SLF001", "UP018"]
 "tests/test_*.py" = ["D103", "PLR2004", "S101", "SLF001", "UP018"]
+# Test doubles legitimately carry unused protocol args (ARG002).
+"tests/**/conftest.py" = ["ARG002"]

--- a/v3/src/spf/assets/__init__.py
+++ b/v3/src/spf/assets/__init__.py
@@ -1,0 +1,21 @@
+"""The shared Asset generation subsystem for SteamPunkFantasy.
+
+Turns a source object into curated, committed Assets in three steps: **generate**
+Candidates under ``candidates/``, a human reviews them, then **promote** exactly
+one into the committed store under ``assets/``. Behavior is driven by data
+records (:class:`Kind`, :class:`Service`) rather than per-kind code. The seams are
+:func:`generate` and :func:`promote`; concrete kinds plug in via
+:func:`register_kind`.
+"""
+
+from spf.assets.kinds import Kind, Service, get_kind, register_kind
+from spf.assets.spine import generate, promote
+
+__all__ = [
+    "Kind",
+    "Service",
+    "generate",
+    "get_kind",
+    "promote",
+    "register_kind",
+]

--- a/v3/src/spf/assets/kinds.py
+++ b/v3/src/spf/assets/kinds.py
@@ -17,7 +17,7 @@ from typing import Protocol
 class Service(Protocol):
     """Generates the raw content for a Kind's Candidates."""
 
-    def generate(self, source: object, count: int) -> Sequence[bytes | str]:
+    def generate(self, source: str, count: int) -> Sequence[bytes | str]:
         """Return ``count`` generated values (text or binary) for ``source``."""
         ...
 

--- a/v3/src/spf/assets/kinds.py
+++ b/v3/src/spf/assets/kinds.py
@@ -1,0 +1,51 @@
+"""The Kind record and its registry.
+
+A :class:`Kind` is a kind of Asset (Lore, Image, Model). It owns the
+:class:`Service` that generates its Candidates and declares, declaratively, how
+its files are laid out under a race: ``<race>/[<subdir>/]<name>.<extension>``.
+
+This foundation ships the record type, the :class:`Service` protocol, and the
+registry mechanism only. **Zero** concrete kinds are registered here; each kind
+issue registers its own.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Service(Protocol):
+    """Generates the raw content for a Kind's Candidates."""
+
+    def generate(self, source: object, count: int) -> Sequence[bytes | str]:
+        """Return ``count`` generated values (text or binary) for ``source``."""
+        ...
+
+
+@dataclass(frozen=True)
+class Kind:
+    """A registered kind of Asset."""
+
+    name: str
+    service: Service
+    subdir: str | None
+    extension: str
+
+
+KINDS: dict[str, Kind] = {}
+
+
+def register_kind(kind: Kind) -> Kind:
+    """Register a Kind under its name and return it."""
+    KINDS[kind.name] = kind
+    return kind
+
+
+def get_kind(name: str) -> Kind:
+    """Look up a registered Kind by name."""
+    try:
+        return KINDS[name]
+    except KeyError:
+        known = ", ".join(KINDS) or "(none registered)"
+        msg = f"Unknown kind {name!r}; known kinds: {known}"
+        raise ValueError(msg) from None

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -1,0 +1,82 @@
+"""The assets seams: generate Candidates, then promote one into the store.
+
+Both functions are kind-agnostic — behavior comes entirely from the :class:`Kind`
+record. A Kind's layout is ``<race>/[<subdir>/]<name>.<extension>``; Candidates
+insert a 1-based ``.<index>`` before the extension so the same layout addresses
+both stores.
+"""
+
+import shutil
+from pathlib import Path
+
+from spf.assets.kinds import Kind
+from spf.config import config
+
+
+def _asset_dir(root: Path, kind: Kind, race: str) -> Path:
+    """Return the directory a Kind's files live in under ``root`` for ``race``."""
+    directory = root / race
+    if kind.subdir is not None:
+        directory = directory / kind.subdir
+    return directory
+
+
+def generate(  # noqa: PLR0913  the seam's parameters are fixed by the assets-foundation spec
+    kind: Kind,
+    source: object,
+    *,
+    race: str,
+    name: str,
+    count: int,
+    candidates_root: Path | None = None,
+) -> list[Path]:
+    """Generate ``count`` Candidates for ``source`` and write them to disk.
+
+    Each generated value is written to
+    ``candidates_root/<race>/[<subdir>/]<name>.<index>.<extension>`` with a
+    1-based index, inferring text-vs-binary mode from the value's type. Existing
+    candidate files are overwritten silently. Returns the written paths in order.
+    """
+    root = candidates_root if candidates_root is not None else config.paths.candidates
+    directory = _asset_dir(root, kind, race)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    paths: list[Path] = []
+    for index, value in enumerate(kind.service.generate(source, count), start=1):
+        path = directory / f"{name}.{index}.{kind.extension}"
+        if isinstance(value, bytes):
+            path.write_bytes(value)
+        else:
+            path.write_text(value, encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def promote(  # noqa: PLR0913  the seam's parameters are fixed by the assets-foundation spec
+    kind: Kind,
+    *,
+    race: str,
+    name: str,
+    pick: int,
+    candidates_root: Path | None = None,
+    assets_root: Path | None = None,
+) -> Path:
+    """Promote the picked Candidate into the committed Asset store.
+
+    Copies ``<race>/[<subdir>/]<name>.<pick>.<extension>`` from the candidates
+    store to ``<race>/[<subdir>/]<name>.<extension>`` in the assets store,
+    bytes-for-bytes. ``pick`` is 1-based. An existing Asset is overwritten
+    silently. Raises :class:`ValueError` when the picked Candidate is missing.
+    """
+    c_root = candidates_root if candidates_root is not None else config.paths.candidates
+    a_root = assets_root if assets_root is not None else config.paths.assets
+
+    candidate = _asset_dir(c_root, kind, race) / f"{name}.{pick}.{kind.extension}"
+    if not candidate.is_file():
+        msg = f"No candidate to promote at {candidate} (pick {pick})"
+        raise ValueError(msg)
+
+    asset = _asset_dir(a_root, kind, race) / f"{name}.{kind.extension}"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(candidate, asset)
+    return asset

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -23,12 +23,12 @@ def _asset_dir(root: Path, kind: Kind, race: str) -> Path:
 
 def generate(  # noqa: PLR0913  the seam's parameters are fixed by the assets-foundation spec
     kind: Kind,
-    source: object,
+    source: str,
     *,
     race: str,
     name: str,
     count: int,
-    candidates_root: Path | None = None,
+    candidates_root: Path = config.paths.candidates,
 ) -> list[Path]:
     """Generate ``count`` Candidates for ``source`` and write them to disk.
 
@@ -37,8 +37,7 @@ def generate(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fo
     1-based index, inferring text-vs-binary mode from the value's type. Existing
     candidate files are overwritten silently. Returns the written paths in order.
     """
-    root = candidates_root if candidates_root is not None else config.paths.candidates
-    directory = _asset_dir(root, kind, race)
+    directory = _asset_dir(candidates_root, kind, race)
     directory.mkdir(parents=True, exist_ok=True)
 
     paths: list[Path] = []
@@ -58,8 +57,8 @@ def promote(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fou
     race: str,
     name: str,
     pick: int,
-    candidates_root: Path | None = None,
-    assets_root: Path | None = None,
+    candidates_root: Path = config.paths.candidates,
+    assets_root: Path = config.paths.assets,
 ) -> Path:
     """Promote the picked Candidate into the committed Asset store.
 
@@ -68,15 +67,14 @@ def promote(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fou
     bytes-for-bytes. ``pick`` is 1-based. An existing Asset is overwritten
     silently. Raises :class:`ValueError` when the picked Candidate is missing.
     """
-    c_root = candidates_root if candidates_root is not None else config.paths.candidates
-    a_root = assets_root if assets_root is not None else config.paths.assets
-
-    candidate = _asset_dir(c_root, kind, race) / f"{name}.{pick}.{kind.extension}"
+    candidate = (
+        _asset_dir(candidates_root, kind, race) / f"{name}.{pick}.{kind.extension}"
+    )
     if not candidate.is_file():
         msg = f"No candidate to promote at {candidate} (pick {pick})"
         raise ValueError(msg)
 
-    asset = _asset_dir(a_root, kind, race) / f"{name}.{kind.extension}"
+    asset = _asset_dir(assets_root, kind, race) / f"{name}.{kind.extension}"
     asset.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(candidate, asset)
     return asset

--- a/v3/src/spf/frontends/cli/__init__.py
+++ b/v3/src/spf/frontends/cli/__init__.py
@@ -1,6 +1,6 @@
 """Command line interface for SteamPunkFantasy."""
 
-from spf.frontends.cli import army, race, render, rules, special
+from spf.frontends.cli import army, assets, race, render, rules, special
 from spf.frontends.cli.main import app
 
-__all__ = ["app", "army", "race", "render", "rules", "special"]
+__all__ = ["app", "army", "assets", "race", "render", "rules", "special"]

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -1,0 +1,42 @@
+"""Asset commands for the SteamPunkFantasy CLI.
+
+This foundation registers the shared, kind-agnostic ``spf assets promote``
+command and the reusable ``AssetOpts`` parameter set that per-kind ``generate``
+subcommands will accept. Those generate subcommands land in the kind issues.
+"""
+
+from dataclasses import dataclass
+from typing import Annotated
+
+import cyclopts
+
+from spf.assets import get_kind, promote
+
+
+def _validate_kind(_type: type, value: str) -> None:
+    """Reject a KIND that is not registered, surfacing the known kinds."""
+    get_kind(value)  # raises ValueError naming the known kinds
+
+
+Kind = Annotated[str, cyclopts.Parameter(validator=_validate_kind)]
+
+
+@dataclass
+class AssetOpts:
+    """Reusable options for asset generate subcommands."""
+
+    count: int | None = None
+
+
+def add_commands(app: cyclopts.App) -> None:
+    """Add asset commands to the CLI."""
+
+    def promote_asset(race: str, kind: Kind, name: str, *, pick: int) -> None:
+        """Promote the picked Candidate into the committed Asset store.
+
+        RACE is the race the Asset belongs to, KIND its Asset kind, NAME its base
+        file name. ``--pick`` selects the 1-based Candidate to commit.
+        """
+        promote(get_kind(kind), race=race, name=name, pick=pick)
+
+    app.command(promote_asset, name="promote")

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -11,6 +11,7 @@ from typing import Annotated
 import cyclopts
 
 from spf.assets import get_kind, promote
+from spf.config import config
 
 
 def _validate_kind(_type: type, value: str) -> None:
@@ -37,6 +38,13 @@ def add_commands(app: cyclopts.App) -> None:
         RACE is the race the Asset belongs to, KIND its Asset kind, NAME its base
         file name. ``--pick`` selects the 1-based Candidate to commit.
         """
-        promote(get_kind(kind), race=race, name=name, pick=pick)
+        promote(
+            get_kind(kind),
+            race=race,
+            name=name,
+            pick=pick,
+            candidates_root=config.paths.candidates,
+            assets_root=config.paths.assets,
+        )
 
     app.command(promote_asset, name="promote")

--- a/v3/src/spf/frontends/cli/main.py
+++ b/v3/src/spf/frontends/cli/main.py
@@ -21,6 +21,10 @@ rules_app = app.command(cyclopts.App(name="rules", help="Work with rules."))
 cli.rules.add_commands(rules_app)
 render_app = app.command(cyclopts.App(name="render", help="Render products to files."))
 cli.render.add_commands(render_app)
+assets_app = app.command(
+    cyclopts.App(name="assets", help="Generate and curate assets.")
+)
+cli.assets.add_commands(assets_app)
 special_app = app.command(cyclopts.App(name="special", help="Work with special rules."))
 cli.special.add_commands(special_app)
 

--- a/v3/src/spf/schemas/config.py
+++ b/v3/src/spf/schemas/config.py
@@ -12,6 +12,8 @@ class PathsConfig(StrictModel):
     rules: Path
     templates: Path
     output: Path
+    candidates: Path
+    assets: Path
 
 
 class LatexConfig(StrictModel):
@@ -22,6 +24,21 @@ class RenderConfig(StrictModel):
     latex: LatexConfig = LatexConfig()
 
 
+class AssetKindConfig(StrictModel):
+    """Per-kind Asset settings (how many Candidates to generate, ...)."""
+
+    count: int
+
+
+class AssetsConfig(StrictModel):
+    """Asset generation config, one entry per Asset kind."""
+
+    lore: AssetKindConfig = AssetKindConfig(count=1)
+    image: AssetKindConfig = AssetKindConfig(count=3)
+    model: AssetKindConfig = AssetKindConfig(count=2)
+
+
 class SteamPunkFantasyConfig(StrictModel):
     paths: PathsConfig
     render: RenderConfig = RenderConfig()
+    assets: AssetsConfig = AssetsConfig()

--- a/v3/tests/assets/__init__.py
+++ b/v3/tests/assets/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the spf.assets subsystem."""

--- a/v3/tests/assets/conftest.py
+++ b/v3/tests/assets/conftest.py
@@ -1,0 +1,35 @@
+"""Shared test doubles for the assets foundation.
+
+A throwaway :class:`FakeService` returning canned bytes and a matching throwaway
+:class:`~spf.assets.Kind` stand in for the concrete kinds (Lore, Image, Model)
+that land in the child issues. Nothing here lives in ``src/``.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import pytest
+
+from spf.assets import Kind
+
+
+@dataclass
+class FakeService:
+    """A :class:`~spf.assets.Service` returning a fixed list of canned bytes."""
+
+    values: Sequence[bytes | str] = (b"one", b"two", b"three")
+
+    def generate(self, source: object, count: int) -> Sequence[bytes | str]:
+        """Return the first ``count`` canned values."""
+        return list(self.values)[:count]
+
+
+@pytest.fixture
+def test_kind() -> Kind:
+    """Return a throwaway binary kind laid out at ``<race>/_test/<name>.txt``."""
+    return Kind(
+        name="_test",
+        service=FakeService(),
+        subdir="_test",
+        extension="txt",
+    )

--- a/v3/tests/assets/conftest.py
+++ b/v3/tests/assets/conftest.py
@@ -19,7 +19,7 @@ class FakeService:
 
     values: Sequence[bytes | str] = (b"one", b"two", b"three")
 
-    def generate(self, source: object, count: int) -> Sequence[bytes | str]:
+    def generate(self, source: str, count: int) -> Sequence[bytes | str]:
         """Return the first ``count`` canned values."""
         return list(self.values)[:count]
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -2,8 +2,8 @@
 
 from pathlib import Path
 
-import cyclopts
 import pytest
+from cyclopts.exceptions import CycloptsError
 
 from spf.assets import Kind, generate
 from spf.assets.kinds import KINDS
@@ -23,7 +23,14 @@ def registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
 
 
 def test_promote_command_lands_picked_candidate(registered_kind: Kind) -> None:
-    generate(registered_kind, source=object(), race="orks", name="grunt", count=3)
+    generate(
+        registered_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=config.paths.candidates,
+    )
     app(
         ["assets", "promote", "orks", "_test", "grunt", "--pick", "2"],
         exit_on_error=False,
@@ -38,7 +45,7 @@ def test_promote_command_unknown_kind_errors(
 ) -> None:
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
     monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
-    with pytest.raises(cyclopts.exceptions.CycloptsError, match="Unknown kind"):
+    with pytest.raises(CycloptsError, match="Unknown kind"):
         app(
             ["assets", "promote", "orks", "nope", "grunt", "--pick", "1"],
             exit_on_error=False,

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -1,0 +1,45 @@
+"""S5: the shared ``spf assets promote`` CLI command over a throwaway kind."""
+
+from pathlib import Path
+
+import cyclopts
+import pytest
+
+from spf.assets import Kind, generate
+from spf.assets.kinds import KINDS
+from spf.config import config
+from spf.frontends.cli import app
+from tests.assets.conftest import FakeService
+
+
+@pytest.fixture
+def registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
+    """Register a throwaway kind and point the config roots under tmp."""
+    kind = Kind(name="_test", service=FakeService(), subdir="_test", extension="txt")
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    return kind
+
+
+def test_promote_command_lands_picked_candidate(registered_kind: Kind) -> None:
+    generate(registered_kind, source=object(), race="orks", name="grunt", count=3)
+    app(
+        ["assets", "promote", "orks", "_test", "grunt", "--pick", "2"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+    asset = config.paths.assets / "orks" / "_test" / "grunt.txt"
+    assert asset.read_bytes() == b"two"
+
+
+def test_promote_command_unknown_kind_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    with pytest.raises(cyclopts.exceptions.CycloptsError, match="Unknown kind"):
+        app(
+            ["assets", "promote", "orks", "nope", "grunt", "--pick", "1"],
+            exit_on_error=False,
+        )

--- a/v3/tests/assets/test_config.py
+++ b/v3/tests/assets/test_config.py
@@ -1,0 +1,18 @@
+"""S4: the assets layout paths and per-kind counts resolve from config."""
+
+from pathlib import Path
+
+from spf.config import config
+
+
+def test_candidates_and_assets_paths_resolve() -> None:
+    assert isinstance(config.paths.candidates, Path)
+    assert config.paths.candidates.name == "candidates"
+    assert isinstance(config.paths.assets, Path)
+    assert config.paths.assets.name == "assets"
+
+
+def test_per_kind_counts_resolve() -> None:
+    assert config.assets.lore.count == 1
+    assert config.assets.image.count == 3
+    assert config.assets.model.count == 2

--- a/v3/tests/assets/test_kinds.py
+++ b/v3/tests/assets/test_kinds.py
@@ -1,0 +1,28 @@
+"""S1: the Kind record and its registry mechanism."""
+
+import pytest
+
+from spf.assets import Kind, get_kind, register_kind
+from spf.assets.kinds import KINDS
+
+
+def test_registry_starts_empty() -> None:
+    assert KINDS == {}
+
+
+def test_register_and_look_up(test_kind: Kind) -> None:
+    try:
+        registered = register_kind(test_kind)
+        assert get_kind("_test") is registered
+    finally:
+        KINDS.pop("_test", None)
+
+
+def test_unknown_kind_raises_naming_known_kinds(test_kind: Kind) -> None:
+    try:
+        register_kind(test_kind)
+        with pytest.raises(ValueError, match="Unknown kind 'nope'") as excinfo:
+            get_kind("nope")
+        assert "_test" in str(excinfo.value)
+    finally:
+        KINDS.pop("_test", None)

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -1,0 +1,138 @@
+"""S2 + S3: the generate and promote spine functions."""
+
+from pathlib import Path
+
+import pytest
+
+from spf.assets import Kind, generate, promote
+from tests.assets.conftest import FakeService
+
+
+def test_generate_writes_n_candidates_at_kind_layout(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    paths = generate(
+        test_kind,
+        source=object(),
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=tmp_path,
+    )
+    assert paths == [
+        tmp_path / "orks" / "_test" / "grunt.1.txt",
+        tmp_path / "orks" / "_test" / "grunt.2.txt",
+        tmp_path / "orks" / "_test" / "grunt.3.txt",
+    ]
+    assert [p.read_bytes() for p in paths] == [b"one", b"two", b"three"]
+
+
+def test_generate_honors_count(tmp_path: Path, test_kind: Kind) -> None:
+    paths = generate(
+        test_kind,
+        source=object(),
+        race="orks",
+        name="grunt",
+        count=2,
+        candidates_root=tmp_path,
+    )
+    assert len(paths) == 2
+
+
+def test_generate_without_subdir_writes_flat_text(tmp_path: Path) -> None:
+    lore_kind = Kind(
+        name="_lore",
+        service=FakeService(values=("chapter one", "chapter two")),
+        subdir=None,
+        extension="md",
+    )
+    paths = generate(
+        lore_kind,
+        source=object(),
+        race="orks",
+        name="lore",
+        count=2,
+        candidates_root=tmp_path,
+    )
+    assert paths == [
+        tmp_path / "orks" / "lore.1.md",
+        tmp_path / "orks" / "lore.2.md",
+    ]
+    assert paths[0].read_text(encoding="utf-8") == "chapter one"
+
+
+def test_promote_copies_picked_candidate_into_store(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    candidates = tmp_path / "candidates"
+    store = tmp_path / "assets"
+    generate(
+        test_kind,
+        source=object(),
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=candidates,
+    )
+    asset = promote(
+        test_kind,
+        race="orks",
+        name="grunt",
+        pick=2,
+        candidates_root=candidates,
+        assets_root=store,
+    )
+    assert asset == store / "orks" / "_test" / "grunt.txt"
+    assert asset.read_bytes() == b"two"
+
+
+def test_promote_missing_candidate_raises(tmp_path: Path, test_kind: Kind) -> None:
+    generate(
+        test_kind,
+        source=object(),
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=tmp_path / "candidates",
+    )
+    with pytest.raises(ValueError, match="candidate"):
+        promote(
+            test_kind,
+            race="orks",
+            name="grunt",
+            pick=99,
+            candidates_root=tmp_path / "candidates",
+            assets_root=tmp_path / "assets",
+        )
+
+
+def test_promote_overwrites_existing_asset_silently(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    candidates = tmp_path / "candidates"
+    store = tmp_path / "assets"
+    generate(
+        test_kind,
+        source=object(),
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=candidates,
+    )
+    promote(
+        test_kind,
+        race="orks",
+        name="grunt",
+        pick=1,
+        candidates_root=candidates,
+        assets_root=store,
+    )
+    asset = promote(
+        test_kind,
+        race="orks",
+        name="grunt",
+        pick=3,
+        candidates_root=candidates,
+        assets_root=store,
+    )
+    assert asset.read_bytes() == b"three"

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -13,7 +13,7 @@ def test_generate_writes_n_candidates_at_kind_layout(
 ) -> None:
     paths = generate(
         test_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="grunt",
         count=3,
@@ -30,7 +30,7 @@ def test_generate_writes_n_candidates_at_kind_layout(
 def test_generate_honors_count(tmp_path: Path, test_kind: Kind) -> None:
     paths = generate(
         test_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="grunt",
         count=2,
@@ -48,7 +48,7 @@ def test_generate_without_subdir_writes_flat_text(tmp_path: Path) -> None:
     )
     paths = generate(
         lore_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="lore",
         count=2,
@@ -68,7 +68,7 @@ def test_promote_copies_picked_candidate_into_store(
     store = tmp_path / "assets"
     generate(
         test_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="grunt",
         count=3,
@@ -89,7 +89,7 @@ def test_promote_copies_picked_candidate_into_store(
 def test_promote_missing_candidate_raises(tmp_path: Path, test_kind: Kind) -> None:
     generate(
         test_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="grunt",
         count=3,
@@ -113,7 +113,7 @@ def test_promote_overwrites_existing_asset_silently(
     store = tmp_path / "assets"
     generate(
         test_kind,
-        source=object(),
+        source="a grunt description",
         race="orks",
         name="grunt",
         count=3,


### PR DESCRIPTION
## Summary

Implements the **foundation `spf/assets/` subsystem** (issue #23): the shared **generate → curate → commit** spine every Asset kind builds on. Peer of `spf/render/`; **blocks** the three kind issues (Lore, Image, Model). Ships **zero concrete kinds**, proven entirely by tests over a throwaway kind — exactly as `render-foundation` shipped zero products.

Built test-first with the **tdd** skill (red → green, vertical slices) against the five pre-agreed seams from the planning session.

## What's included

- **`spf/assets/kinds.py`** — `Service` (`Protocol`), frozen `Kind(name, service, subdir, extension)`, the `KINDS` registry, and `register_kind`/`get_kind`. Zero concrete kinds registered.
- **`spf/assets/spine.py`** — the two seam functions:
  - `generate(kind, source, *, race, name, count, candidates_root=None)` writes N Candidates at `<race>/[<subdir>/]<name>.<i>.<ext>` under `candidates/`, inferring text-vs-binary from the returned value type.
  - `promote(kind, *, race, name, pick, candidates_root=None, assets_root=None)` copies the picked (1-based) Candidate bytes-for-bytes into the committed `assets/` store, overwriting silently and raising a clear error on a missing/out-of-range pick.
- **`spf assets promote` CLI command** — real, kind-agnostic, over the `spf assets` group; plus reusable `AssetOpts(--count)`. Unknown kinds surface a clean cyclopts validation error (no traceback).
- **Config** — `paths.candidates` + `paths.assets`; `[assets.lore|image|model].count` (1/3/2). `candidates/` gitignored; `assets/` committed.

## Seams under test

All hermetic — no provider, network, or TTY. A throwaway `Kind` wrapping an in-memory `FakeService` (canned bytes) lives in `tests/assets/conftest.py`, never in `src/`.

| Seam | Coverage |
|---|---|
| S1 Kind/Service/registry | `test_kinds.py` |
| S2 generate | `test_spine.py` (incl. `subdir=None` layout variant) |
| S3 promote | `test_spine.py` (copy, missing-pick error, silent overwrite) |
| S4 config resolves | `test_config.py` |
| S5 `spf assets promote` CLI | `test_cli.py` (happy path + unknown-kind error) |

## Deviation from plan

The plan listed only `paths.candidates`, but `promote`'s default `assets_root` needs a home, so I added a symmetric `paths.assets`.

## Testing

- All 13 new assets tests pass; full suite green (179 passed).
- `just check`: format, lint, typecheck all clean. The one `spell` failure (`templates/card_standar.tex`) is a **pre-existing** filename typo, unrelated to this branch and untouched here.

## Not in this foundation

Any kind's generation logic/provider, a `generate` CLI entrypoint (needs a real provider), how `render/` embeds Image assets, and the 3D print-on-demand leg — all deferred to the child kind issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6c7mDyXpKTAwkkPVqPh32