### PR TITLE
Add Army Reference product (spf render army-rules)

### DIFF
--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -14,6 +14,7 @@ import cyclopts
 from spf.armies import io
 from spf.console import stderr, stdout
 from spf.render import Product, render
+from spf.render.army_rules import build_reference
 from spf.render.cards import build_deck
 from spf.render.formats import FORMATS, get_format
 from spf.render.products import register_product
@@ -22,6 +23,10 @@ DEFAULT_FORMAT = "pdf"
 
 # The Order Card Product: templates live at ``<family>/cards/main.<ext>.jinja``.
 CARDS = register_product(Product(name="cards"))
+
+# The Army Reference Product: templates live at
+# ``<family>/army-rules/main.<ext>.jinja``.
+ARMY_RULES = register_product(Product(name="army-rules"))
 
 
 def _validate_format(_type: type, value: str) -> None:
@@ -74,6 +79,27 @@ def render_cards(
     stdout.print(f"Wrote {out}")
 
 
+def render_army_rules(
+    army_name: str,
+    *,
+    opts: Annotated[RenderOpts | None, cyclopts.Parameter(name="*")] = None,
+) -> None:
+    """Render an army's rules reference to a document."""
+    opts = opts or RenderOpts()
+    try:
+        army = io.load_army(army_name)
+    except (FileNotFoundError, ValueError) as err:
+        stderr.print(f"[red]Error:[/] {err}")
+        raise SystemExit(1) from None
+
+    stem = _safe_stem(army_name)
+    reference = build_reference(army, stem=stem)
+    fmt = get_format(opts.format)
+    out = render(ARMY_RULES, reference, fmt, name=stem, out=opts.out)
+    stdout.print(f"Wrote {out}")
+
+
 def add_commands(app: cyclopts.App) -> None:
     """Add render commands to the CLI."""
     app.command(render_cards, name="cards")
+    app.command(render_army_rules, name="army-rules")

--- a/v3/src/spf/render/army_rules.py
+++ b/v3/src/spf/render/army_rules.py
@@ -73,6 +73,7 @@ class UnitEntry:
     armor: tuple[int, ...] | None
     points: int
     shaken_speed: t.Speed
+    shaken_movement: tuple[str, ...]
     shaken_fire: str
     specials: _Specials
     damage_tables: tuple[tuple[str, tuple[str, ...]], ...]
@@ -138,6 +139,7 @@ def _unit_entry(unit: Unit) -> UnitEntry:
         armor=tuple(unit.config.armor) if unit.config.armor is not None else None,
         points=unit.cost().to_points(),
         shaken_speed=unit.config.shaken.speed,
+        shaken_movement=tuple(unit.config.shaken.movement_order),
         shaken_fire=unit.config.shaken.fire_order,
         specials=tuple(unit.unit_specials.items()),
         damage_tables=tuple(

--- a/v3/src/spf/render/army_rules.py
+++ b/v3/src/spf/render/army_rules.py
@@ -1,0 +1,172 @@
+"""Army Reference view-model: shape a resolved Army into a nested rules view.
+
+This is a *presentation* transposition (ADR 0007), like :mod:`spf.render.cards`.
+It reads only the resolved :class:`~spf.armies.army.Army` — no ``race_config``,
+no rules loading, no full special-rule text (that belongs to the Rulebook
+product). No I/O, no templates.
+"""
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+
+from spf.armies.army import Army
+from spf.armies.model import Model
+from spf.armies.unit import Unit
+from spf.schemas import type_aliases as t
+from spf.schemas.race import EquipmentConfig
+
+type _Specials = tuple[tuple[str, str], ...]
+
+
+def _count_summary[T](
+    items: Sequence[T], name_of: Callable[[T], str]
+) -> tuple[str, ...]:
+    """Group ``items`` by equality, first-seen order, into ``NxName`` labels."""
+    counts: list[tuple[T, int]] = []
+    for item in items:
+        for i, (existing, n) in enumerate(counts):
+            if existing == item:
+                counts[i] = (existing, n + 1)
+                break
+        else:
+            counts.append((item, 1))
+    return tuple(f"{n}x {name_of(item)}" for item, n in counts)
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    """One distinct Model configuration within a Unit."""
+
+    name: str
+    equipment_summary: tuple[str, ...]
+    specials: _Specials
+    assault_strength: tuple[int, ...]
+    assault_strength_die: t.DieResult
+    assault_deflection: tuple[int, ...]
+    assault_deflection_die: t.DieResult
+    assault_damage: t.Die
+    assault_ap: t.ArmorPenetration
+    assault_specials: _Specials
+    equipment: tuple["EquipmentEntry", ...]
+
+
+@dataclass(frozen=True)
+class EquipmentEntry:
+    """One distinct ranged-equipment sub-entry within a Model."""
+
+    name: str
+    range: int
+    angle: tuple[bool | str, ...]
+    damage: t.Die
+    ap: t.ArmorPenetration
+    specials: _Specials
+
+
+@dataclass(frozen=True)
+class UnitEntry:
+    """One distinct Unit configuration, with a count of identical duplicates."""
+
+    name: str
+    count: int
+    size: t.Size
+    model_summary: tuple[str, ...]
+    armor: tuple[int, ...] | None
+    points: int
+    shaken_speed: t.Speed
+    shaken_fire: str
+    specials: _Specials
+    damage_tables: tuple[tuple[str, tuple[str, ...]], ...]
+    models: tuple[ModelEntry, ...]
+
+
+@dataclass(frozen=True)
+class ArmyReference:
+    """The whole Army's reference document: title block plus distinct Units."""
+
+    stem: str
+    nick: str
+    race: t.RaceName
+    points: int
+    units: tuple[UnitEntry, ...]
+
+
+def _equipment_entry(equip: EquipmentConfig) -> EquipmentEntry:
+    assert equip.range is not None  # noqa: S101  guarded by caller
+    return EquipmentEntry(
+        name=equip.name,
+        range=equip.range.range,
+        angle=tuple(equip.range.angle),
+        damage=equip.range.damage,
+        ap=equip.range.ap,
+        specials=tuple(equip.range.special.items()),
+    )
+
+
+def _dedup[T](entries: Sequence[T]) -> tuple[T, ...]:
+    """Drop duplicate entries, preserving first-seen order."""
+    result: list[T] = []
+    for entry in entries:
+        if entry not in result:
+            result.append(entry)
+    return tuple(result)
+
+
+def _model_entry(model: Model) -> ModelEntry:
+    ranged_equipment = [equip for equip in model.equipment if equip.range is not None]
+    assault = model.assault()
+    return ModelEntry(
+        name=model.config.name,
+        equipment_summary=_count_summary(model.equipment, lambda e: e.name),
+        specials=tuple(model.model_specials.items()),
+        assault_strength=tuple(assault.strength),
+        assault_strength_die=assault.strength_die,
+        assault_deflection=tuple(assault.deflection),
+        assault_deflection_die=assault.deflection_die,
+        assault_damage=assault.damage,
+        assault_ap=assault.ap,
+        assault_specials=tuple(assault.special.items()),
+        equipment=_dedup([_equipment_entry(e) for e in ranged_equipment]),
+    )
+
+
+def _unit_entry(unit: Unit) -> UnitEntry:
+    return UnitEntry(
+        name=unit.config.name,
+        count=1,
+        size=unit.config.size,
+        model_summary=_count_summary(unit.models, lambda m: m.config.name),
+        armor=tuple(unit.config.armor) if unit.config.armor is not None else None,
+        points=unit.cost().to_points(),
+        shaken_speed=unit.config.shaken.speed,
+        shaken_fire=unit.config.shaken.fire_order,
+        specials=tuple(unit.unit_specials.items()),
+        damage_tables=tuple(
+            (name, tuple(rows)) for name, rows in unit.config.damage_tables.items()
+        ),
+        models=_dedup([_model_entry(model) for model in unit.models]),
+    )
+
+
+def _collapse_units(entries: Sequence[UnitEntry]) -> tuple[UnitEntry, ...]:
+    """Collapse units equal in every field but ``count``, summing their counts."""
+    collapsed: list[UnitEntry] = []
+    for entry in entries:
+        bare = replace(entry, count=1)
+        for i, existing in enumerate(collapsed):
+            if replace(existing, count=1) == bare:
+                collapsed[i] = replace(existing, count=existing.count + 1)
+                break
+        else:
+            collapsed.append(entry)
+    return tuple(collapsed)
+
+
+def build_reference(army: Army, *, stem: str) -> ArmyReference:
+    """Build an :class:`ArmyReference` from a resolved Army."""
+    return ArmyReference(
+        stem=stem,
+        nick=army.nick,
+        race=army.race,
+        points=army.cost().to_points(),
+        units=_collapse_units([_unit_entry(unit) for unit in army.units]),
+    )

--- a/v3/templates/latex/army-rules/main.tex.jinja
+++ b/v3/templates/latex/army-rules/main.tex.jinja
@@ -11,13 +11,13 @@
 \BLOCK{for unit in source.units}
 \section{\VAR{unit.name | latex_escape}\BLOCK{if unit.count > 1} (\VAR{unit.count}$\times$)\BLOCK{endif}}
 
-Size: \VAR{unit.size | latex_escape} \\
-Models: \VAR{unit.model_summary | join(', ') | latex_escape} \\
+\textbf{Size:} \VAR{unit.size | latex_escape} \\
+\textbf{Models:} \VAR{unit.model_summary | join(', ') | latex_escape} \\
 \BLOCK{if unit.armor}
-Armor: \VAR{unit.armor | join('/')} \\
+\textbf{Armor:} [\VAR{unit.armor | join(', ')}] \\
 \BLOCK{endif}
-Points: \VAR{unit.points} \\
-Shaken: \VAR{unit.shaken_speed | latex_escape} [\VAR{unit.shaken_movement | join(', ') | latex_escape}] / \VAR{unit.shaken_fire | latex_escape}
+\textbf{Points:} \VAR{unit.points} \\
+\textbf{Shaken:} \VAR{unit.shaken_speed | latex_escape} [\VAR{unit.shaken_movement | join(', ') | latex_escape}] / \VAR{unit.shaken_fire | latex_escape}
 
 \BLOCK{if unit.specials}
 \begin{itemize}
@@ -41,8 +41,8 @@ Shaken: \VAR{unit.shaken_speed | latex_escape} [\VAR{unit.shaken_movement | join
 \BLOCK{for model in unit.models}
 \subsection{\VAR{model.name | latex_escape}}
 
-Equipment: \VAR{model.equipment_summary | join(', ') | latex_escape} \\
-Assault: strength \VAR{model.assault_strength | join('/')} (\VAR{model.assault_strength_die | latex_escape}),
+\textbf{Equipment:} \VAR{model.equipment_summary | join(', ') | latex_escape} \\
+\textbf{Assault:} strength \VAR{model.assault_strength | join('/')} (\VAR{model.assault_strength_die | latex_escape}),
 deflection \VAR{model.assault_deflection | join('/')} (\VAR{model.assault_deflection_die | latex_escape}),
 damage \VAR{model.assault_damage | latex_escape}, AP \VAR{model.assault_ap}
 
@@ -60,7 +60,7 @@ damage \VAR{model.assault_damage | latex_escape}, AP \VAR{model.assault_ap}
 \BLOCK{for equip in model.equipment}
 \subsubsection{\VAR{equip.name | latex_escape}}
 
-Range: \VAR{equip.range}, angle \VAR{equip.angle | join('/') | latex_escape}, damage \VAR{equip.damage | latex_escape}, AP \VAR{equip.ap}
+\textbf{Range:} \VAR{equip.range}, angle \VAR{equip.angle | join('/') | latex_escape}, damage \VAR{equip.damage | latex_escape}, AP \VAR{equip.ap}
 
 \BLOCK{if equip.specials}
 \begin{itemize}

--- a/v3/templates/latex/army-rules/main.tex.jinja
+++ b/v3/templates/latex/army-rules/main.tex.jinja
@@ -1,0 +1,75 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage[margin=2cm]{geometry}
+\usepackage{textcomp}
+
+\begin{document}
+\begin{center}
+{\Large \VAR{source.nick | latex_escape}} \\
+\VAR{source.race | latex_escape} --- \VAR{source.points} points
+\end{center}
+
+\BLOCK{for unit in source.units}
+\section{\VAR{unit.name | latex_escape}\BLOCK{if unit.count > 1} (\VAR{unit.count}$\times$)\BLOCK{endif}}
+
+Size: \VAR{unit.size | latex_escape} \\
+Models: \VAR{unit.model_summary | join(', ') | latex_escape} \\
+\BLOCK{if unit.armor}
+Armor: \VAR{unit.armor | join('/')} \\
+\BLOCK{endif}
+Points: \VAR{unit.points} \\
+Shaken: \VAR{unit.shaken_speed | latex_escape} / \VAR{unit.shaken_fire | latex_escape}
+
+\BLOCK{if unit.specials}
+\begin{itemize}
+\BLOCK{for name, text in unit.specials}
+\item \textbf{\VAR{name | latex_escape}}: \VAR{text | latex_escape}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endif}
+
+\BLOCK{for name, rows in unit.damage_tables}
+\textbf{\VAR{name | latex_escape}}
+\begin{itemize}
+\BLOCK{for row in rows}
+\item \VAR{row | latex_escape}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endfor}
+
+\BLOCK{for model in unit.models}
+\subsection{\VAR{model.name | latex_escape}}
+
+Equipment: \VAR{model.equipment_summary | join(', ') | latex_escape} \\
+Assault: strength \VAR{model.assault_strength | join('/')} (\VAR{model.assault_strength_die | latex_escape}),
+deflection \VAR{model.assault_deflection | join('/')} (\VAR{model.assault_deflection_die | latex_escape}),
+damage \VAR{model.assault_damage | latex_escape}, AP \VAR{model.assault_ap}
+
+\BLOCK{if model.specials or model.assault_specials}
+\begin{itemize}
+\BLOCK{for name, text in model.specials}
+\item \textbf{\VAR{name | latex_escape}}: \VAR{text | latex_escape}
+\BLOCK{endfor}
+\BLOCK{for name, text in model.assault_specials}
+\item \textbf{\VAR{name | latex_escape}}: \VAR{text | latex_escape}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endif}
+
+\BLOCK{for equip in model.equipment}
+\subsubsection{\VAR{equip.name | latex_escape}}
+
+Range: \VAR{equip.range}, angle \VAR{equip.angle | join('/') | latex_escape}, damage \VAR{equip.damage | latex_escape}, AP \VAR{equip.ap}
+
+\BLOCK{if equip.specials}
+\begin{itemize}
+\BLOCK{for name, text in equip.specials}
+\item \textbf{\VAR{name | latex_escape}}: \VAR{text | latex_escape}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endif}
+\BLOCK{endfor}
+\BLOCK{endfor}
+
+\newpage
+\BLOCK{endfor}
+\end{document}

--- a/v3/templates/latex/army-rules/main.tex.jinja
+++ b/v3/templates/latex/army-rules/main.tex.jinja
@@ -2,11 +2,11 @@
 \usepackage[margin=2cm]{geometry}
 \usepackage{textcomp}
 
+\title{\VAR{source.nick | latex_escape}}
+\author{\VAR{source.race | latex_escape} --- \VAR{source.points} points}
+
 \begin{document}
-\begin{center}
-{\Large \VAR{source.nick | latex_escape}} \\
-\VAR{source.race | latex_escape} --- \VAR{source.points} points
-\end{center}
+\maketitle
 
 \BLOCK{for unit in source.units}
 \section{\VAR{unit.name | latex_escape}\BLOCK{if unit.count > 1} (\VAR{unit.count}$\times$)\BLOCK{endif}}
@@ -17,7 +17,7 @@ Models: \VAR{unit.model_summary | join(', ') | latex_escape} \\
 Armor: \VAR{unit.armor | join('/')} \\
 \BLOCK{endif}
 Points: \VAR{unit.points} \\
-Shaken: \VAR{unit.shaken_speed | latex_escape} / \VAR{unit.shaken_fire | latex_escape}
+Shaken: \VAR{unit.shaken_speed | latex_escape} [\VAR{unit.shaken_movement | join(', ') | latex_escape}] / \VAR{unit.shaken_fire | latex_escape}
 
 \BLOCK{if unit.specials}
 \begin{itemize}
@@ -26,14 +26,16 @@ Shaken: \VAR{unit.shaken_speed | latex_escape} / \VAR{unit.shaken_fire | latex_e
 \BLOCK{endfor}
 \end{itemize}
 \BLOCK{endif}
-
 \BLOCK{for name, rows in unit.damage_tables}
-\textbf{\VAR{name | latex_escape}}
-\begin{itemize}
+
+\noindent\textbf{Damage Table: \VAR{name | latex_escape}}
+
+\begin{tabular}{l}
 \BLOCK{for row in rows}
-\item \VAR{row | latex_escape}
+\VAR{row | latex_escape} \\
 \BLOCK{endfor}
-\end{itemize}
+\end{tabular}
+\vspace{1ex}
 \BLOCK{endfor}
 
 \BLOCK{for model in unit.models}

--- a/v3/templates/markdown/army-rules/main.md.jinja
+++ b/v3/templates/markdown/army-rules/main.md.jinja
@@ -8,7 +8,7 @@
 - Armor: {{ unit.armor | join('/') }}
 {%- endif %}
 - Points: {{ unit.points }}
-- Shaken: {{ unit.shaken_speed }} / {{ unit.shaken_fire }}
+- Shaken: {{ unit.shaken_speed }} [{{ unit.shaken_movement | join(', ') }}] / {{ unit.shaken_fire }}
 {% for name, text in unit.specials %}
 - **{{ name }}**: {{ text }}
 {%- endfor %}

--- a/v3/templates/markdown/army-rules/main.md.jinja
+++ b/v3/templates/markdown/army-rules/main.md.jinja
@@ -1,0 +1,42 @@
+# {{ source.nick }} — {{ source.race }} — {{ source.points }} points
+{% for unit in source.units %}
+## {{ unit.name }}{% if unit.count > 1 %} ({{ unit.count }}×){% endif %}
+
+- Size: {{ unit.size }}
+- Models: {{ unit.model_summary | join(', ') }}
+{%- if unit.armor %}
+- Armor: {{ unit.armor | join('/') }}
+{%- endif %}
+- Points: {{ unit.points }}
+- Shaken: {{ unit.shaken_speed }} / {{ unit.shaken_fire }}
+{% for name, text in unit.specials %}
+- **{{ name }}**: {{ text }}
+{%- endfor %}
+{% for name, rows in unit.damage_tables %}
+**{{ name }}**
+{% for row in rows %}
+- {{ row }}
+{%- endfor %}
+{% endfor %}
+{% for model in unit.models %}
+### {{ model.name }}
+
+- Equipment: {{ model.equipment_summary | join(', ') }}
+- Assault: strength {{ model.assault_strength | join('/') }} ({{ model.assault_strength_die }}), deflection {{ model.assault_deflection | join('/') }} ({{ model.assault_deflection_die }}), damage {{ model.assault_damage }}, AP {{ model.assault_ap }}
+{% for name, text in model.specials %}
+- **{{ name }}**: {{ text }}
+{%- endfor %}
+{% for name, text in model.assault_specials %}
+- **{{ name }}**: {{ text }}
+{%- endfor %}
+{% for equip in model.equipment %}
+#### {{ equip.name }}
+
+- Range: {{ equip.range }}, angle {{ equip.angle | join('/') }}, damage {{ equip.damage }}, AP {{ equip.ap }}
+{%- for name, text in equip.specials %}
+- **{{ name }}**: {{ text }}
+{%- endfor %}
+{% endfor %}
+{% endfor %}
+---
+{% endfor %}

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -115,6 +115,7 @@ def test_build_reference_basic_unit_and_model_fields() -> None:
     assert unit_entry.armor == (10, 8, 6, 4)
     assert unit_entry.points == unit.cost().to_points()
     assert unit_entry.shaken_speed == "slow"
+    assert unit_entry.shaken_movement == ("-", "-", "flee")
     assert unit_entry.shaken_fire == "No weapons"
     assert unit_entry.specials == (("Take Cover", "[sneak][-2]"),)
     assert unit_entry.damage_tables == (("Regular", ("Fine", "Dead")),)

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -1,0 +1,356 @@
+"""Tests for the Army Reference product: build_reference() and the CLI."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from spf.armies.army import Army
+from spf.armies.model import Model
+from spf.armies.unit import Unit
+from spf.config import config
+from spf.frontends.cli.render import RenderOpts, render_army_rules
+from spf.render.army_rules import build_reference
+from spf.schemas.race import (
+    AssaultConfig,
+    EquipmentAssaultConfig,
+    EquipmentConfig,
+    ModelConfig,
+    OrdersConfig,
+    ShakenConfig,
+    Stacker,
+    UnitConfig,
+)
+from spf.schemas.race import (
+    EquipmentRangeConfig as RangeConfig,
+)
+
+ENGINE = config.render.latex.engine
+
+_ASSAULT = AssaultConfig(
+    strength=[1, 0, 0, 0],
+    strength_die="4+",
+    deflection=[1, 0, 0, 0],
+    deflection_die="4+",
+    damage="d4",
+    ap=0,
+)
+
+
+def _model(
+    *,
+    name: str = "Soldier",
+    equipment: tuple[EquipmentConfig, ...] = (),
+    assault: AssaultConfig = _ASSAULT,
+    model_special: dict[str, str] | None = None,
+) -> Model:
+    config = ModelConfig(
+        race="elf",
+        name=name,  # pyright: ignore[reportArgumentType]
+        equipment_limit=[],  # pyright: ignore[reportArgumentType]
+        equipment=[],
+        type=["Infantry"],
+        assault=assault,
+        cost=None,
+        special=model_special or {},  # pyright: ignore[reportArgumentType]
+    )
+    return Model(
+        name=name,
+        config=config,
+        default_equipment=(),
+        upgrade_equipment=equipment,
+    )
+
+
+def _unit(  # noqa: PLR0913  test fixture covers every UnitConfig field under test
+    *,
+    models: tuple[Model, ...] | None = None,
+    name: str = "Squad",
+    size: str = "Small",
+    shaken: ShakenConfig | None = None,
+    armor: list[int] | None = None,
+    unit_special: dict[str, str] | None = None,
+) -> Unit:
+    resolved_models = models or (_model(),)
+    config = UnitConfig(
+        race="elf",
+        name=name,  # pyright: ignore[reportArgumentType]
+        models=[m.name for m in resolved_models],
+        size=size,  # pyright: ignore[reportArgumentType]
+        shaken=shaken
+        or ShakenConfig(
+            speed="slow", movement_order=["-", "-", "flee"], fire_order="No weapons"
+        ),
+        orders=OrdersConfig(),
+        armor=armor,
+        special=unit_special or {},  # pyright: ignore[reportArgumentType]
+        damage_tables={"Regular": ["Fine", "Dead"]},
+    )
+    return Unit(name=name, config=config, models=resolved_models)
+
+
+def _army(*units: Unit, nick: str = "Test", race: str = "elf") -> Army:
+    return Army(race=race, nick=nick, units=units)  # pyright: ignore[reportArgumentType]
+
+
+# --- build_reference: basic Unit/Model shape --------------------------------
+
+
+def test_build_reference_basic_unit_and_model_fields() -> None:
+    unit = _unit(
+        armor=[10, 8, 6, 4],
+        unit_special={"Take Cover": "[sneak][-2]"},
+    )
+
+    reference = build_reference(_army(unit, nick="The Iron Claws"), stem="test")
+
+    assert reference.stem == "test"
+    assert reference.nick == "The Iron Claws"
+    assert reference.race == "elf"
+    (unit_entry,) = reference.units
+    assert unit_entry.name == "Squad"
+    assert unit_entry.count == 1
+    assert unit_entry.size == "Small"
+    assert unit_entry.model_summary == ("1x Soldier",)
+    assert unit_entry.armor == (10, 8, 6, 4)
+    assert unit_entry.points == unit.cost().to_points()
+    assert unit_entry.shaken_speed == "slow"
+    assert unit_entry.shaken_fire == "No weapons"
+    assert unit_entry.specials == (("Take Cover", "[sneak][-2]"),)
+    assert unit_entry.damage_tables == (("Regular", ("Fine", "Dead")),)
+    (model_entry,) = unit_entry.models
+    assert model_entry.name == "Soldier"
+    assert model_entry.equipment_summary == ()
+
+
+def _equip(
+    *,
+    name: str = "Rifle",
+    range_config: RangeConfig | None = None,
+) -> EquipmentConfig:
+    return EquipmentConfig(
+        race="elf",  # pyright: ignore[reportArgumentType]
+        name=name,
+        requires=[],
+        range=range_config,
+    )
+
+
+def test_build_reference_equipment_summary_counts_rangeless_equipment() -> None:
+    rifle = _equip(name="Rifle")
+    grenade = _equip(name="Grenade")
+    unit = _unit(models=(_model(equipment=(rifle, rifle, grenade)),))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    (model_entry,) = unit_entry.models
+    assert model_entry.equipment_summary == ("2x Rifle", "1x Grenade")
+    assert model_entry.equipment == ()
+
+
+def test_build_reference_ranged_equipment_gets_sub_entry() -> None:
+    musket = _equip(
+        name="Clockwork Musket",
+        range_config=RangeConfig(
+            range=24,
+            angle=[True, False, False, False],
+            damage="d6",
+            ap=2,
+            special={"Sniper": "[+1]"},  # pyright: ignore[reportArgumentType]
+        ),
+    )
+    unit = _unit(models=(_model(equipment=(musket,)),))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    (model_entry,) = unit_entry.models
+    assert model_entry.equipment_summary == ("1x Clockwork Musket",)
+    (equip_entry,) = model_entry.equipment
+    assert equip_entry.name == "Clockwork Musket"
+    assert equip_entry.range == 24
+    assert equip_entry.angle == (True, False, False, False)
+    assert equip_entry.damage == "d6"
+    assert equip_entry.ap == 2
+    assert equip_entry.specials == (("Sniper", "[+1]"),)
+
+
+def test_build_reference_rangeless_equipment_gets_no_sub_entry() -> None:
+    rifle = _equip(name="Rifle")
+    unit = _unit(models=(_model(equipment=(rifle,)),))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    (model_entry,) = unit_entry.models
+    assert model_entry.equipment == ()
+
+
+def test_build_reference_dedups_identical_ranged_equipment_within_a_model() -> None:
+    range_config = RangeConfig(
+        range=24, angle=[True, False, False, False], damage="d6", ap=2
+    )
+    musket_a = _equip(name="Musket", range_config=range_config)
+    musket_b = _equip(name="Musket", range_config=range_config)
+    unit = _unit(models=(_model(equipment=(musket_a, musket_b)),))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    (model_entry,) = unit_entry.models
+    assert model_entry.equipment_summary == ("2x Musket",)
+    (equip_entry,) = model_entry.equipment
+    assert equip_entry.name == "Musket"
+
+
+# --- build_reference: dedup identical Models within a Unit ------------------
+
+
+def test_build_reference_collapses_identical_models_within_a_unit() -> None:
+    elite = _model(name="Elite Infantry")
+    grunt = _model(name="Infantry")
+    unit = _unit(models=(elite, grunt, grunt, elite))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.model_summary == ("2x Elite Infantry", "2x Infantry")
+    assert [m.name for m in unit_entry.models] == ["Elite Infantry", "Infantry"]
+
+
+def test_build_reference_keeps_distinct_model_upgrades_separate() -> None:
+    plain = _model(name="Soldier")
+    upgraded = _model(name="Soldier", equipment=(_equip(name="Rifle"),))
+    unit = _unit(models=(plain, upgraded))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    assert len(unit_entry.models) == 2
+
+
+# --- build_reference: dedup identical Units, points -------------------------
+
+
+def test_build_reference_collapses_identical_units_with_count() -> None:
+    unit_a = _unit(name="Infantry")
+    unit_b = _unit(name="Infantry")
+
+    reference = build_reference(_army(unit_a, unit_b), stem="test")
+
+    assert len(reference.units) == 1
+    (unit_entry,) = reference.units
+    assert unit_entry.count == 2
+    assert unit_entry.points == unit_a.cost().to_points()
+
+
+def test_build_reference_keeps_distinct_units_separate() -> None:
+    unit_a = _unit(name="Infantry", size="Small")
+    unit_b = _unit(name="Archer", size="Small")
+
+    reference = build_reference(_army(unit_a, unit_b), stem="test")
+
+    assert len(reference.units) == 2
+    assert all(u.count == 1 for u in reference.units)
+
+
+def test_build_reference_army_points_counts_duplicate_units() -> None:
+    unit_a = _unit(name="Infantry")
+    unit_b = _unit(name="Infantry")
+
+    reference = build_reference(_army(unit_a, unit_b, nick="Test"), stem="test")
+
+    assert reference.points == unit_a.cost().to_points() + unit_b.cost().to_points()
+
+
+# --- build_reference: resolved assault, not raw config ----------------------
+
+
+def test_build_reference_model_assault_is_resolved_not_raw() -> None:
+    stacking_rifle = _equip(name="Rifle")
+    stacking_rifle = stacking_rifle.model_copy(
+        update={
+            "assault": EquipmentAssaultConfig(
+                strength=Stacker(add=[1, 0, 0, 0]),
+                damage=Stacker(replace="d8"),
+                ap=Stacker(add=1),
+                special={"Bonus": "[+1 strength]"},  # pyright: ignore[reportArgumentType]
+            )
+        }
+    )
+    model = _model(equipment=(stacking_rifle,))
+    unit = _unit(models=(model,))
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    (model_entry,) = unit_entry.models
+    resolved = model.assault()
+    assert model_entry.assault_strength == tuple(resolved.strength)
+    assert model_entry.assault_strength == (2, 0, 0, 0)
+    assert model_entry.assault_strength_die == resolved.strength_die
+    assert model_entry.assault_damage == "d8"
+    assert model_entry.assault_ap == 1
+    assert model_entry.assault_specials == (("Bonus", "[+1 strength]"),)
+
+
+# --- CLI: render army-rules end-to-end (drives the real templates) ---------
+
+DEMO_ARMY = "demo"
+
+
+def test_render_army_rules_markdown_has_title_and_unit_sections(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "demo.md"
+    render_army_rules(DEMO_ARMY, opts=RenderOpts(format="markdown", out=out))
+
+    text = out.read_text(encoding="utf-8")
+    assert "Iron Claws" in text
+    assert "goblin" in text
+    assert "## Goblin Infantry" in text
+    assert "---" in text
+    assert "### " in text  # a Model subsection
+    assert "Movement" not in text
+    assert "Fire Order" in text or "Take Cover" in text  # a unit special
+    assert "0-5: Kill 1 model" in text  # a damage-table row
+
+
+def test_render_army_rules_html_is_a_document(tmp_path: Path) -> None:
+    out = tmp_path / "demo.html"
+    render_army_rules(DEMO_ARMY, opts=RenderOpts(format="html", out=out))
+
+    text = out.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in text
+    assert "Iron Claws" in text
+
+
+def test_render_army_rules_latex_uses_article_with_newpage_per_unit(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "demo.tex"
+    render_army_rules(DEMO_ARMY, opts=RenderOpts(format="latex", out=out))
+
+    text = out.read_text(encoding="utf-8")
+    assert r"\documentclass" in text
+    assert "{article}" in text
+    assert r"\section{" in text
+    assert r"\newpage" in text
+
+
+@pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
+def test_render_army_rules_pdf_compiles(tmp_path: Path) -> None:
+    out = tmp_path / "demo.pdf"
+    render_army_rules(DEMO_ARMY, opts=RenderOpts(format="pdf", out=out))
+
+    assert out.stat().st_size > 0
+
+
+def test_render_army_rules_missing_army_exits_nonzero(tmp_path: Path) -> None:
+    out = tmp_path / "missing.md"
+    with pytest.raises(SystemExit) as excinfo:
+        render_army_rules("no-such-army", opts=RenderOpts(format="markdown", out=out))
+
+    assert excinfo.value.code == 1
+    assert not out.exists()


### PR DESCRIPTION
## Summary
- Closes #19. Builds on the render foundation (ADR 0005) and the Order Card product (#34), per `.scratch/army-reference-plan.md`.
- Adds `build_reference()` (`src/spf/render/army_rules.py`): a nested Unit → Model → Equipment view-model built only from a resolved `Army` (no `race_config`, no rules loading, no full special-rule text — that's the Rulebook product).
- Adds the CLI command `spf render army-rules <army> --format {markdown,html,latex,pdf}` (default `pdf`), mirroring `render_cards`.
- Adds `templates/markdown/army-rules/main.md.jinja` and `templates/latex/army-rules/main.tex.jinja` (plain `article` class, `\newpage` per unit).
- Identically-configured Units collapse with a count; identical Models within a Unit collapse too. Orders are excluded (Order Cards own those); rangeless equipment appears only in the model's equipment summary line, not as a sub-block.

## Test plan
- [x] `tests/render/test_army_rules.py`: `build_reference()` nesting, dedup (units/models/equipment), resolved-assault reflection, points; CLI end-to-end markdown/html/latex render assertions; pdflatex-gated PDF compile test; unknown-army error handling.
- [x] `just check` (format, lint, validate, spell, test, typecheck) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbcJAs16TkooKQTq3ELcQP