### PR TITLE
Add `spf assets list` (asset coverage survey)

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -256,3 +256,27 @@ The dotted 1-based Candidate index (`2`, `2.1`, `2.1.3`) recording derivation:
 straight off the filename, so no provenance is recorded anywhere else. The
 coordinate both `refine --from` and `promote --pick` take.
 _Avoid_: version, revision, generation, history
+
+**Target**:
+The thing an Asset depicts — a Race, a Unit, or a Model. Which of those a given
+Kind applies to is declared by the Kind itself (Lore targets a Race only; an
+Image targets a Race or a Unit). The name that addresses a Target on the command
+line is the same key `promote` and `refine` take.
+_Avoid_: subject, referent
+
+**Survey**:
+The result of checking one Kind's Targets for one Race against the two stores:
+which have an Asset, which have Candidates waiting, and which files match no
+Target. Derived on demand, never stored.
+_Avoid_: inventory (a Survey is driven by what *should* exist, not by what is on
+disk), report, census
+
+**Coverage**:
+One Target's line in a Survey: whether its Asset exists, and its Candidates.
+_Avoid_: status, entry
+
+**Orphan**:
+A file in the Asset or Candidate store matching no Target of its Kind — usually
+a Target renamed in TOML after generation, or a typo. Surfaced under the
+`Unknown` heading rather than silently ignored.
+_Avoid_: stray, dangling

--- a/v3/docs/adr/0011-coverage-survey-of-assets.md
+++ b/v3/docs/adr/0011-coverage-survey-of-assets.md
@@ -69,7 +69,11 @@ and makes the pure half trivially testable.
   section exists so this is visible rather than silent — it is how the real
   `gigant_snake_cavalry.png` typo surfaced.
 - **Coverage of a Race whose TOML fails to validate is not reported at all**,
-  per ADR 0004: `list_races(validate=True)`, silent omission.
-- `list` **always exits 0.** A missing Asset is a normal state, not a failure.
+  per ADR 0004: `list_races(validate=True)`, silent omission. Silence is right
+  for the sweep, but *naming* such a Race is a request that cannot be answered,
+  so the explicit path reports it on stderr and exits 1 rather than raising a
+  `ValidationError` traceback.
+- `list` **exits 0 whenever it reports coverage.** A missing Asset is a normal
+  state, not a failure; only an unanswerable request exits non-zero.
 - **Out of scope:** fuzzy "did you mean" suggestions on Orphans; status filters
   (`--missing` / `--promoted`) on `list`.

--- a/v3/docs/adr/0011-coverage-survey-of-assets.md
+++ b/v3/docs/adr/0011-coverage-survey-of-assets.md
@@ -1,0 +1,75 @@
+# Asset listing reports coverage, driven by a Kind-declared Target set
+
+ADR 0008 settled curation as a generate → refine → promote loop. What it left
+open is how a curator finds the next thing to work on. With 8 races, 101
+**Targets** and 19 committed Assets, "what's left?" is not answerable by
+looking at the filesystem — the missing things are, by definition, not there.
+
+```console
+$ spf assets list goblin
+Goblin
+  Image
+  - goblin                   Goblin                   missing
+  - goblin_infantry          Goblin Infantry          ✓
+  - giant_snake_cavalry      Giant Snake Cavalry      missing
+  …
+  Unknown
+  - gigant_snake_cavalry.png
+```
+
+## Coverage, not inventory
+
+**Decision: the Race TOML drives the rows; the filesystem annotates them.**
+
+A directory listing answers "what files do I have?", which `ls` already does.
+The curator's question is the complement — which Targets have nothing yet — and
+that is only answerable from the source of truth for what *should* exist. So
+`spf assets list` walks the Targets a Kind declares for a Race and checks each
+against the two stores, rather than walking the stores and reporting what it
+finds.
+
+This inverts `race things`: the **key** is the primary column and the human
+name is dimmed beside it, because a coverage row exists to be copied into the
+next `spf assets image` or `promote` command.
+
+Rejected: a filesystem inventory (cannot answer "what's missing", and a Target
+renamed in TOML looks like a covered Target rather than a problem); a summary
+count per race (the owner explicitly chose full detail — ~120 lines, ~82%
+`missing` — because the detail *is* the worklist).
+
+## The Target set is declared per Kind
+
+**Decision: a `Kind.targets` field, `frozenset[TargetLevel]`, alongside
+`subdir` and `extension`.** Image declares `{"race", "unit"}`; Lore will
+declare `{"race"}` and Model `{"unit", "model"}` when they register.
+
+The `Kind` record already holds the layout knowledge that varies per kind, and
+which levels a kind depicts is exactly that sort of fact. Declaring it there
+means the listing code, and the `--all` / `--missing` selectors built on the
+same seam, never change when a Kind lands.
+
+The field is **required, with no default**. A registry field that silently
+defaults is one a future Kind author forgets to set, and the failure mode is a
+Kind that reports coverage of the wrong things.
+
+Rejected: hardcoding the race/unit fork in the listing command (would need
+rewriting the moment `model` registers, and inverts the registry's purpose).
+
+## Two seams, split on whether they touch disk
+
+**Decision: `targets()` is pure TOML; `survey()` touches the filesystem.**
+
+`spf assets image --all` needs the Target set but has no business scanning the
+Asset store to get it. Splitting the two keeps that path free of disk access
+and makes the pure half trivially testable.
+
+## Consequences
+
+- **A Target renamed in TOML strands its files as Orphans.** The `Unknown`
+  section exists so this is visible rather than silent — it is how the real
+  `gigant_snake_cavalry.png` typo surfaced.
+- **Coverage of a Race whose TOML fails to validate is not reported at all**,
+  per ADR 0004: `list_races(validate=True)`, silent omission.
+- `list` **always exits 0.** A missing Asset is a normal state, not a failure.
+- **Out of scope:** fuzzy "did you mean" suggestions on Orphans; status filters
+  (`--missing` / `--promoted`) on `list`.

--- a/v3/docs/adr/0011-coverage-survey-of-assets.md
+++ b/v3/docs/adr/0011-coverage-survey-of-assets.md
@@ -9,9 +9,9 @@ looking at the filesystem — the missing things are, by definition, not there.
 $ spf assets list goblin
 Goblin
   Image
-  - goblin                   Goblin                   missing
+  - goblin                   Goblin                   ✗
   - goblin_infantry          Goblin Infantry          ✓
-  - giant_snake_cavalry      Giant Snake Cavalry      missing
+  - giant_snake_cavalry      Giant Snake Cavalry      ✗
   …
   Unknown
   - gigant_snake_cavalry.png
@@ -35,7 +35,7 @@ next `spf assets image` or `promote` command.
 Rejected: a filesystem inventory (cannot answer "what's missing", and a Target
 renamed in TOML looks like a covered Target rather than a problem); a summary
 count per race (the owner explicitly chose full detail — ~120 lines, ~82%
-`missing` — because the detail *is* the worklist).
+uncovered — because the detail *is* the worklist).
 
 ## The Target set is declared per Kind
 

--- a/v3/docs/adr/0012-hash-recovered-promotion-provenance.md
+++ b/v3/docs/adr/0012-hash-recovered-promotion-provenance.md
@@ -1,0 +1,48 @@
+# Promotion provenance is recovered by digest, not recorded
+
+A Survey (ADR 0011) can say a Target has an Asset and three Candidates waiting.
+The question it cannot answer from filenames alone is the one that stops a
+curator re-picking what they already picked: *which* of those Candidates is the
+Asset?
+
+```console
+$ spf assets list goblin --candidates
+  - goblin_infantry          Goblin Infantry          ✓        7 candidates
+      1  2  2.1  3  4  4.1←promoted  4.3
+```
+
+## Compare digests at display time
+
+**Decision: derive provenance by hashing, rather than recording it at promote
+time.**
+
+`CONTEXT.md` states plainly that Lineage reads off the filename and *no
+provenance is recorded anywhere else* (ADR 0010). `promote` is a
+`shutil.copyfile`, so the Asset is byte-identical to the Candidate it came
+from — the fact is already on disk, just not written down. Deriving it keeps
+that documented statement true, invents no sidecar or manifest format, and
+leaves the promote path untouched.
+
+Rejected: a provenance sidecar written at promote time (survives candidate
+cleanup, but contradicts a documented decision and expands the one path that
+must stay a copy); reporting nothing (simplest, but leaves the single most
+actionable signal on the floor).
+
+## All matches are reported, never one guessed
+
+**Decision: when several Candidates are byte-identical to the Asset, show every
+one.**
+
+Seeds are deterministic, so a re-run with the same seed produces identical
+bytes under a different Lineage. Picking one to display would be a coin flip
+presented as a fact. Showing both is honest about what the digest can and
+cannot establish.
+
+## Consequences
+
+- **Provenance degrades to a plain `✓` once Candidates are cleaned.** It is a
+  convenience, never an authority — nothing else may depend on it.
+- **Cost is hashing the Candidate store**, so it runs only under
+  `--candidates`. The default listing never hashes a file.
+- Because `candidates/` is gitignored, this output is machine-dependent by
+  design.

--- a/v3/docs/agents/cli.md
+++ b/v3/docs/agents/cli.md
@@ -26,10 +26,19 @@ Generating, refining, and promoting Assets. Candidates are addressed by
 **Lineage** — a dotted 1-based index that both `--from` and `--pick` take.
 
 ```console
+# What's left? One row per Target, with its Asset status and Candidate count.
+# Omit the race to cover every validating race; --kind narrows to one kind.
+uv run spf assets list goblin
+uv run spf assets list goblin --candidates   # expand rows into Lineages
+
 # Generate Candidates for a race, or one unit of it (--count, --seed)
 uv run spf assets image goblin
 uv run spf assets image goblin goblin_infantry
 # -> candidates/goblin/images/goblin_infantry.{1,2,3}.png
+
+# Cover several Targets at once. At most one selector may be given.
+uv run spf assets image goblin --all       # the race and every unit
+uv run spf assets image goblin --missing   # every Target with no Asset yet
 
 # Refine one Candidate by applying a Correction to it. The Correction is the
 # whole prompt, verbatim; results land under the derived name <NAME>.<LINEAGE>.

--- a/v3/races/abomination.toml
+++ b/v3/races/abomination.toml
@@ -320,7 +320,7 @@ name = "Shriek Monstrosity"
 models = ["shriek_monstrosity"]
 size = "Large"
 cost.xp = 24
-description = '''A flying monstros bird scaring the enemy with a deadly scream.
+description = '''A flying monstrous bird scaring the enemy with a deadly scream.
 '''
 
 

--- a/v3/races/elf.toml
+++ b/v3/races/elf.toml
@@ -595,7 +595,7 @@ cost.mp = 16
 cost.xp = 24
 cost.cp = 24
 armor = [3, 3, 0, 0]
-description = ''' Pachyephalosourus is a two legged dinaosour. On the pachephalosourus there is an elegant elf wielding an smg. On the sides of the pachephalosourus there are two cannons, on on each side ot the Pachyephalosourus'''
+description = ''' Pachyephalosourus is a two legged dinaosour. On the pachephalosourus there is an elegant elf wielding an smg. On the sides of the pachephalosourus there are two cannons, one on each side of the Pachyephalosourus'''
 
 
 [units.pachyephalosaurus_riders.special]

--- a/v3/src/spf/assets/__init__.py
+++ b/v3/src/spf/assets/__init__.py
@@ -8,17 +8,28 @@ records (`Kind`, `Service`) rather than per-kind code. The seams are
 `register_kind`.
 """
 
-from spf.assets.kinds import Kind, Refiner, Service, get_kind, register_kind
+from spf.assets.kinds import (
+    Kind,
+    Refiner,
+    Service,
+    TargetLevel,
+    get_kind,
+    register_kind,
+)
 from spf.assets.spine import generate, promote, refine, validate_lineage
+from spf.assets.targets import Target, targets
 
 __all__ = [
     "Kind",
     "Refiner",
     "Service",
+    "Target",
+    "TargetLevel",
     "generate",
     "get_kind",
     "promote",
     "refine",
     "register_kind",
+    "targets",
     "validate_lineage",
 ]

--- a/v3/src/spf/assets/__init__.py
+++ b/v3/src/spf/assets/__init__.py
@@ -17,12 +17,15 @@ from spf.assets.kinds import (
     register_kind,
 )
 from spf.assets.spine import generate, promote, refine, validate_lineage
+from spf.assets.survey import Coverage, Survey, survey
 from spf.assets.targets import Target, targets
 
 __all__ = [
+    "Coverage",
     "Kind",
     "Refiner",
     "Service",
+    "Survey",
     "Target",
     "TargetLevel",
     "generate",
@@ -30,6 +33,7 @@ __all__ = [
     "promote",
     "refine",
     "register_kind",
+    "survey",
     "targets",
     "validate_lineage",
 ]

--- a/v3/src/spf/assets/image.py
+++ b/v3/src/spf/assets/image.py
@@ -36,5 +36,6 @@ IMAGE = register_kind(
         service=_build_service(),
         subdir="images",
         extension="png",
+        targets=frozenset({"race", "unit"}),
     )
 )

--- a/v3/src/spf/assets/kinds.py
+++ b/v3/src/spf/assets/kinds.py
@@ -11,7 +11,9 @@ issue registers its own.
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
+
+TargetLevel = Literal["race", "unit", "model"]
 
 
 class Service(Protocol):
@@ -73,6 +75,8 @@ class Kind:
     service: Service
     subdir: str | None
     extension: str
+    targets: frozenset[TargetLevel]
+    """The levels this Kind can depict: an Image targets a Race or a Unit."""
 
 
 KINDS: dict[str, Kind] = {}

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -84,6 +84,12 @@ def survey(
         for path in sorted(asset_dir.glob(f"*.{kind.extension}"))
         if path.name[: -len(kind.extension) - 1] not in known
     ]
+    if with_candidates:
+        orphans += [
+            candidate_dir / f"{name}.{lineage}.{kind.extension}"
+            for name in sorted(waiting.keys() - known)
+            for lineage in sorted(waiting[name], key=_lineage_key)
+        ]
     return Survey(rows=rows, orphans=orphans)
 
 

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -9,6 +9,8 @@ Derived on demand, never stored. `targets` supplies the spine; this module is
 the only part that touches disk.
 """
 
+import re
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -17,6 +19,8 @@ from spf.assets.spine import _asset_dir
 from spf.assets.targets import Target, targets
 from spf.config import config
 from spf.schemas import type_aliases as t
+
+_INDEX_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 @dataclass(frozen=True)
@@ -43,6 +47,7 @@ def survey(
     kind: Kind,
     race: t.RaceName,
     *,
+    candidates_root: Path = config.paths.candidates,
     assets_root: Path = config.paths.assets,
 ) -> Survey:
     """Return `kind`'s coverage of `race`, one row per Target.
@@ -50,8 +55,13 @@ def survey(
     Rows follow `targets()` order. Raises `ValueError` for an unknown race.
     """
     asset_dir = _asset_dir(assets_root, kind, race=race)
+    waiting = _candidates_by_name(_asset_dir(candidates_root, kind, race=race), kind)
     rows = [
-        Coverage(target=target, asset=_asset_for(asset_dir, kind, target))
+        Coverage(
+            target=target,
+            asset=_asset_for(asset_dir, kind, target),
+            candidates=sorted(waiting.get(target.name, []), key=_lineage_key),
+        )
         for target in targets(kind, race)
     ]
     return Survey(rows=rows, orphans=[])
@@ -61,3 +71,34 @@ def _asset_for(asset_dir: Path, kind: Kind, target: Target) -> Path | None:
     """Return the committed Asset for `target`, or `None` when there is none."""
     path = asset_dir / f"{target.name}.{kind.extension}"
     return path if path.is_file() else None
+
+
+def _lineage_key(lineage: str) -> tuple[int, ...]:
+    """Return the sort key for a Lineage: `2.1` sorts before `10`, not after."""
+    return tuple(int(part) for part in lineage.split("."))
+
+
+def _split_lineage(stem: str) -> tuple[str, str] | None:
+    """Return `(target_name, lineage)` for a Candidate stem, or `None`.
+
+    Splits from the *right* on components that are whole 1-based indices, so a
+    Target name that itself ends in digits (`ork_char_b1`, `e34`) keeps them.
+    `None` means the stem carries no Lineage at all.
+    """
+    parts = stem.split(".")
+    cut = len(parts)
+    while cut > 1 and _INDEX_PATTERN.match(parts[cut - 1]):
+        cut -= 1
+    if cut == len(parts):
+        return None
+    return ".".join(parts[:cut]), ".".join(parts[cut:])
+
+
+def _candidates_by_name(candidate_dir: Path, kind: Kind) -> dict[str, list[str]]:
+    """Return the Lineages waiting in `candidate_dir`, keyed by Target name."""
+    waiting: dict[str, list[str]] = defaultdict(list)
+    for path in sorted(candidate_dir.glob(f"*.{kind.extension}")):
+        split = _split_lineage(path.name[: -len(kind.extension) - 1])
+        if split is not None:
+            waiting[split[0]].append(split[1])
+    return waiting

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -56,15 +56,22 @@ def survey(
     """
     asset_dir = _asset_dir(assets_root, kind, race=race)
     waiting = _candidates_by_name(_asset_dir(candidates_root, kind, race=race), kind)
+    found = targets(kind, race)
     rows = [
         Coverage(
             target=target,
             asset=_asset_for(asset_dir, kind, target),
             candidates=sorted(waiting.get(target.name, []), key=_lineage_key),
         )
-        for target in targets(kind, race)
+        for target in found
     ]
-    return Survey(rows=rows, orphans=[])
+    known = {target.name for target in found}
+    orphans = [
+        path
+        for path in sorted(asset_dir.glob(f"*.{kind.extension}"))
+        if path.name[: -len(kind.extension) - 1] not in known
+    ]
+    return Survey(rows=rows, orphans=orphans)
 
 
 def _asset_for(asset_dir: Path, kind: Kind, target: Target) -> Path | None:

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -9,6 +9,7 @@ Derived on demand, never stored. `targets` supplies the spine; this module is
 the only part that touches disk.
 """
 
+import hashlib
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -49,22 +50,34 @@ def survey(
     *,
     candidates_root: Path = config.paths.candidates,
     assets_root: Path = config.paths.assets,
+    with_candidates: bool = False,
 ) -> Survey:
     """Return `kind`'s coverage of `race`, one row per Target.
 
-    Rows follow `targets()` order. Raises `ValueError` for an unknown race.
+    Rows follow `targets()` order. `with_candidates` additionally recovers, by
+    digest, which Candidate each Asset was promoted from — the expensive part,
+    so it is off by default (ADR 0012). Raises `ValueError` for an unknown race.
     """
     asset_dir = _asset_dir(assets_root, kind, race=race)
-    waiting = _candidates_by_name(_asset_dir(candidates_root, kind, race=race), kind)
+    candidate_dir = _asset_dir(candidates_root, kind, race=race)
+    waiting = _candidates_by_name(candidate_dir, kind)
     found = targets(kind, race)
-    rows = [
-        Coverage(
-            target=target,
-            asset=_asset_for(asset_dir, kind, target),
-            candidates=sorted(waiting.get(target.name, []), key=_lineage_key),
+    rows = []
+    for target in found:
+        asset = _asset_for(asset_dir, kind, target)
+        lineages = sorted(waiting.get(target.name, []), key=_lineage_key)
+        rows.append(
+            Coverage(
+                target=target,
+                asset=asset,
+                candidates=lineages,
+                promoted_from=(
+                    _promoted_from(asset, candidate_dir, kind, target, lineages)
+                    if with_candidates and asset is not None
+                    else []
+                ),
+            )
         )
-        for target in found
-    ]
     known = {target.name for target in found}
     orphans = [
         path
@@ -78,6 +91,34 @@ def _asset_for(asset_dir: Path, kind: Kind, target: Target) -> Path | None:
     """Return the committed Asset for `target`, or `None` when there is none."""
     path = asset_dir / f"{target.name}.{kind.extension}"
     return path if path.is_file() else None
+
+
+def _promoted_from(
+    asset: Path,
+    candidate_dir: Path,
+    kind: Kind,
+    target: Target,
+    lineages: list[str],
+) -> list[str]:
+    """Return every Lineage byte-identical to `asset`.
+
+    `promote` is a plain copy, so the Asset matches the Candidate it came from.
+    Seeds are deterministic, so two Candidates can collide — all matches are
+    reported rather than one guessed (ADR 0012).
+    """
+    digest = _digest(asset)
+    matches = []
+    for lineage in lineages:
+        path = candidate_dir / f"{target.name}.{lineage}.{kind.extension}"
+        if path.is_file() and _digest(path) == digest:
+            matches.append(lineage)
+    return matches
+
+
+def _digest(path: Path) -> bytes:
+    """Return the SHA-256 digest of `path`."""
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").digest()
 
 
 def _lineage_key(lineage: str) -> tuple[int, ...]:

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -1,0 +1,63 @@
+"""Checking a Kind's Targets for a Race against the two stores.
+
+A **Survey** answers "what's left?": for each Target the Kind covers, whether a
+committed Asset exists and how many Candidates are waiting. Files matching no
+Target are reported as **Orphans** rather than ignored, so a Target renamed in
+TOML after generation is visible instead of silent.
+
+Derived on demand, never stored. `targets` supplies the spine; this module is
+the only part that touches disk.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from spf.assets.kinds import Kind
+from spf.assets.spine import _asset_dir
+from spf.assets.targets import Target, targets
+from spf.config import config
+from spf.schemas import type_aliases as t
+
+
+@dataclass(frozen=True)
+class Coverage:
+    """One Target's line in a Survey."""
+
+    target: Target
+    asset: Path | None
+    candidates: list[str] = field(default_factory=list)
+    """Lineages of the Candidates waiting for this Target, numerically sorted."""
+    promoted_from: list[str] = field(default_factory=list)
+    """Lineages byte-identical to the Asset; empty when not looked for."""
+
+
+@dataclass(frozen=True)
+class Survey:
+    """One Kind's coverage of one Race."""
+
+    rows: list[Coverage]
+    orphans: list[Path]
+
+
+def survey(
+    kind: Kind,
+    race: t.RaceName,
+    *,
+    assets_root: Path = config.paths.assets,
+) -> Survey:
+    """Return `kind`'s coverage of `race`, one row per Target.
+
+    Rows follow `targets()` order. Raises `ValueError` for an unknown race.
+    """
+    asset_dir = _asset_dir(assets_root, kind, race=race)
+    rows = [
+        Coverage(target=target, asset=_asset_for(asset_dir, kind, target))
+        for target in targets(kind, race)
+    ]
+    return Survey(rows=rows, orphans=[])
+
+
+def _asset_for(asset_dir: Path, kind: Kind, target: Target) -> Path | None:
+    """Return the committed Asset for `target`, or `None` when there is none."""
+    path = asset_dir / f"{target.name}.{kind.extension}"
+    return path if path.is_file() else None

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -43,4 +43,14 @@ def targets(kind: Kind, race: t.RaceName) -> list[Target]:
                 level="race",
             )
         )
+    if "unit" in kind.targets:
+        found.extend(
+            Target(
+                name=name,
+                human_name=unit.name,
+                description=unit.description,
+                level="unit",
+            )
+            for name, unit in races.get_units(race).items()
+        )
     return found

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -53,4 +53,14 @@ def targets(kind: Kind, race: t.RaceName) -> list[Target]:
             )
             for name, unit in races.get_units(race).items()
         )
+    if "model" in kind.targets:
+        found.extend(
+            Target(
+                name=name,
+                human_name=model.name,
+                description=model.description,
+                level="model",
+            )
+            for name, model in races.get_models(race).items()
+        )
     return found

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -9,7 +9,9 @@ Pure: this module reads the Race TOML and nothing else. Checking what is
 actually on disk is `survey`'s job.
 """
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from typing import Protocol
 
 from spf import races
 from spf.assets.kinds import Kind, TargetLevel
@@ -26,41 +28,37 @@ class Target:
     level: TargetLevel
 
 
+class _Described(Protocol):
+    """The shape every level's entries share: a display name and a blurb."""
+
+    name: str
+    description: str
+
+
+# Every level resolves to a mapping of key to described entry, so the race
+# level -- a single object -- is wrapped in one to match. Insertion order is
+# the order Targets come back in: race, then units, then models.
+_LEVELS: dict[TargetLevel, Callable[[t.RaceName], Mapping[str, _Described]]] = {
+    "race": lambda race: {race: races.get_metadata(race)},
+    "unit": races.get_units,
+    "model": races.get_models,
+}
+
+
 def targets(kind: Kind, race: t.RaceName) -> list[Target]:
     """Return the Targets `kind` covers for `race`, race level first.
 
     `name` is the key that addresses the Target on the command line — the same
     one `promote` and `refine` take. Raises `ValueError` for an unknown race.
     """
-    found: list[Target] = []
-    if "race" in kind.targets:
-        metadata = races.get_metadata(race)  # raises ValueError for unknown race
-        found.append(
-            Target(
-                name=race,
-                human_name=metadata.name,
-                description=metadata.description,
-                level="race",
-            )
+    return [
+        Target(
+            name=name,
+            human_name=entry.name,
+            description=entry.description,
+            level=level,
         )
-    if "unit" in kind.targets:
-        found.extend(
-            Target(
-                name=name,
-                human_name=unit.name,
-                description=unit.description,
-                level="unit",
-            )
-            for name, unit in races.get_units(race).items()
-        )
-    if "model" in kind.targets:
-        found.extend(
-            Target(
-                name=name,
-                human_name=model.name,
-                description=model.description,
-                level="model",
-            )
-            for name, model in races.get_models(race).items()
-        )
-    return found
+        for level, getter in _LEVELS.items()
+        if level in kind.targets
+        for name, entry in getter(race).items()  # raises ValueError for unknown race
+    ]

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -1,0 +1,46 @@
+"""The Targets a Kind covers for a Race.
+
+A **Target** is the thing an Asset depicts — a Race, a Unit, or a Model. Which
+of those a given Kind applies to is declared by the Kind itself (`Kind.targets`),
+so resolving them is one loop over the Race config rather than a per-command
+race/unit fork.
+
+Pure: this module reads the Race TOML and nothing else. Checking what is
+actually on disk is `survey`'s job.
+"""
+
+from dataclasses import dataclass
+
+from spf import races
+from spf.assets.kinds import Kind, TargetLevel
+from spf.schemas import type_aliases as t
+
+
+@dataclass(frozen=True)
+class Target:
+    """One thing a Kind could have an Asset for."""
+
+    name: str
+    human_name: str
+    description: str
+    level: TargetLevel
+
+
+def targets(kind: Kind, race: t.RaceName) -> list[Target]:
+    """Return the Targets `kind` covers for `race`, race level first.
+
+    `name` is the key that addresses the Target on the command line — the same
+    one `promote` and `refine` take. Raises `ValueError` for an unknown race.
+    """
+    found: list[Target] = []
+    if "race" in kind.targets:
+        metadata = races.get_metadata(race)  # raises ValueError for unknown race
+        found.append(
+            Target(
+                name=race,
+                human_name=metadata.name,
+                description=metadata.description,
+                level="race",
+            )
+        )
+    return found

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Annotated
 
 import cyclopts
+import pydantic
 
 from spf import races
 from spf.assets import (
@@ -139,7 +140,9 @@ def list_assets(
     `--candidates` expands each row into its Candidate Lineages, marking the
     one the Asset was promoted from.
 
-    Missing Assets are a normal state, so this always exits 0.
+    Missing Assets are a normal state, so reporting coverage always exits 0.
+    A RACE named explicitly but failing to validate cannot be reported at all,
+    and exits 1; the omitted-RACE sweep skips such races silently (ADR 0004).
     """
     race_names: list[t.RaceName] = (
         [race] if race is not None else races.list_races(validate=True)
@@ -147,7 +150,17 @@ def list_assets(
     kinds = [get_kind(kind)] if kind is not None else list(KINDS.values())
 
     for race_name in race_names:
-        stdout.print(f"[bold]{races.get_metadata(race_name).name}[/]", highlight=False)
+        try:
+            # `get_race` validates the whole RaceConfig, so this one guard also
+            # covers the `survey` calls below.
+            metadata = races.get_metadata(race_name)
+        except pydantic.ValidationError:
+            stderr.print(
+                f"[red]Error:[/] race '{race_name}' does not validate, "
+                "so its coverage cannot be reported"
+            )
+            raise SystemExit(1) from None
+        stdout.print(f"[bold]{metadata.name}[/]", highlight=False)
         for asset_kind in kinds:
             found = survey(
                 asset_kind,

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -135,10 +135,14 @@ def _print_lineages(row: Coverage) -> None:
 
 def _print_coverage(row: Coverage) -> None:
     """Print one Coverage row: key first, human name dimmed, then status."""
-    # Pad the *plain* text, then wrap it in markup: padding a marked-up string
-    # counts the tag characters and misaligns every column.
-    status = "[green]✓[/]      " if row.asset else "[red]missing[/]"
+    # Covered and uncovered are a symmetric pair of one-column glyphs, so the
+    # status needs no padding of its own. Named escapes rather than literals:
+    # a bare check mark and ballot X are hard to tell apart in a diff.
+    status = "[green]\N{CHECK MARK}[/]" if row.asset else "[red]\N{BALLOT X}[/]"
     count = f"{len(row.candidates)} candidates" if row.candidates else ""
+    # The name columns pad the *plain* value before the markup wraps it:
+    # padding an already-marked-up string counts the tag characters and
+    # misaligns every column after it.
     stdout.print(
         f"  - {row.target.name:<24} [dim]{row.target.human_name:<24}[/]"
         f" {status} {count}",

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -13,9 +13,18 @@ from typing import Annotated
 import cyclopts
 
 from spf import races
-from spf.assets import generate, get_kind, promote, refine, validate_lineage
+from spf.assets import (
+    Target,
+    generate,
+    get_kind,
+    promote,
+    refine,
+    targets,
+    validate_lineage,
+)
 from spf.assets import image as _image  # noqa: F401  registers the "image" Kind
 from spf.assets.comfyui import ComfyUIError
+from spf.assets.kinds import Kind as AssetKind
 from spf.config import config
 from spf.console import stderr, stdout
 from spf.schemas import type_aliases as t
@@ -63,23 +72,21 @@ class AssetOpts:
         return self.count or config.assets.image.count, seed
 
 
-def _resolve_target(race: t.RaceName, unit: str | None) -> tuple[str, str, str]:
-    """Return `(name, human_name, description)` for a race or unit target.
+def _resolve_target(kind: AssetKind, race: t.RaceName, unit: str | None) -> Target:
+    """Return the Target a command addresses: the race itself, or a unit of it.
 
     `race` must be a known race; `unit` (when given) a known unit key of it.
     Raises `ValueError` mirroring `get_race` for unknown names.
     """
-    if unit is None:
-        metadata = races.get_metadata(race)  # raises ValueError for unknown race
-        return race, metadata.name, metadata.description
-    units = races.get_units(race)  # raises ValueError for unknown race
-    try:
-        config_unit = units[unit]
-    except KeyError:
-        available = ", ".join(units)
-        msg = f"Unknown unit '{unit}' for race '{race}'. Available units: {available}"
-        raise ValueError(msg) from None
-    return unit, config_unit.name, config_unit.description
+    found = targets(kind, race)  # raises ValueError for unknown race
+    wanted = race if unit is None else unit
+    level = "race" if unit is None else "unit"
+    for target in found:
+        if target.level == level and target.name == wanted:
+            return target
+    available = ", ".join(t_.name for t_ in found if t_.level == "unit")
+    msg = f"Unknown unit '{unit}' for race '{race}'. Available units: {available}"
+    raise ValueError(msg)
 
 
 def promote_asset(race: t.RaceName, kind: Kind, name: str, *, pick: Lineage) -> None:
@@ -168,21 +175,22 @@ def image(
             image(race, unit=unit_name, opts=opts)
         return
 
+    kind = get_kind("image")
     try:
-        name, human_name, description = _resolve_target(race, unit)
+        target = _resolve_target(kind, race, unit)
     except ValueError as err:
         stderr.print(f"[red]Error:[/] {err}")
         raise SystemExit(1) from None
 
-    target = unit or race
-    if not description.strip():
+    if not target.description.strip():
         stderr.print(
-            f"[red]Error:[/] no description for {target!r}, cannot generate an image"
+            f"[red]Error:[/] no description for {target.name!r}, "
+            "cannot generate an image"
         )
         raise SystemExit(1)
 
     system = (config.paths.prompts / "image.txt").read_text(encoding="utf-8")
-    prompt = f"Subject: {human_name}.\nDetails: {description}\n{system}"
+    prompt = f"Subject: {target.human_name}.\nDetails: {target.description}\n{system}"
 
     count, seed = opts.resolve()
     stdout.print(f"Seed: {seed}  (rerun with --seed {seed} to reproduce)")
@@ -192,10 +200,10 @@ def image(
 
     try:
         generate(
-            get_kind("image"),
+            kind,
             prompt,
             race=race,
-            name=name,
+            name=target.name,
             count=count,
             seed=seed,
             candidates_root=config.paths.candidates,
@@ -205,4 +213,6 @@ def image(
         stderr.print(f"[red]Error:[/] image generation failed: {err}")
         raise SystemExit(1) from None
 
-    stdout.print(f"Promote one with: spf assets promote {race} image {target} --pick N")
+    stdout.print(
+        f"Promote one with: spf assets promote {race} image {target.name} --pick N"
+    )

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -93,6 +93,15 @@ def _resolve_target(kind: AssetKind, race: t.RaceName, unit: str | None) -> Targ
     raise ValueError(msg)
 
 
+def _print_lineages(row: Coverage) -> None:
+    """Print a row's Candidate Lineages, flat and numerically sorted."""
+    parts = [
+        f"[green]{lineage}←promoted[/]" if lineage in row.promoted_from else lineage
+        for lineage in row.candidates
+    ]
+    stdout.print(f"      {'  '.join(parts)}", highlight=False, soft_wrap=True)
+
+
 def _print_coverage(row: Coverage) -> None:
     """Print one Coverage row: key first, human name dimmed, then status."""
     # Pad the *plain* text, then wrap it in markup: padding a marked-up string
@@ -140,6 +149,8 @@ def list_assets(
             stdout.print(f"  {asset_kind.name.title()}", highlight=False)
             for row in found.rows:
                 _print_coverage(row)
+                if candidates and row.candidates:
+                    _print_lineages(row)
             if found.orphans:
                 stdout.print("  Unknown", highlight=False)
                 for orphan in found.orphans:

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -14,16 +14,19 @@ import cyclopts
 
 from spf import races
 from spf.assets import (
+    Coverage,
     Target,
     generate,
     get_kind,
     promote,
     refine,
+    survey,
     targets,
     validate_lineage,
 )
 from spf.assets import image as _image  # noqa: F401  registers the "image" Kind
 from spf.assets.comfyui import ComfyUIError
+from spf.assets.kinds import KINDS
 from spf.assets.kinds import Kind as AssetKind
 from spf.config import config
 from spf.console import stderr, stdout
@@ -34,6 +37,7 @@ _SEED_BOUND = 2**31
 
 def add_commands(app: cyclopts.App) -> None:
     """Add asset commands to the CLI."""
+    app.command(list_assets, name="list")
     app.command(promote_asset, name="promote")
     app.command(refine_asset, name="refine")
     app.command(image, name="image")
@@ -87,6 +91,59 @@ def _resolve_target(kind: AssetKind, race: t.RaceName, unit: str | None) -> Targ
     available = ", ".join(t_.name for t_ in found if t_.level == "unit")
     msg = f"Unknown unit '{unit}' for race '{race}'. Available units: {available}"
     raise ValueError(msg)
+
+
+def _print_coverage(row: Coverage) -> None:
+    """Print one Coverage row: key first, human name dimmed, then status."""
+    # Pad the *plain* text, then wrap it in markup: padding a marked-up string
+    # counts the tag characters and misaligns every column.
+    status = "[green]✓[/]      " if row.asset else "[red]missing[/]"
+    count = f"{len(row.candidates)} candidates" if row.candidates else ""
+    stdout.print(
+        f"  - {row.target.name:<24} [dim]{row.target.human_name:<24}[/]"
+        f" {status} {count}",
+        highlight=False,
+        soft_wrap=True,  # a coverage row is scanned or piped, never reflowed
+    )
+
+
+def list_assets(
+    race: t.RaceName | None = None,
+    *,
+    kind: Kind | None = None,
+    candidates: bool = False,
+) -> None:
+    """Report which Targets have Assets, and how many Candidates are waiting.
+
+    RACE restricts the report to one race; omitted, every validating race is
+    covered. `--kind` restricts it to one registered Asset kind, and
+    `--candidates` expands each row into its Candidate Lineages, marking the
+    one the Asset was promoted from.
+
+    Missing Assets are a normal state, so this always exits 0.
+    """
+    race_names: list[t.RaceName] = (
+        [race] if race is not None else races.list_races(validate=True)
+    )
+    kinds = [get_kind(kind)] if kind is not None else list(KINDS.values())
+
+    for race_name in race_names:
+        stdout.print(f"[bold]{races.get_metadata(race_name).name}[/]", highlight=False)
+        for asset_kind in kinds:
+            found = survey(
+                asset_kind,
+                race_name,
+                candidates_root=config.paths.candidates,
+                assets_root=config.paths.assets,
+                with_candidates=candidates,
+            )
+            stdout.print(f"  {asset_kind.name.title()}", highlight=False)
+            for row in found.rows:
+                _print_coverage(row)
+            if found.orphans:
+                stdout.print("  Unknown", highlight=False)
+                for orphan in found.orphans:
+                    stdout.print(f"  - {orphan.name}", highlight=False)
 
 
 def promote_asset(race: t.RaceName, kind: Kind, name: str, *, pick: Lineage) -> None:

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -43,8 +43,14 @@ def add_commands(app: cyclopts.App) -> None:
     app.command(image, name="image")
 
 
-def _validate_kind(_type: type, value: str) -> None:
-    """Reject a KIND that is not registered, surfacing the known kinds."""
+def _validate_kind(_type: type, value: str | None) -> None:
+    """Reject a KIND that is not registered, surfacing the known kinds.
+
+    `None` is an omitted optional `--kind`, which means "every registered
+    kind" — the validator must let it through rather than look it up.
+    """
+    if value is None:
+        return
     get_kind(value)  # raises ValueError naming the known kinds
 
 

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -90,16 +90,20 @@ class AssetOpts:
 def _resolve_target(kind: AssetKind, race: t.RaceName, unit: str | None) -> Target:
     """Return the Target a command addresses: the race itself, or a unit of it.
 
-    `race` must be a known race; `unit` (when given) a known unit key of it.
+    `race` must be a known race; `unit` (when given) a known key of it.
     Raises `ValueError` mirroring `get_race` for unknown names.
+
+    Matching is by name across every level the Kind declares, rather than a
+    hardcoded race/unit fork, so a Kind that declares `model` resolves without
+    touching this helper. `targets()` yields the race level first, so a unit
+    keyed like its own race cannot shadow it.
     """
     found = targets(kind, race)  # raises ValueError for unknown race
     wanted = race if unit is None else unit
-    level = "race" if unit is None else "unit"
     for target in found:
-        if target.level == level and target.name == wanted:
+        if target.name == wanted:
             return target
-    available = ", ".join(t_.name for t_ in found if t_.level == "unit")
+    available = ", ".join(t_.name for t_ in found if t_.level != "race")
     msg = f"Unknown unit '{unit}' for race '{race}'. Available units: {available}"
     raise ValueError(msg)
 

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -34,6 +34,10 @@ from spf.schemas import type_aliases as t
 
 _SEED_BOUND = 2**31
 
+# UNIT, --all and --missing pick *which* Targets to generate for, so at most one
+# may be given. LimitedChoice() defaults to min=0, max=1: exactly that rule.
+_SELECTION = cyclopts.Group("Selection", validator=cyclopts.validators.LimitedChoice())
+
 
 def add_commands(app: cyclopts.App) -> None:
     """Add asset commands to the CLI."""
@@ -229,33 +233,64 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     )
 
 
+def _image_targets(
+    kind: AssetKind, race: t.RaceName, unit: str | None, *, all_: bool, missing: bool
+) -> list[Target]:
+    """Return the Targets one `image` invocation should generate for.
+
+    Exactly one selector applies, enforced by `_SELECTION` before we get here:
+    `--all` takes every Target, `--missing` every Target with no promoted Asset
+    (the race-level one included), and otherwise it is the single named Target.
+    """
+    if all_:
+        return targets(kind, race)
+    if missing:
+        found = survey(
+            kind,
+            race,
+            candidates_root=config.paths.candidates,
+            assets_root=config.paths.assets,
+        )
+        return [row.target for row in found.rows if row.asset is None]
+    return [_resolve_target(kind, race, unit)]
+
+
 def image(
     race: t.RaceName,
-    unit: str | None = None,
+    unit: Annotated[str | None, cyclopts.Parameter(group=_SELECTION)] = None,
     *,
+    all_: Annotated[bool, cyclopts.Parameter(name="--all", group=_SELECTION)] = False,
+    missing: Annotated[bool, cyclopts.Parameter(group=_SELECTION)] = False,
     opts: Annotated[AssetOpts | None, cyclopts.Parameter(name="*")] = None,
 ) -> None:
     """Generate image Candidates for a RACE, or a UNIT of it.
+
+    `--all` covers the race and every unit; `--missing` covers every Target
+    with no promoted Asset yet, the race-level image included. The two, and a
+    named UNIT, are mutually exclusive.
 
     The prompt is composed from `prompts/image.txt` plus the target's name
     and description; a target without a description is a hard error.
     """
     opts = opts or AssetOpts()
-
-    if unit == "all":
-        for unit_name in [None, *races.get_units(race)]:
-            if unit_name:
-                stdout.print(f"[green]{unit_name}[/]")
-            image(race, unit=unit_name, opts=opts)
-        return
-
     kind = get_kind("image")
+
     try:
-        target = _resolve_target(kind, race, unit)
+        selected = _image_targets(kind, race, unit, all_=all_, missing=missing)
     except ValueError as err:
         stderr.print(f"[red]Error:[/] {err}")
         raise SystemExit(1) from None
 
+    for target in selected:
+        if len(selected) > 1:
+            stdout.print(f"[green]{target.name}[/]")
+        _generate_image(kind, race, target, opts)
+
+
+def _generate_image(
+    kind: AssetKind, race: t.RaceName, target: Target, opts: AssetOpts
+) -> None:
+    """Generate Candidates for one Target, reporting each as it lands."""
     if not target.description.strip():
         stderr.print(
             f"[red]Error:[/] no description for {target.name!r}, "

--- a/v3/tests/assets/conftest.py
+++ b/v3/tests/assets/conftest.py
@@ -70,6 +70,7 @@ def test_kind() -> Kind:
         service=FakeService(),
         subdir="_test",
         extension="txt",
+        targets=frozenset({"race", "unit"}),
     )
 
 
@@ -81,4 +82,5 @@ def refinable_kind() -> Kind:
         service=FakeRefiner(),
         subdir="_test",
         extension="txt",
+        targets=frozenset({"race", "unit"}),
     )

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -15,7 +15,13 @@ from tests.assets.conftest import FakeRefiner, FakeService
 @pytest.fixture
 def registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
     """Register a throwaway kind and point the config roots under tmp."""
-    kind = Kind(name="_test", service=FakeService(), subdir="_test", extension="txt")
+    kind = Kind(
+        name="_test",
+        service=FakeService(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+    )
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
     monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
@@ -82,7 +88,11 @@ def test_promote_command_unknown_kind_errors(
 def refinable_registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
     """Register a throwaway refinable kind with a Candidate already on disk."""
     kind = Kind(
-        name="_refinable", service=FakeRefiner(), subdir="_test", extension="txt"
+        name="_refinable",
+        service=FakeRefiner(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
     )
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -300,3 +300,13 @@ def test_list_command_surfaces_orphans_under_unknown(
     out = capsys.readouterr().out
     assert "Unknown" in out
     assert "gigant_snake_cavalry.txt" in out
+
+
+@pytest.mark.usefixtures("registered_kind")
+def test_list_command_defaults_to_every_registered_kind(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # An omitted --kind must not be run through the kind validator.
+    app(["assets", "list", "ork"], exit_on_error=False, result_action="return_value")
+
+    assert "Ork" in capsys.readouterr().out

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from cyclopts.exceptions import CycloptsError
 
-from spf.assets import Kind, generate
+from spf.assets import Kind, generate, promote
 from spf.assets.kinds import KINDS
 from spf.config import config
 from spf.frontends.cli import app
@@ -193,3 +193,38 @@ def test_image_command_errors_cleanly_on_an_unknown_unit(
     err = capsys.readouterr().err
     assert "nosuchunit" in err
     assert "grunt" in err
+
+
+def test_list_command_reports_coverage_for_one_race(
+    registered_kind: Kind, capsys: pytest.CaptureFixture[str]
+) -> None:
+    generate(
+        registered_kind,
+        source="a grunt description",
+        race="ork",
+        name="grunt",
+        count=2,
+        candidates_root=config.paths.candidates,
+    )
+    promote(
+        registered_kind,
+        race="ork",
+        name="grunt",
+        pick="2",
+        candidates_root=config.paths.candidates,
+        assets_root=config.paths.assets,
+    )
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    assert "Ork" in out  # the race heading always prints
+    grunt_line = next(line for line in out.splitlines() if "grunt" in line)
+    assert "2 candidates" in grunt_line
+    # A Target with neither Asset nor Candidates still gets a row.
+    troll_line = next(line for line in out.splitlines() if "troll" in line)
+    assert "missing" in troll_line

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -264,3 +264,39 @@ def test_list_command_expands_lineages_under_candidates(
     ]
     # The Asset is byte-identical to 4.1, so that is the one already promoted.
     assert "4.1\u2190promoted" in lineage_line
+
+
+@pytest.mark.usefixtures("registered_kind")
+def test_list_command_without_a_race_covers_every_validating_race(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app(
+        ["assets", "list", "--kind", "_test"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    # Full detail for every race, not a summary (D12).
+    assert "Ork" in out
+    assert "Goblin" in out
+    assert "grunt" in out
+
+
+def test_list_command_surfaces_orphans_under_unknown(
+    registered_kind: Kind,  # noqa: ARG001  registers the _test kind and tmp roots
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assets = config.paths.assets / "ork" / "_test"
+    assets.mkdir(parents=True)
+    (assets / "gigant_snake_cavalry.txt").write_bytes(b"typo")
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    assert "Unknown" in out
+    assert "gigant_snake_cavalry.txt" in out

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -236,9 +236,12 @@ def test_list_command_reports_coverage_for_one_race(
     assert "Ork" in out  # the race heading always prints
     grunt_line = next(line for line in out.splitlines() if "grunt" in line)
     assert "2 candidates" in grunt_line
+    # Covered and uncovered read as a symmetric pair of glyphs, not a glyph
+    # opposed to a word.
+    assert "\N{CHECK MARK}" in grunt_line
     # A Target with neither Asset nor Candidates still gets a row.
     troll_line = next(line for line in out.splitlines() if "troll" in line)
-    assert "missing" in troll_line
+    assert "\N{BALLOT X}" in troll_line
 
 
 def test_list_command_expands_lineages_under_candidates(

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -179,3 +179,17 @@ def test_refine_command_errors_cleanly_on_a_kind_that_cannot_refine(
         app(argv, exit_on_error=False, result_action="return_value")
 
     assert "does not support refinement" in capsys.readouterr().err
+
+
+def test_image_command_errors_cleanly_on_an_unknown_unit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    argv = ["assets", "image", "ork", "nosuchunit"]
+
+    with pytest.raises(SystemExit):
+        app(argv, exit_on_error=False, result_action="return_value")
+
+    # Lists what the caller could have meant, rather than just rejecting it.
+    err = capsys.readouterr().err
+    assert "nosuchunit" in err
+    assert "grunt" in err

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -228,3 +228,39 @@ def test_list_command_reports_coverage_for_one_race(
     # A Target with neither Asset nor Candidates still gets a row.
     troll_line = next(line for line in out.splitlines() if "troll" in line)
     assert "missing" in troll_line
+
+
+def test_list_command_expands_lineages_under_candidates(
+    registered_kind: Kind, capsys: pytest.CaptureFixture[str]
+) -> None:
+    candidates = config.paths.candidates / "ork" / "_test"
+    candidates.mkdir(parents=True)
+    for lineage, content in [("10", b"a"), ("2", b"b"), ("4.1", b"chosen")]:
+        (candidates / f"grunt.{lineage}.txt").write_bytes(content)
+    promote(
+        registered_kind,
+        race="ork",
+        name="grunt",
+        pick="4.1",
+        candidates_root=config.paths.candidates,
+        assets_root=config.paths.assets,
+    )
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--candidates"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    lineage_line = next(
+        line for line in out.splitlines() if line.strip().startswith("2")
+    )
+    # Numerically sorted: 10 sorts last, not straight after 1.
+    assert [part.split("\u2190")[0] for part in lineage_line.split()] == [
+        "2",
+        "4.1",
+        "10",
+    ]
+    # The Asset is byte-identical to 4.1, so that is the one already promoted.
+    assert "4.1\u2190promoted" in lineage_line

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -303,6 +303,30 @@ def test_list_command_surfaces_orphans_under_unknown(
 
 
 @pytest.mark.usefixtures("registered_kind")
+def test_list_command_errors_on_an_explicitly_named_invalid_race(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The bare-race sweep omits a non-validating race silently (ADR 0004), but
+    # naming one explicitly must say so rather than raise ValidationError.
+    races_dir = tmp_path / "broken-races"
+    races_dir.mkdir()
+    (races_dir / "gnome.toml").write_text("[races.gnome]\nname = 123\n")
+    monkeypatch.setattr(config.paths, "races", races_dir)
+
+    with pytest.raises(SystemExit) as excinfo:
+        app(
+            ["assets", "list", "gnome", "--kind", "_test"],
+            exit_on_error=False,
+            result_action="return_value",
+        )
+
+    assert excinfo.value.code == 1
+    assert "gnome" in capsys.readouterr().err
+
+
+@pytest.mark.usefixtures("registered_kind")
 def test_list_command_defaults_to_every_registered_kind(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -58,6 +58,39 @@ movement_order = ["-", "-", "flee"]
 [equipment]
 """
 
+_DWARF_TOML = """\
+[races.dwarf]
+name = "Dwarf"
+description = "Stubborn engineers with brass-plated beards"
+
+[units.dwarf_grunt]
+race = "dwarf"
+name = "Dwarf Grunt"
+description = "A dwarf grunt swinging a riveted club"
+models = []
+size = "Small"
+[units.dwarf_grunt.shaken]
+speed = "slow"
+movement_order = ["-", "-", "flee"]
+[units.dwarf_grunt.orders]
+[units.dwarf_grunt.damage_tables]
+
+[units.dwarf_scout]
+race = "dwarf"
+name = "Dwarf Scout"
+description = "A wiry dwarf scout with a spyglass"
+models = []
+size = "Small"
+[units.dwarf_scout.shaken]
+speed = "slow"
+movement_order = ["-", "-", "flee"]
+[units.dwarf_scout.orders]
+[units.dwarf_scout.damage_tables]
+
+[models]
+[equipment]
+"""
+
 _GNOME_TOML = """\
 [races.gnome]
 name = "Gnome"
@@ -133,6 +166,7 @@ def _make_env(
     races.mkdir()
     (races / "ogre.toml").write_text(_OGRE_TOML, encoding="utf-8")
     (races / "gnome.toml").write_text(_GNOME_TOML, encoding="utf-8")
+    (races / "dwarf.toml").write_text(_DWARF_TOML, encoding="utf-8")
     prompts = tmp_path / "prompts"
     prompts.mkdir()
     (prompts / "image.txt").write_text("Preamble one.\ntwo.\n", encoding="utf-8")
@@ -311,3 +345,51 @@ def test_cli_unknown_unit_lists_available(
     err = capsys.readouterr().err
     assert "not_a_unit" in err
     assert "ogre_grunt" in err  # available units listed
+
+
+def test_cli_all_flag_covers_the_race_and_every_unit(image_env: _ImageEnv) -> None:
+    _run("assets", "image", "dwarf", "--all", "--seed", "5", "--count", "1")
+
+    images = image_env.candidates / "dwarf" / "images"
+    assert sorted(p.name for p in images.glob("*.png")) == [
+        "dwarf.1.png",
+        "dwarf_grunt.1.png",
+        "dwarf_scout.1.png",
+    ]
+
+
+def test_cli_missing_flag_skips_targets_that_already_have_assets(
+    image_env: _ImageEnv,
+) -> None:
+    assets = image_env.root / "assets" / "dwarf" / "images"
+    assets.mkdir(parents=True)
+    (assets / "dwarf_grunt.png").write_bytes(_PNG)
+
+    _run("assets", "image", "dwarf", "--missing", "--seed", "5", "--count", "1")
+
+    images = image_env.candidates / "dwarf" / "images"
+    # dwarf_grunt is already promoted; the race-level Target is included.
+    assert sorted(p.name for p in images.glob("*.png")) == [
+        "dwarf.1.png",
+        "dwarf_scout.1.png",
+    ]
+
+
+@pytest.mark.usefixtures("image_env")
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["assets", "image", "dwarf", "--all", "--missing"],
+        ["assets", "image", "dwarf", "dwarf_grunt", "--all"],
+    ],
+)
+def test_cli_selectors_are_mutually_exclusive(argv: list[str]) -> None:
+    with pytest.raises(CycloptsError, match=r"[Mm]utually exclusive"):
+        _run(*argv)
+
+
+@pytest.mark.usefixtures("image_env")
+def test_cli_magic_all_unit_is_gone() -> None:
+    # `image <race> all` used to mean --all; it is now just an unknown unit.
+    with pytest.raises(SystemExit):
+        _run("assets", "image", "dwarf", "all")

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -52,7 +52,13 @@ def test_generate_persists_each_candidate_before_reporting_it(
 
 def test_generate_threads_seed_to_service(tmp_path: Path) -> None:
     service = FakeService()
-    kind = Kind(name="_seedy", service=service, subdir="_test", extension="txt")
+    kind = Kind(
+        name="_seedy",
+        service=service,
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+    )
     generate(
         kind,
         source="a grunt description",
@@ -83,6 +89,7 @@ def test_generate_without_subdir_writes_flat_text(tmp_path: Path) -> None:
         service=FakeService(values=("chapter one", "chapter two")),
         subdir=None,
         extension="md",
+        targets=frozenset({"race"}),
     )
     paths = generate(
         lore_kind,

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -84,3 +84,41 @@ def test_survey_reports_asset_files_matching_no_target_as_orphans(
     )
 
     assert found.orphans == [typo]
+
+
+def test_survey_recovers_which_candidate_was_promoted(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    assets_root, candidates_root = stores
+    _write(candidates_root, "grunt.2.txt", b"the other one")
+    _write(candidates_root, "grunt.4.1.txt", b"the chosen one")
+    _write(assets_root, "grunt.txt", b"the chosen one")
+
+    found = survey(
+        test_kind,
+        "ork",
+        assets_root=assets_root,
+        candidates_root=candidates_root,
+        with_candidates=True,
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert by_name["grunt"].promoted_from == ["4.1"]
+
+
+def test_survey_skips_provenance_unless_candidates_are_asked_for(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    # Hashing the Candidate store is the expensive part; the default listing
+    # must not pay for it (ADR 0012).
+    assets_root, candidates_root = stores
+    _write(candidates_root, "grunt.2.txt", b"the chosen one")
+    _write(assets_root, "grunt.txt", b"the chosen one")
+
+    found = survey(
+        test_kind, "ork", assets_root=assets_root, candidates_root=candidates_root
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert by_name["grunt"].promoted_from == []
+    assert by_name["grunt"].candidates == ["2"]

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -122,3 +122,49 @@ def test_survey_skips_provenance_unless_candidates_are_asked_for(
     by_name = {row.target.name: row for row in found.rows}
     assert by_name["grunt"].promoted_from == []
     assert by_name["grunt"].candidates == ["2"]
+
+
+def test_survey_reports_every_candidate_matching_the_asset(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    # Seeds are deterministic, so two Candidates can be byte-identical. Both are
+    # reported rather than one guessed (ADR 0012).
+    assets_root, candidates_root = stores
+    _write(candidates_root, "grunt.2.txt", b"identical")
+    _write(candidates_root, "grunt.5.txt", b"identical")
+    _write(candidates_root, "grunt.3.txt", b"different")
+    _write(assets_root, "grunt.txt", b"identical")
+
+    found = survey(
+        test_kind,
+        "ork",
+        assets_root=assets_root,
+        candidates_root=candidates_root,
+        with_candidates=True,
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert by_name["grunt"].promoted_from == ["2", "5"]
+
+
+def test_survey_extends_orphans_to_candidates_when_asked(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    assets_root, candidates_root = stores
+    stray = _write(candidates_root, "gigant_snake_cavalry.2.txt")
+    _write(candidates_root, "grunt.2.txt")
+
+    default = survey(
+        test_kind, "ork", assets_root=assets_root, candidates_root=candidates_root
+    )
+    detailed = survey(
+        test_kind,
+        "ork",
+        assets_root=assets_root,
+        candidates_root=candidates_root,
+        with_candidates=True,
+    )
+
+    # By default the Unknown section covers Assets only.
+    assert default.orphans == []
+    assert detailed.orphans == [stray]

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -51,3 +51,20 @@ def test_survey_lists_candidate_lineages_sorted_numerically(
     # Dotted components sort as integers: 10 comes last, not after 1.
     assert by_name["grunt"].candidates == ["2", "2.1", "4", "4.1", "4.3", "10"]
     assert by_name["ork_infantry"].candidates == []
+
+
+def test_survey_keeps_digits_that_belong_to_the_target_name(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    # `ork_char_b1` is a real ork unit key ending in a digit. Splitting on the
+    # first dot, or treating the trailing "1" as a Lineage, would misfile these.
+    assets_root, candidates_root = stores
+    _write(candidates_root, "ork_char_b1.2.txt")
+    _write(candidates_root, "ork_char_b1.4.1.txt")
+
+    found = survey(
+        test_kind, "ork", assets_root=assets_root, candidates_root=candidates_root
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert by_name["ork_char_b1"].candidates == ["2", "4.1"]

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -68,3 +68,19 @@ def test_survey_keeps_digits_that_belong_to_the_target_name(
 
     by_name = {row.target.name: row for row in found.rows}
     assert by_name["ork_char_b1"].candidates == ["2", "4.1"]
+
+
+def test_survey_reports_asset_files_matching_no_target_as_orphans(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    # The real case this view exists to surface: a typo'd file name that no
+    # longer matches any unit key, so it silently covers nothing.
+    assets_root, candidates_root = stores
+    _write(assets_root, "grunt.txt")
+    typo = _write(assets_root, "gigant_snake_cavalry.txt")
+
+    found = survey(
+        test_kind, "ork", assets_root=assets_root, candidates_root=candidates_root
+    )
+
+    assert found.orphans == [typo]

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -34,3 +34,20 @@ def test_survey_reports_one_row_per_target_with_its_asset(
     assert by_name["ork_infantry"].asset is None
     # Rows follow targets() order: the race first, then units as declared.
     assert [row.target.name for row in found.rows][:2] == ["ork", "ork_infantry"]
+
+
+def test_survey_lists_candidate_lineages_sorted_numerically(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    assets_root, candidates_root = stores
+    for lineage in ["10", "2", "4.3", "4.1", "2.1", "4"]:
+        _write(candidates_root, f"grunt.{lineage}.txt")
+
+    found = survey(
+        test_kind, "ork", assets_root=assets_root, candidates_root=candidates_root
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    # Dotted components sort as integers: 10 comes last, not after 1.
+    assert by_name["grunt"].candidates == ["2", "2.1", "4", "4.1", "4.3", "10"]
+    assert by_name["ork_infantry"].candidates == []

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -1,0 +1,36 @@
+"""The Survey: a Kind's Targets for a Race, checked against the two stores."""
+
+from pathlib import Path
+
+import pytest
+
+from spf.assets import Kind, survey
+
+
+@pytest.fixture
+def stores(tmp_path: Path) -> tuple[Path, Path]:
+    """Return empty `(assets_root, candidates_root)` under tmp."""
+    return tmp_path / "assets", tmp_path / "candidates"
+
+
+def _write(root: Path, name: str, content: bytes = b"x") -> Path:
+    """Write `content` to `<root>/ork/_test/<name>`, making parents."""
+    path = root / "ork" / "_test" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_survey_reports_one_row_per_target_with_its_asset(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    assets_root, _ = stores
+    grunt_asset = _write(assets_root, "grunt.txt")
+
+    found = survey(test_kind, "ork", assets_root=assets_root)
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert by_name["grunt"].asset == grunt_asset
+    assert by_name["ork_infantry"].asset is None
+    # Rows follow targets() order: the race first, then units as declared.
+    assert [row.target.name for row in found.rows][:2] == ["ork", "ork_infantry"]

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -1,0 +1,20 @@
+"""The Targets a Kind covers for a Race, resolved from the Race TOML alone."""
+
+from spf.assets import Kind, targets
+from tests.assets.conftest import FakeService
+
+
+def test_race_level_kind_covers_the_race_itself() -> None:
+    kind = Kind(
+        name="_lore",
+        service=FakeService(),
+        subdir="_lore",
+        extension="txt",
+        targets=frozenset({"race"}),
+    )
+
+    found = targets(kind, "ork")
+
+    assert [target.name for target in found] == ["ork"]
+    assert found[0].level == "race"
+    assert found[0].human_name == "Ork"

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -41,3 +41,23 @@ def test_unit_level_kind_covers_the_race_then_its_units(test_kind: Kind) -> None
         "ork_char_b1",
     ]
     assert {target.level for target in found[1:]} == {"unit"}
+
+
+def test_model_level_kind_covers_the_races_models() -> None:
+    # No Kind targets models yet; the field is the hook the Model Kind lands on.
+    kind = Kind(
+        name="_model",
+        service=FakeService(),
+        subdir="_model",
+        extension="stl",
+        targets=frozenset({"model"}),
+    )
+
+    found = targets(kind, "ork")
+
+    assert [target.name for target in found][:3] == [
+        "troll",
+        "grunt",
+        "ork_elite_infantry",
+    ]
+    assert {target.level for target in found} == {"model"}

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -18,3 +18,26 @@ def test_race_level_kind_covers_the_race_itself() -> None:
     assert [target.name for target in found] == ["ork"]
     assert found[0].level == "race"
     assert found[0].human_name == "Ork"
+
+
+def test_unit_level_kind_covers_the_race_then_its_units(test_kind: Kind) -> None:
+    # `test_kind` declares {"race", "unit"}, matching the image Kind. Ork's unit
+    # keys, in `races/ork.toml` declaration order — coverage follows the TOML,
+    # not cost order as `race things` does.
+    found = targets(test_kind, "ork")
+
+    assert [target.name for target in found] == [
+        "ork",
+        "ork_infantry",
+        "troll",
+        "champion",
+        "warg_rider",
+        "speedhead",
+        "hammerhead",
+        "battlewagon",
+        "grunt",
+        "ork_werewarg",
+        "bioengineered_ork",
+        "ork_char_b1",
+    ]
+    assert {target.level for target in found[1:]} == {"unit"}


### PR DESCRIPTION
Closes #51.

Adds `spf assets list`, which reports **Asset coverage**: it walks the Targets a
Race could have Assets for and reports, for each, whether an Asset exists and how
many Candidates are waiting. The Race TOML is the spine; the filesystem is the
annotation.

```console
$ spf assets list goblin
Goblin
  Image
  - goblin                   Goblin                   missing
  - goblin_infantry          Goblin Infantry          ✓
  - giant_snake_cavalry      Giant Snake Cavalry      missing
  …
  Unknown
  - gigant_snake_cavalry.png
```

That `Unknown` entry is a real typo in the repo (`gigant_` vs the unit key
`giant_snake_cavalry`) that the coverage view exists to surface — it was found by
running the new command, not by inspection.

## ⚠️ Breaking change

**`spf assets image <race> all` no longer works.** The magic `all` string is
replaced by flags built on the same seam:

| Before | After |
|---|---|
| `image ork all` | `image ork --all` |
| — | `image ork --missing` (every Target with no Asset, race-level included) |

`UNIT`, `--all` and `--missing` share a cyclopts `Group` with `LimitedChoice()`,
so at most one may be given. There is no deprecation alias.

## What's here

- **`Kind.targets`** — a required `frozenset[TargetLevel]` field declaring which
  levels a Kind depicts. Image declares `{"race", "unit"}`; the field is the hook
  Lore and Model land on.
- **`targets(kind, race)`** — pure, TOML only. Race Target first, then units in
  declaration order.
- **`survey(kind, race, ...)`** — Coverage rows, Candidate Lineages sorted
  numerically (`2 < 2.1 < 4.3 < 10`), Orphan detection, and digest-recovered
  promotion provenance.
- **`_resolve_target`** rebuilt on `targets()`, replacing its hand-rolled
  race/unit fork.
- **ADR 0011** (coverage, not inventory; Target set declared per Kind) and
  **ADR 0012** (hash-recovered provenance), plus four `CONTEXT.md` terms.

## Verification

Ran against the real store: **101 Targets** and the orphan both match the
figures measured when the work was planned. The 19 committed Assets reconcile as
18 covered + 1 orphan.

`just check` passes. It was failing on `master` before this branch — a typo in
`races/elf.toml` prose broke the spell gate, fixed here in its own commit
(`7b4ac88`).

## Notes for review

- **Candidate counts are machine-dependent.** `candidates/` is gitignored, so a
  fresh checkout reports 0 candidates. No test assumes otherwise.
- **Only one Kind is registered**, so `--kind` and the per-Kind loop can't be
  exercised against real data; they're covered via the throwaway Kind in
  `tests/assets/conftest.py`.
- **Model-level Targets are implemented and tested but have no consumer yet.**
- Three of the 18 commits are tests that passed on write rather than red-green
  cycles — they pin risks the plan named (digit-ending Target names, byte-identical
  Candidate collisions, the all-races loop) and say so in their commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VkwjcPfmUXUHUha52vjWr