### PR TITLE
Author the Negative Prompt in prompts/ (#50)

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -234,9 +234,17 @@ _Avoid_: shell environment (unrelated), backend, target.
 A ComfyUI API-format graph (JSON) naming the nodes and models one generation
 runs. Per-Environment, and one each for generating and refining: `cloud.json`
 and `cloud-refine.json` are committed, the `local*` ones are per-machine. The
-Image Service patches only the positive prompt and a per-job seed into it —
-plus, for a refine Workflow, the sole `LoadImage`'s filename.
+Image Service patches only the positive prompt, the Negative Prompt, and the
+seed — plus, for a refine Workflow, the sole `LoadImage`'s filename.
 _Avoid_: pipeline, graph (in user-facing text).
+
+**Negative Prompt** (image generation):
+What an image should _not_ contain, authored in `prompts/image-negative.txt`
+and patched into a Workflow's negative encoder at generation time. One file
+serves both Environments and both operations (generate and refine), and it
+**replaces** whatever the Workflow authored rather than adding to it. Required
+— a missing file is an error, not a fall-through.
+_Avoid_: negative, neg prompt, exclusions, banned terms
 
 **Refinement**:
 Generating Candidates from an existing Candidate plus a Correction, rather than
@@ -247,7 +255,8 @@ the domain operation)
 **Correction**:
 The verbatim edit prompt a Refinement applies ("make the hat brass instead of
 leather"). Used as the whole positive prompt — no description, no wrapper — and
-always phrased positively, since the negative prompt is never patched.
+always phrased positively: the Negative Prompt is a fixed, shared file, so a
+Correction has no per-call negative to carry an exclusion in.
 _Avoid_: instruction, tweak, fix, note
 
 **Lineage**:

--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -239,8 +239,9 @@ seed — plus, for a refine Workflow, the sole `LoadImage`'s filename.
 _Avoid_: pipeline, graph (in user-facing text).
 
 **Negative Prompt** (image generation):
-What an image should _not_ contain, authored in `prompts/image-negative.txt`
-and patched into a Workflow's negative encoder at generation time. One file
+What an image should _not_ contain, authored in the file named by
+`assets.image.negative_prompt` (by default `prompts/image-negative.txt`) and
+patched into a Workflow's negative encoder at generation time. One file
 serves both Environments and both operations (generate and refine), and it
 **replaces** whatever the Workflow authored rather than adding to it. Required
 — a missing file is an error, not a fall-through.

--- a/v3/configs/spf.toml
+++ b/v3/configs/spf.toml
@@ -18,6 +18,8 @@ count = 1
 
 [assets.image]
 count = 3
+prompt = "{paths.prompts}/image.txt"
+negative_prompt = "{paths.prompts}/image-negative.txt"
 
 [assets.image.comfyui]
 env = "local"

--- a/v3/docs/adr/0009-comfyui-image-service.md
+++ b/v3/docs/adr/0009-comfyui-image-service.md
@@ -104,8 +104,9 @@ are now narrower than the code:
 - **The patch set is prompt + seed + the sole `LoadImage`.** "Patch only prompt
   + seed" still describes *generate* exactly. A Refinement patches one further
   input: the filename of the uploaded init image, on the graph's one
-  `LoadImage`. Model names, steps, cfg, LoRAs, and the negative prompt remain
-  untouched in both operations.
+  `LoadImage`. Model names, steps, cfg, and LoRAs remain untouched in both
+  operations. (The negative prompt did too when this was written; the amendment
+  below overturns that.)
 - **The positive node's prompt input is `text` *or* `prompt`.** Following the
   sampler's `positive` link and setting `text` was correct for every generate
   graph, where the encoder is `CLIPTextEncode`. Qwen's edit encoder,
@@ -115,3 +116,30 @@ are now narrower than the code:
 Nothing else about this ADR changes. In particular the single-`_request` seam
 still holds: the init-image upload is `multipart/form-data` built on the
 stdlib, inside `_request`, rather than a new HTTP dependency.
+
+## Amendment (2026-07-18) — the Negative Prompt is authored, not embedded
+
+Issue 50 overturns this ADR's "Patch only prompt + seed" and the amendment
+above's "the negative prompt remain[s] untouched in both operations". The patch
+set is now **prompt + negative prompt + seed + the sole `LoadImage`**.
+
+- **The Negative Prompt lives in `prompts/image-negative.txt`**, resolved under
+  `paths.prompts`, and is **required** — a missing file is a hard error, not a
+  fallback to the Workflow's authored value.
+- **It replaces, it does not append.** Whatever the Workflow authors on its
+  negative encoder is overwritten wholesale, exactly as the positive already
+  is. The point is that the effective Negative Prompt is readable in one
+  version-controlled file rather than being a function of a committed Workflow
+  and a gitignored per-machine one.
+- **One file serves both operations and both Environments.** ADR 0010's reason
+  for a Refinement dropping the positive preamble does not extend to a
+  constraint on output quality.
+- **An unpatchable negative is a hard error**, symmetric with the positive.
+  This rejects guidance-distilled Workflows that wire `negative` to a
+  `ConditioningZeroOut` — notably FLUX.1 schnell, named above as the
+  licensing-clean Cloud option. Neither shipped Environment does this today;
+  the first Workflow that needs it decides then, loudly, rather than us
+  shipping a silent skip that would hide real misconfigurations meanwhile.
+
+Model names, steps, cfg, and LoRAs remain untouched. The single `_request` seam
+and the stdlib-only constraint are unaffected.

--- a/v3/docs/adr/0009-comfyui-image-service.md
+++ b/v3/docs/adr/0009-comfyui-image-service.md
@@ -123,9 +123,10 @@ Issue 50 overturns this ADR's "Patch only prompt + seed" and the amendment
 above's "the negative prompt remain[s] untouched in both operations". The patch
 set is now **prompt + negative prompt + seed + the sole `LoadImage`**.
 
-- **The Negative Prompt lives in `prompts/image-negative.txt`**, resolved under
-  `paths.prompts`, and is **required** — a missing file is a hard error, not a
-  fallback to the Workflow's authored value.
+- **The Negative Prompt lives in `prompts/image-negative.txt`** and is
+  **required** — a missing file is a hard error, not a fallback to the
+  Workflow's authored value. (The amendment below makes that path configured
+  rather than hardcoded; the default is unchanged.)
 - **It replaces, it does not append.** Whatever the Workflow authors on its
   negative encoder is overwritten wholesale, exactly as the positive already
   is. The point is that the effective Negative Prompt is readable in one
@@ -143,3 +144,35 @@ set is now **prompt + negative prompt + seed + the sole `LoadImage`**.
 
 Model names, steps, cfg, and LoRAs remain untouched. The single `_request` seam
 and the stdlib-only constraint are unaffected.
+
+## Amendment (2026-07-18) — both prompt files are configured, not hardcoded
+
+Issue 50 first shipped the Negative Prompt as a hardcoded basename under
+`paths.prompts`, following the precedent of the positive preamble. Review
+rejected that precedent rather than extending it: **both** prompt files are now
+named by config, under `[assets.image]`.
+
+```toml
+[assets.image]
+prompt = "{paths.prompts}/image.txt"
+negative_prompt = "{paths.prompts}/image-negative.txt"
+```
+
+- **They follow the Workflow keys' pattern**, interpolating under a `paths.*`
+  root exactly as `ComfyUIEnvConfig.workflow` does under `paths.workflows`.
+  A prompt file and a Workflow file are the same kind of thing — an authored
+  input the Service reads by path — so they are configured the same way.
+- **They sit in `[assets.image]`, not in an Environment block**, because one
+  pair serves both Environments and both operations. Putting them per-Environment
+  would invite exactly the drift this issue set out to remove.
+- **Neither key has a default.** A missing one fails at config load, not at
+  generate time — the same bargain `refine_workflow` already makes.
+- **The positive was retrofitted for symmetry.** Making the negative
+  configurable while the positive stayed a string literal would have left the
+  more-edited of the two files the less-reachable one. This is scope beyond
+  issue 50, taken deliberately: the hardcoding had never been examined as a
+  decision, only inherited.
+
+The shipped default paths are unchanged, so no existing checkout moves a file.
+
+Nothing else about this ADR changes.

--- a/v3/docs/adr/0010-refinement-of-candidates.md
+++ b/v3/docs/adr/0010-refinement-of-candidates.md
@@ -135,3 +135,13 @@ Candidate twice reuses one server-side file rather than accumulating
   an already-promoted Asset (Refinement is closed over the candidates store);
   Refinement for the Lore and Model kinds (the protocol makes it possible,
   nothing implements it).
+
+## Amendment (2026-07-18) — the standing guardrail moved out of the Workflow
+
+Issue 50 makes the Negative Prompt a patched input, so "The negative prompt
+stays unpatched" above is no longer true. It remains a **standing guardrail**
+applied identically to every generation and Refinement — and a Correction is
+still always a positive statement, for exactly the reason given there. Only its
+home changed: it is authored in `prompts/image-negative.txt` rather than in
+each Workflow JSON, so tuning it is a one-file edit instead of a per-Workflow
+one. See [ADR 0009](0009-comfyui-image-service.md)'s fourth amendment.

--- a/v3/prompts/image-negative.txt
+++ b/v3/prompts/image-negative.txt
@@ -1,0 +1,4 @@
+low resolution, low quality, deformed limbs, deformed fingers,
+oversaturated, waxy skin, faces without detail, overly smooth,
+AI-generated look, chaotic composition,
+text, logos, warhammer, boardgame board

--- a/v3/prompts/image.txt
+++ b/v3/prompts/image.txt
@@ -1,4 +1,3 @@
 Environment: Detailed fantasy-steampunk for a tabletop wargame.
 Style: Painted concept-art, subject in action centered on a dimmed, war-torn background.
 Lighting: Dramatic.
-Do not include any text or logos.

--- a/v3/src/spf/assets/comfyui.py
+++ b/v3/src/spf/assets/comfyui.py
@@ -2,10 +2,11 @@
 
 Turns a composed prompt into `count` PNG blobs by submitting an authored
 ComfyUI **Workflow** (an API-format graph) to a configured **Environment**
-(local ComfyUI or Comfy Cloud). Only the positive prompt and a per-job seed are
-patched into the graph — plus, for a Refinement, the sole `LoadImage`'s
-filename; the model, steps, cfg, LoRAs, and negative prompt stay exactly as
-authored (see ADR 0009 and its amendment, and ADR 0010).
+(local ComfyUI or Comfy Cloud). Only the positive prompt, the Negative Prompt
+(read from `negative_path`), and a per-job seed are patched into the graph —
+plus, for a Refinement, the sole `LoadImage`'s filename; the model, steps, cfg,
+and LoRAs stay exactly as authored (see ADR 0009 and its amendments, and
+ADR 0010).
 
 All network I/O funnels through the single `_request` seam, so tests
 monkeypatch exactly that one function. Stdlib only — the prototype proved a
@@ -214,13 +215,41 @@ def _patch_init_image(graph: dict[str, Any], filename: str) -> None:
     graph[nid]["inputs"]["image"] = filename
 
 
-def _patch_prompt_and_seed(graph: dict[str, Any], *, prompt: str, seed: int) -> None:
-    """Patch only the positive prompt and the seed, by graph-follow.
+def _patch_text(
+    graph: dict[str, Any],
+    sampler_inputs: dict[str, Any],
+    slot: str,
+    text: str,
+) -> None:
+    """Follow the sampler's `slot` link and set the text node's prompt input.
+
+    `slot` is `positive` or `negative`; both are patched the same way, and an
+    encoder declaring neither of `PROMPT_KEYS` is an error either way (see
+    ADR 0009's fourth amendment).
+    """
+    link = sampler_inputs.get(slot)
+    if not isinstance(link, list):
+        msg = f"sampler's {slot!r} input is not a link to a text node"
+        raise ComfyUIError(msg)
+    node = graph[link[0]]
+    for key in PROMPT_KEYS:
+        if key in node["inputs"]:
+            node["inputs"][key] = text
+            return
+    klass = node["class_type"]
+    msg = f"{slot} node {klass} has no 'text' or 'prompt' input to patch"
+    raise ComfyUIError(msg)
+
+
+def _patch_prompts_and_seed(
+    graph: dict[str, Any], *, prompt: str, negative: str, seed: int
+) -> None:
+    """Patch only the two prompts and the seed, by graph-follow.
 
     Locates the sole sampler, patches its seed (following a linked primitive),
-    then follows its `positive` link to the text node and sets its prompt
-    input, whichever of `PROMPT_KEYS` that node declares.
-    Everything else — model, steps, cfg, LoRAs, negative — is left untouched.
+    then follows its `positive` and `negative` links to their text nodes and
+    sets each one's prompt input, whichever of `PROMPT_KEYS` that node
+    declares. Everything else — model, steps, cfg, LoRAs — is left untouched.
     Raises `ComfyUIError` on an unpatchable graph.
     """
     sid = _sole_node_of_class(graph, SAMPLER_CLASSES, what="sampler")
@@ -231,18 +260,8 @@ def _patch_prompt_and_seed(graph: dict[str, Any], *, prompt: str, seed: int) -> 
         msg = f"could not find a seed input on sampler {sid}"
         raise ComfyUIError(msg)
 
-    positive = inputs.get("positive")
-    if not isinstance(positive, list):
-        msg = "sampler's 'positive' input is not a link to a text node"
-        raise ComfyUIError(msg)
-    text_node = graph[positive[0]]["inputs"]
-    for key in PROMPT_KEYS:
-        if key in text_node:
-            text_node[key] = prompt
-            return
-    klass = graph[positive[0]]["class_type"]
-    msg = f"positive node {klass} has no 'text' or 'prompt' input to patch"
-    raise ComfyUIError(msg)
+    _patch_text(graph, inputs, "positive", prompt)
+    _patch_text(graph, inputs, "negative", negative)
 
 
 # --- Submit / poll / fetch ---------------------------------------------------
@@ -372,12 +391,13 @@ class ComfyUIService:
     auth header), so it can be exported after import.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913  one Environment's config, all keyword-only
         self,
         *,
         base_url: str,
         workflow_path: Path,
         refine_workflow_path: Path,
+        negative_path: Path,
         api_key_env: str,
         timeout_s: int,
     ) -> None:
@@ -386,10 +406,13 @@ class ComfyUIService:
         Every Environment names both Workflows, but `refine_workflow_path` may
         point at a file that does not exist — an Environment without an
         authored refine Workflow generates fine, and only fails, cleanly, if a
-        Refinement is actually run.
+        Refinement is actually run. `negative_path` is required, however: a
+        missing Negative Prompt file is an error, not a fall-through to the
+        Workflow's authored value (ADR 0009's fourth amendment).
         """
         self._base_url = base_url
         self._workflow_path = workflow_path
+        self._negative_path = negative_path
         self._api_key_env = api_key_env
         self._timeout_s = timeout_s
         self._refine_workflow_path = refine_workflow_path
@@ -413,9 +436,12 @@ class ComfyUIService:
         """Submit `count` jobs off `graph`, one per sub-seed, fetching as they land.
 
         The one place jobs are run: `generate` and `refine` differ only in the
-        Workflow they load and whether an init image was uploaded first.
+        Workflow they load and whether an init image was uploaded first. The
+        Negative Prompt is read once per batch, so a batch stays internally
+        consistent even if the file is edited mid-run.
         """
         api_key = self._api_key
+        negative = self._negative_path.read_text(encoding="utf-8").strip()
         rng = random.Random(seed)  # noqa: S311  image seeds, not cryptographic
         sub_seeds = [rng.randrange(_SEED_BOUND) for _ in range(count)]
 
@@ -425,7 +451,9 @@ class ComfyUIService:
             job_graph = json.loads(json.dumps(graph))  # per-job copy
             if init_filename is not None:
                 _patch_init_image(job_graph, init_filename)
-            _patch_prompt_and_seed(job_graph, prompt=prompt, seed=sub_seed)
+            _patch_prompts_and_seed(
+                job_graph, prompt=prompt, negative=negative, seed=sub_seed
+            )
             prompt_id = _submit(self._base_url, api_key, graph=job_graph)
             record, cached_route = _poll(
                 self._base_url,

--- a/v3/src/spf/assets/comfyui.py
+++ b/v3/src/spf/assets/comfyui.py
@@ -25,7 +25,7 @@ import urllib.request
 import uuid
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 SAMPLER_CLASSES = ("KSampler", "KSamplerAdvanced")
 _MAX_ATTEMPTS = 4  # one initial try plus three retries (from PollinationsService)
@@ -218,14 +218,13 @@ def _patch_init_image(graph: dict[str, Any], filename: str) -> None:
 def _patch_text(
     graph: dict[str, Any],
     sampler_inputs: dict[str, Any],
-    slot: str,
+    slot: Literal["positive", "negative"],
     text: str,
 ) -> None:
     """Follow the sampler's `slot` link and set the text node's prompt input.
 
-    `slot` is `positive` or `negative`; both are patched the same way, and an
-    encoder declaring neither of `PROMPT_KEYS` is an error either way (see
-    ADR 0009's fourth amendment).
+    Both slots are patched the same way, and an encoder declaring neither of
+    `PROMPT_KEYS` is an error either way (see ADR 0009's fourth amendment).
     """
     link = sampler_inputs.get(slot)
     if not isinstance(link, list):
@@ -236,8 +235,8 @@ def _patch_text(
         if key in node["inputs"]:
             node["inputs"][key] = text
             return
-    klass = node["class_type"]
-    msg = f"{slot} node {klass} has no 'text' or 'prompt' input to patch"
+    class_type = node["class_type"]
+    msg = f"{slot} node {class_type} has no 'text' or 'prompt' input to patch"
     raise ComfyUIError(msg)
 
 

--- a/v3/src/spf/assets/image.py
+++ b/v3/src/spf/assets/image.py
@@ -4,9 +4,9 @@ Registers the `image` `Kind`, laid out at
 `<race>/images/<name>.png`, backed by
 `ComfyUIService`. This module is pure wiring: it
 builds the service from the configured ComfyUI **Environment** — plus the
-shared Negative Prompt file, which is not per-Environment — and registers the
-Kind. The provider — one stdlib client across local ComfyUI and Comfy Cloud
-— lives in `spf.assets.comfyui` (see ADR 0009).
+configured Negative Prompt file, which is shared rather than per-Environment —
+and registers the Kind. The provider — one stdlib client across local ComfyUI
+and Comfy Cloud — lives in `spf.assets.comfyui` (see ADR 0009).
 """
 
 from spf.assets.comfyui import ComfyUIService
@@ -26,7 +26,7 @@ def _build_service() -> ComfyUIService:
         base_url=env.base_url,
         workflow_path=env.workflow,
         refine_workflow_path=env.refine_workflow,
-        negative_path=config.paths.prompts / "image-negative.txt",
+        negative_path=config.assets.image.negative_prompt,
         api_key_env=env.api_key_env,
         timeout_s=comfyui.timeout_s,
     )

--- a/v3/src/spf/assets/image.py
+++ b/v3/src/spf/assets/image.py
@@ -3,8 +3,9 @@
 Registers the `image` `Kind`, laid out at
 `<race>/images/<name>.png`, backed by
 `ComfyUIService`. This module is pure wiring: it
-builds the service from the configured ComfyUI **Environment** and registers
-the Kind. The provider — one stdlib client across local ComfyUI and Comfy Cloud
+builds the service from the configured ComfyUI **Environment** — plus the
+shared Negative Prompt file, which is not per-Environment — and registers the
+Kind. The provider — one stdlib client across local ComfyUI and Comfy Cloud
 — lives in `spf.assets.comfyui` (see ADR 0009).
 """
 
@@ -25,6 +26,7 @@ def _build_service() -> ComfyUIService:
         base_url=env.base_url,
         workflow_path=env.workflow,
         refine_workflow_path=env.refine_workflow,
+        negative_path=config.paths.prompts / "image-negative.txt",
         api_key_env=env.api_key_env,
         timeout_s=comfyui.timeout_s,
     )

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -8,6 +8,7 @@ subcommands accept, and the first concrete generate subcommand,
 
 import random
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated
 
 import cyclopts
@@ -36,6 +37,16 @@ def _validate_kind(_type: type, value: str) -> None:
 
 
 Kind = Annotated[str, cyclopts.Parameter(validator=_validate_kind)]
+
+
+def _negative_prompt_path() -> Path:
+    """Where the Image Service reads its Negative Prompt from (issue 50, D7).
+
+    Echoed by path, not by content: unlike the composed positive prompt it is
+    static and version-controlled, so naming the file keeps it discoverable
+    without scrolling the varying prompt off screen.
+    """
+    return config.paths.prompts / "image-negative.txt"
 
 
 def _validate_lineage(_type: type, value: str) -> None:
@@ -124,8 +135,13 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     stdout.print(f"Seed: {seed}  (rerun with --seed {seed} to reproduce)")
 
     # Show what is actually sent (dimmed), matching `image`; here it is just
-    # the Correction.
+    # the Correction. The Negative Prompt is an image concern, so name its file
+    # only when an image is what is being refined.
     stdout.print(correction, style="dim", markup=False)
+    if kind == "image":
+        stdout.print(
+            f"Negative: {_negative_prompt_path()}", style="dim", soft_wrap=True
+        )
 
     try:
         refine(
@@ -189,6 +205,7 @@ def image(
 
     # Show the composed prompt (dimmed) before sending it to the Service.
     stdout.print(prompt, style="dim", markup=False)
+    stdout.print(f"Negative: {_negative_prompt_path()}", style="dim", soft_wrap=True)
 
     try:
         generate(

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -8,7 +8,6 @@ subcommands accept, and the first concrete generate subcommand,
 
 import random
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Annotated
 
 import cyclopts
@@ -39,14 +38,20 @@ def _validate_kind(_type: type, value: str) -> None:
 Kind = Annotated[str, cyclopts.Parameter(validator=_validate_kind)]
 
 
-def _negative_prompt_path() -> Path:
-    """Where the Image Service reads its Negative Prompt from (issue 50, D7).
+def _negative_prompt_echo() -> str:
+    """Return the `Negative:` line naming where the Service reads it (D7).
 
     Echoed by path, not by content: unlike the composed positive prompt it is
     static and version-controlled, so naming the file keeps it discoverable
-    without scrolling the varying prompt off screen.
+    without scrolling the varying prompt off screen. Shown project-relative
+    (as `race.py` does) — short enough to read and to retype.
     """
-    return config.paths.prompts / "image-negative.txt"
+    path = config.assets.image.negative_prompt
+    try:
+        shown = str(path.relative_to(config.paths.project))
+    except ValueError:  # configured outside the project; absolute is all we have
+        shown = str(path)
+    return f"Negative: {shown}"
 
 
 def _validate_lineage(_type: type, value: str) -> None:
@@ -139,9 +144,7 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     # only when an image is what is being refined.
     stdout.print(correction, style="dim", markup=False)
     if kind == "image":
-        stdout.print(
-            f"Negative: {_negative_prompt_path()}", style="dim", soft_wrap=True
-        )
+        stdout.print(_negative_prompt_echo(), style="dim", soft_wrap=True)
 
     try:
         refine(
@@ -172,8 +175,9 @@ def image(
 ) -> None:
     """Generate image Candidates for a RACE, or a UNIT of it.
 
-    The prompt is composed from `prompts/image.txt` plus the target's name
-    and description; a target without a description is a hard error.
+    The prompt is composed from the configured preamble file
+    (`assets.image.prompt`, by default `prompts/image.txt`) plus the target's
+    name and description; a target without a description is a hard error.
     """
     opts = opts or AssetOpts()
 
@@ -197,7 +201,7 @@ def image(
         )
         raise SystemExit(1)
 
-    system = (config.paths.prompts / "image.txt").read_text(encoding="utf-8")
+    system = config.assets.image.prompt.read_text(encoding="utf-8")
     prompt = f"Subject: {human_name}.\nDetails: {description}\n{system}"
 
     count, seed = opts.resolve()
@@ -205,7 +209,7 @@ def image(
 
     # Show the composed prompt (dimmed) before sending it to the Service.
     stdout.print(prompt, style="dim", markup=False)
-    stdout.print(f"Negative: {_negative_prompt_path()}", style="dim", soft_wrap=True)
+    stdout.print(_negative_prompt_echo(), style="dim", soft_wrap=True)
 
     try:
         generate(

--- a/v3/src/spf/schemas/config.py
+++ b/v3/src/spf/schemas/config.py
@@ -64,9 +64,17 @@ class ComfyUIConfig(StrictModel):
 
 
 class ImageAssetConfig(StrictModel):
-    """Image asset settings: count plus the ComfyUI provider config."""
+    """Image asset settings: count, the two prompt files, and the provider.
+
+    Both prompt files are configured paths rather than hardcoded basenames,
+    following `ComfyUIEnvConfig`'s Workflow keys. They sit here and not in an
+    Environment block because one pair serves both Environments and both
+    operations (see ADR 0009's fifth amendment).
+    """
 
     count: int
+    prompt: Path
+    negative_prompt: Path
     comfyui: ComfyUIConfig
 
 

--- a/v3/tests/assets/fixtures/negative_prompt.txt
+++ b/v3/tests/assets/fixtures/negative_prompt.txt
@@ -1,0 +1,1 @@
+a negative prompt from the file

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -117,6 +117,17 @@ def test_refine_command_writes_candidates_under_the_lineage() -> None:
     assert (candidates / "grunt.2.txt").read_bytes() == b"the original"
 
 
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_omits_the_negative_prompt_line_for_a_non_image_kind(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # `refine` serves every Kind; the Negative Prompt is an image concern, so
+    # naming its file during a lore or model refinement would be a lie.
+    app(_refine_argv("--count", "1"), exit_on_error=False, result_action="return_value")
+
+    assert "image-negative.txt" not in capsys.readouterr().out
+
+
 def test_refine_command_passes_the_correction_verbatim(
     refinable_registered_kind: Kind,
 ) -> None:

--- a/v3/tests/assets/test_comfyui.py
+++ b/v3/tests/assets/test_comfyui.py
@@ -297,6 +297,20 @@ def test_rejects_a_non_text_negative_input(
         service.generate("prompt", 1, seed=7)
 
 
+def test_requires_the_negative_prompt_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A missing file is an error, not a fall-through to the Workflow's
+    # authored negative (issue 50, D3).
+    scripted = _ScriptedComfy()
+    service = _service(scripted, monkeypatch, negative_path=tmp_path / "absent.txt")
+
+    with pytest.raises(FileNotFoundError):
+        service.generate("prompt", 1, seed=7)
+
+    assert scripted.submissions == []  # nothing was queued
+
+
 def test_patches_an_encoder_that_names_its_input_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/v3/tests/assets/test_comfyui.py
+++ b/v3/tests/assets/test_comfyui.py
@@ -267,6 +267,36 @@ def test_rejects_a_non_text_positive_input(
         service.generate("prompt", 1, seed=7)
 
 
+def test_rejects_a_sampler_with_no_negative_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Having made the Negative Prompt required, silently discarding it is the
+    # worst outcome (issue 50, D4).
+    graph = json.loads(_MINI.read_text(encoding="utf-8"))
+    del graph[_SAMPLER]["inputs"]["negative"]
+    service = _service_for(
+        graph, tmp_path, scripted=_ScriptedComfy(), monkeypatch=monkeypatch
+    )
+
+    with pytest.raises(comfyui.ComfyUIError, match="'negative' input is not a link"):
+        service.generate("prompt", 1, seed=7)
+
+
+def test_rejects_a_non_text_negative_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A guidance-distilled Workflow wires `negative` to a `ConditioningZeroOut`;
+    # that is rejected loudly rather than silently skipped (issue 50, D4).
+    graph = json.loads(_MINI.read_text(encoding="utf-8"))
+    graph[_NEGATIVE_NODE] = {"class_type": "ConditioningZeroOut", "inputs": {}}
+    service = _service_for(
+        graph, tmp_path, scripted=_ScriptedComfy(), monkeypatch=monkeypatch
+    )
+
+    with pytest.raises(comfyui.ComfyUIError, match="negative node ConditioningZeroOut"):
+        service.generate("prompt", 1, seed=7)
+
+
 def test_patches_an_encoder_that_names_its_input_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/v3/tests/assets/test_comfyui.py
+++ b/v3/tests/assets/test_comfyui.py
@@ -25,11 +25,14 @@ from spf.assets import comfyui
 _FIXTURES = Path(__file__).parent / "fixtures"
 _MINI = _FIXTURES / "mini_workflow.json"
 _MINI_REFINE = _FIXTURES / "mini_refine_workflow.json"
+_NEGATIVE = _FIXTURES / "negative_prompt.txt"
+_NEGATIVE_TEXT = "a negative prompt from the file"
 _PNG = b"\x89PNG\r\n\x1a\n"
 
-# The fixture's KSampler and positive text node (see mini_workflow.json).
+# The fixture's KSampler and positive/negative text nodes (mini_workflow.json).
 _SAMPLER = "5"
 _POSITIVE = "2"
+_NEGATIVE_NODE = "3"
 
 
 def _one_image_outputs(name: str = "spf_00001_.png") -> dict[str, Any]:
@@ -124,6 +127,7 @@ def _service(
         "base_url": "http://server",
         "workflow_path": _MINI,
         "refine_workflow_path": _MINI_REFINE,
+        "negative_path": _NEGATIVE,
         "api_key_env": "",
         "timeout_s": 5,
     }
@@ -185,8 +189,9 @@ def test_patches_prompt_onto_positive_leaving_the_rest_authored(
     expected = random.Random(7).randrange(2**31)  # noqa: S311  independent truth
     assert graph[_SAMPLER]["inputs"]["seed"] == expected  # seed on the sampler
     assert graph[_POSITIVE]["inputs"]["text"] == "a brass rat soldier"
+    # The authored negative is replaced wholesale by the file's (issue 50, D1).
+    assert graph[_NEGATIVE_NODE]["inputs"]["text"] == _NEGATIVE_TEXT
     # Everything else stays exactly as authored (Decision 4).
-    assert graph["3"]["inputs"]["text"] == "a placeholder negative prompt"
     assert graph[_SAMPLER]["inputs"]["steps"] == 20
     assert graph[_SAMPLER]["inputs"]["cfg"] == 7.0
     assert graph["1"]["inputs"]["ckpt_name"] == "model.safetensors"
@@ -198,9 +203,10 @@ def test_follows_a_linked_seed_primitive(
     graph = {
         "s": {
             "class_type": "KSampler",
-            "inputs": {"seed": ["p", 0], "positive": ["t", 0]},
+            "inputs": {"seed": ["p", 0], "positive": ["t", 0], "negative": ["n", 0]},
         },
         "t": {"class_type": "CLIPTextEncode", "inputs": {"text": "placeholder"}},
+        "n": {"class_type": "CLIPTextEncode", "inputs": {"text": "placeholder"}},
         "p": {"class_type": "PrimitiveInt", "inputs": {"value": 0}},
     }
     scripted = _ScriptedComfy()
@@ -269,9 +275,13 @@ def test_patches_an_encoder_that_names_its_input_prompt(
     graph = {
         "s": {
             "class_type": "KSampler",
-            "inputs": {"seed": 0, "positive": ["t", 0]},
+            "inputs": {"seed": 0, "positive": ["t", 0], "negative": ["n", 0]},
         },
         "t": {
+            "class_type": "TextEncodeQwenImageEditPlus",
+            "inputs": {"prompt": "placeholder", "clip": ["c", 0]},
+        },
+        "n": {
             "class_type": "TextEncodeQwenImageEditPlus",
             "inputs": {"prompt": "placeholder", "clip": ["c", 0]},
         },
@@ -283,6 +293,7 @@ def test_patches_an_encoder_that_names_its_input_prompt(
 
     _, submitted = scripted.submissions[0]
     assert submitted["t"]["inputs"]["prompt"] == "make the hat brass instead of leather"
+    assert submitted["n"]["inputs"]["prompt"] == _NEGATIVE_TEXT
 
 
 # --- Cycle 3: happy-path flow (N blobs, in order) ---------------------------
@@ -475,6 +486,7 @@ def test_generate_raises_on_failed_status_carrying_node_errors(
         base_url="http://x",
         workflow_path=_MINI,
         refine_workflow_path=_MINI_REFINE,
+        negative_path=_NEGATIVE,
         api_key_env="",
         timeout_s=5,
     )
@@ -508,6 +520,7 @@ def test_generate_raises_on_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
         base_url="http://x",
         workflow_path=_MINI,
         refine_workflow_path=_MINI_REFINE,
+        negative_path=_NEGATIVE,
         api_key_env="",
         timeout_s=1,
     )
@@ -611,8 +624,9 @@ def test_refine_patches_the_correction_verbatim_as_the_positive_prompt(
     assert graph[_REFINE_POSITIVE]["inputs"]["prompt"] == correction
     expected = random.Random(7).randrange(2**31)  # noqa: S311  independent truth
     assert graph["9"]["inputs"]["seed"] == expected
-    # The standing guardrail and the authored stack are left alone.
-    assert graph["7"]["inputs"]["prompt"] == "a placeholder negative prompt"
+    # One Negative Prompt file serves both operations (issue 50, D2).
+    assert graph["7"]["inputs"]["prompt"] == _NEGATIVE_TEXT
+    # The authored stack is left alone.
     assert graph["1"]["inputs"]["unet_name"] == "edit-model.safetensors"
     assert graph["9"]["inputs"]["steps"] == 4
 

--- a/v3/tests/assets/test_config.py
+++ b/v3/tests/assets/test_config.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from spf.config import config
-from spf.schemas.config import ComfyUIConfig, ComfyUIEnvConfig
+from spf.schemas.config import ComfyUIConfig, ComfyUIEnvConfig, ImageAssetConfig
 
 
 def test_paths_resolve() -> None:
@@ -14,6 +14,23 @@ def test_paths_resolve() -> None:
     assert isinstance(config.paths.assets, Path)
     assert isinstance(config.paths.prompts, Path)
     assert isinstance(config.paths.workflows, Path)
+
+
+def test_image_prompt_paths_resolve() -> None:
+    # Both prompt files are configured paths, not hardcoded basenames, and
+    # interpolate under `paths.prompts` the way the Workflows do under
+    # `paths.workflows` (ADR 0009's fifth amendment).
+    image = config.assets.image
+    assert image.prompt.parent == config.paths.prompts
+    assert image.negative_prompt.parent == config.paths.prompts
+
+
+def test_image_asset_requires_both_prompt_paths() -> None:
+    # Neither key has a default: a missing one fails at load, not at generate.
+    with pytest.raises(ValidationError, match="negative_prompt"):
+        ImageAssetConfig(  # pyright: ignore[reportCallIssue]  the omission is the point
+            count=3, prompt=Path("image.txt"), comfyui=config.assets.image.comfyui
+        )
 
 
 def _env(**kw: str) -> ComfyUIEnvConfig:

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -184,6 +184,8 @@ def test_build_service_points_at_the_selected_env(
     # uses the same Environment's authored edit graph.
     refine = config.paths.workflows / cu.cloud.refine_workflow
     assert service._refine_workflow_path == refine
+    # The Negative Prompt file is shared, not per-Environment (issue 50, D2).
+    assert service._negative_path == config.paths.prompts / "image-negative.txt"
 
 
 def test_build_service_rejects_an_unknown_env(

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -25,7 +25,7 @@ _MINI = _FIXTURES / "mini_workflow.json"
 _MINI_REFINE = _FIXTURES / "mini_refine_workflow.json"
 _PNG = b"\x89PNG\r\n\x1a\n"
 _POSITIVE = "2"  # the positive text node in mini_workflow.json
-_NEGATIVE = "3"  # the negative text node in mini_workflow.json
+_NEGATIVE_NODE = "3"  # the negative text node in mini_workflow.json
 _SAMPLER = "5"  # the KSampler in mini_workflow.json
 _NEGATIVE_TEXT = "blurry, watermarked"
 
@@ -142,12 +142,19 @@ def _make_env(
     (races / "gnome.toml").write_text(_GNOME_TOML, encoding="utf-8")
     prompts = tmp_path / "prompts"
     prompts.mkdir()
-    (prompts / "image.txt").write_text("Preamble one.\ntwo.\n", encoding="utf-8")
-    (prompts / "image-negative.txt").write_text(_NEGATIVE_TEXT, encoding="utf-8")
+    positive = prompts / "image.txt"
+    negative = prompts / "image-negative.txt"
+    positive.write_text("Preamble one.\ntwo.\n", encoding="utf-8")
+    negative.write_text(_NEGATIVE_TEXT, encoding="utf-8")
     monkeypatch.setattr(config.paths, "races", races)
     monkeypatch.setattr(config.paths, "prompts", prompts)
+    monkeypatch.setattr(config.paths, "project", tmp_path)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
     monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    # Both prompt files are configured paths now, so the CLI reads them from
+    # here rather than from `paths.prompts` plus a hardcoded basename.
+    monkeypatch.setattr(config.assets.image, "prompt", positive)
+    monkeypatch.setattr(config.assets.image, "negative_prompt", negative)
 
     comfy = _FakeRequest(fail=fail)
     monkeypatch.setattr(comfyui, "_request", comfy)
@@ -155,11 +162,9 @@ def _make_env(
     # committed fixture so the flow runs without a per-machine local.json.
     monkeypatch.setattr(img.IMAGE.service, "_workflow_path", _MINI)
     monkeypatch.setattr(img.IMAGE.service, "_refine_workflow_path", _MINI_REFINE)
-    # Likewise the Negative Prompt: the service bound the real repo path at
+    # Likewise the Negative Prompt: the service bound the configured path at
     # import, so aim it at this project's own file.
-    monkeypatch.setattr(
-        img.IMAGE.service, "_negative_path", prompts / "image-negative.txt"
-    )
+    monkeypatch.setattr(img.IMAGE.service, "_negative_path", negative)
     return _ImageEnv(tmp_path, comfy)
 
 
@@ -198,8 +203,9 @@ def test_build_service_points_at_the_selected_env(
     # uses the same Environment's authored edit graph.
     refine = config.paths.workflows / cu.cloud.refine_workflow
     assert service._refine_workflow_path == refine
-    # The Negative Prompt file is shared, not per-Environment (issue 50, D2).
-    assert service._negative_path == config.paths.prompts / "image-negative.txt"
+    # The Negative Prompt file is shared, not per-Environment (issue 50, D2),
+    # so it comes off `assets.image` rather than the Environment block.
+    assert service._negative_path == config.assets.image.negative_prompt
 
 
 def test_build_service_rejects_an_unknown_env(
@@ -226,8 +232,9 @@ def test_cli_unit_image_writes_candidates(
     assert "5" in out  # the seed is printed
     # The composed prompt is echoed before the request goes out.
     assert "A stout ogre grunt hefting a huge wrench" in out
-    # The Negative Prompt is static, so only its path is named (issue 50, D7).
-    assert "image-negative.txt" in out
+    # The Negative Prompt is static, so only its path is named — project-
+    # relative, short enough to read and to retype (issue 50, D7).
+    assert "Negative: prompts/image-negative.txt" in out
     # Each Candidate's path is reported as it lands (one "Wrote" per image).
     assert out.count("Wrote ") == 3
     assert "ogre_grunt.1.png" in out
@@ -239,7 +246,9 @@ def test_cli_unit_image_patches_the_authored_negative_prompt(
 ) -> None:
     _run("assets", "image", "ogre", "ogre_grunt", "--seed", "5")
 
-    negatives = [g[_NEGATIVE]["inputs"]["text"] for g in image_env.comfy.submissions]
+    negatives = [
+        g[_NEGATIVE_NODE]["inputs"]["text"] for g in image_env.comfy.submissions
+    ]
     assert negatives == [_NEGATIVE_TEXT] * 3  # every job in the batch
 
 
@@ -263,7 +272,7 @@ def test_cli_refine_image_names_the_negative_prompt_file(
         "1",
     )
 
-    assert "image-negative.txt" in capsys.readouterr().out
+    assert "Negative: prompts/image-negative.txt" in capsys.readouterr().out
 
 
 def test_cli_unit_image_prompt_composes_preamble_name_description(

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -22,9 +22,12 @@ from spf.frontends.cli import app
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 _MINI = _FIXTURES / "mini_workflow.json"
+_MINI_REFINE = _FIXTURES / "mini_refine_workflow.json"
 _PNG = b"\x89PNG\r\n\x1a\n"
 _POSITIVE = "2"  # the positive text node in mini_workflow.json
+_NEGATIVE = "3"  # the negative text node in mini_workflow.json
 _SAMPLER = "5"  # the KSampler in mini_workflow.json
+_NEGATIVE_TEXT = "blurry, watermarked"
 
 _OGRE_TOML = """\
 [races.ogre]
@@ -88,9 +91,13 @@ class _FakeRequest:
         *,
         api_key: str | None = None,  # noqa: ARG002  unused in this fake
         body: dict[str, Any] | None = None,
+        upload: tuple[str, bytes] | None = None,
         raw: bool = False,
         timeout: float = 120,  # noqa: ARG002  part of the seam signature; unused
     ) -> Any:  # noqa: ANN401  mirrors _request's dynamic return
+        if path == "/api/upload/image":  # a Refinement uploads its init image
+            assert upload is not None
+            return {"name": upload[0], "subfolder": "", "type": "input"}
         if path == "/api/prompt":
             self._counter += 1
             assert body is not None
@@ -136,6 +143,7 @@ def _make_env(
     prompts = tmp_path / "prompts"
     prompts.mkdir()
     (prompts / "image.txt").write_text("Preamble one.\ntwo.\n", encoding="utf-8")
+    (prompts / "image-negative.txt").write_text(_NEGATIVE_TEXT, encoding="utf-8")
     monkeypatch.setattr(config.paths, "races", races)
     monkeypatch.setattr(config.paths, "prompts", prompts)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
@@ -146,6 +154,12 @@ def _make_env(
     # The wired service points at the (gitignored) real workflow; aim it at the
     # committed fixture so the flow runs without a per-machine local.json.
     monkeypatch.setattr(img.IMAGE.service, "_workflow_path", _MINI)
+    monkeypatch.setattr(img.IMAGE.service, "_refine_workflow_path", _MINI_REFINE)
+    # Likewise the Negative Prompt: the service bound the real repo path at
+    # import, so aim it at this project's own file.
+    monkeypatch.setattr(
+        img.IMAGE.service, "_negative_path", prompts / "image-negative.txt"
+    )
     return _ImageEnv(tmp_path, comfy)
 
 
@@ -212,10 +226,44 @@ def test_cli_unit_image_writes_candidates(
     assert "5" in out  # the seed is printed
     # The composed prompt is echoed before the request goes out.
     assert "A stout ogre grunt hefting a huge wrench" in out
+    # The Negative Prompt is static, so only its path is named (issue 50, D7).
+    assert "image-negative.txt" in out
     # Each Candidate's path is reported as it lands (one "Wrote" per image).
     assert out.count("Wrote ") == 3
     assert "ogre_grunt.1.png" in out
     assert "spf assets promote ogre image ogre_grunt --pick" in out
+
+
+def test_cli_unit_image_patches_the_authored_negative_prompt(
+    image_env: _ImageEnv,
+) -> None:
+    _run("assets", "image", "ogre", "ogre_grunt", "--seed", "5")
+
+    negatives = [g[_NEGATIVE]["inputs"]["text"] for g in image_env.comfy.submissions]
+    assert negatives == [_NEGATIVE_TEXT] * 3  # every job in the batch
+
+
+def test_cli_refine_image_names_the_negative_prompt_file(
+    image_env: _ImageEnv, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidates = image_env.candidates / "ogre" / "images"
+    candidates.mkdir(parents=True)
+    (candidates / "ogre_grunt.2.png").write_bytes(_PNG)
+
+    _run(
+        "assets",
+        "refine",
+        "ogre",
+        "image",
+        "ogre_grunt",
+        "--from",
+        "2",
+        "make the hat brass",
+        "--count",
+        "1",
+    )
+
+    assert "image-negative.txt" in capsys.readouterr().out
 
 
 def test_cli_unit_image_prompt_composes_preamble_name_description(


### PR DESCRIPTION
Closes #50.

Moves the Negative Prompt out of the Workflow JSONs and into
`prompts/image-negative.txt`, where it is version-controlled and visible in one
place. `ComfyUIService` patches it into the graph at call time, exactly as it
already patches the positive prompt and seed.

## What changed

- `_patch_text` factors out the `text`/`prompt` encoder-key probe; both the
  positive and negative slots now go through it.
- `ComfyUIService` takes a `negative_path` and reads it **once per batch**, so
  `generate` and `refine` are served by the one file.
- The file is **required** (a missing one is a `FileNotFoundError`, not a
  fallback) and **replaces** whatever the Workflow authored.
- An unpatchable negative is a hard error, symmetric with the positive.
- `prompts/image.txt` loses `Do not include any text or logos.` — its job moves
  to the negative file.
- Docs: a fourth amendment to ADR 0009, a matching one to ADR 0010, and
  corrections to `CONTEXT.md`'s `Workflow` and `Correction` entries.

The Workflow JSONs keep their now-inert authored negatives, as planned — the
same treatment `cloud.json`'s stale positive already gets.

## Two deviations from the plan, both deliberate

**The `refine` echo is gated on the image Kind.** The plan (§3.3) had
`refine_asset` printing `Negative: <path>` unconditionally, but that command
serves every Kind — it would have printed an image-specific line during a lore
or model refinement. Gated on `kind == "image"` after checking with the owner.
`image` still echoes unconditionally, since it is image-only by construction.

**The image test env is now hermetic.** `_make_env` monkeypatches
`config.paths.prompts` to a tmp dir, but the Service binds its negative path at
import, so the CLI tests were reading the *real* repo `prompts/` file. It now
writes its own and points the Service at it.

## Please eyeball before promoting anything

Per D5, the seeded file is an **English translation** of the Chinese string all
three Workflows carried. That Chinese string is the only negative validated
against Qwen-Image, and ADR 0009 renounces cross-environment reproducibility,
so there is no cheap A/B for this substitution. Worth a look at a fresh batch
before promoting any Candidate generated under it.

`just check` passes except for a pre-existing typo in `races/elf.toml`
("side ot the") that is unrelated to this branch and present on `master`.
Generation was not exercised against a live ComfyUI — no local instance here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHUHE5fzo1Dce9ECUKj2WS