### PR TITLE
Small improvements when generating image assets

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -249,7 +249,9 @@ _Avoid_: negative, neg prompt, exclusions, banned terms
 
 **Refinement**:
 Generating Candidates from an existing Candidate plus a Correction, rather than
-from a Race description. Chains, because the result is itself a Candidate.
+from a Race description. Chains, because the result is itself a Candidate. May
+also start from a promoted Asset: the Asset is staged into the Candidate store
+first, so the operation itself is unchanged.
 _Avoid_: edit, variation, touch-up, img2img (an implementation mechanism, not
 the domain operation)
 
@@ -264,7 +266,9 @@ _Avoid_: instruction, tweak, fix, note
 The dotted 1-based Candidate index (`2`, `2.1`, `2.1.3`) recording derivation:
 `2.1` is the first Candidate of the Refinement of Candidate `2`. Readable
 straight off the filename, so no provenance is recorded anywhere else. The
-coordinate both `refine --from` and `promote --pick` take.
+coordinate both `refine --from` and `promote --pick` take. Permanent: a Lineage
+is allocated past whatever already exists, never reclaimed and never
+renumbered, so it is a coordinate rather than a count of anything.
 _Avoid_: version, revision, generation, history
 
 **Target**:

--- a/v3/docs/adr/0013-candidate-numbering.md
+++ b/v3/docs/adr/0013-candidate-numbering.md
@@ -1,0 +1,59 @@
+# Candidate indices append, and are never reused
+
+Generating Candidates numbered them per run, always starting at `.1`. A second
+run over the same Target therefore wrote over the first run's files:
+
+```console
+$ spf assets image goblin goblin_infantry --count 3
+Wrote candidates/goblin/images/goblin_infantry.1.png (18.4s)
+Wrote candidates/goblin/images/goblin_infantry.2.png (17.9s)
+Wrote candidates/goblin/images/goblin_infantry.3.png (18.1s)
+$ spf assets image goblin goblin_infantry --count 3   # the three above are gone
+Wrote candidates/goblin/images/goblin_infantry.1.png (18.2s)
+```
+
+## Indices append past the highest existing Lineage
+
+**Decision: a new Candidate takes one past the highest index already present
+under its name, rather than restarting the count each run.**
+
+This is worth an ADR rather than a silent fix because the old behavior was
+*documented* — `generate` promised that "existing candidate files are
+overwritten silently" — and because the fix changes what a Lineage means. The
+loss it caused is unrecoverable and invisible: `candidates/` is gitignored, so
+a Candidate a curator was still weighing is simply gone, with nothing on screen
+saying so. Curation is the expensive human step in this pipeline; destroying
+its inputs as a side effect of asking for more options is the wrong default.
+
+## The maximum runs over the whole subtree
+
+**Decision: the highest index is taken over the first component of *every*
+Lineage under the name, not only over Candidates that still exist.**
+
+A surviving `ork.4.1.png` reserves `4` even when `ork.4.png` itself was
+deleted. Without this, a new Candidate landing on `4` silently **adopts** the
+orphaned `ork.4.1` as its own Refinement: Lineage reads straight off the
+filename and nothing else records provenance (ADR 0010), so
+`promote --pick 4.1` would hand back an image derived from a parent that no
+longer exists, with no signal that anything is wrong.
+
+This is exactly the sort of rule a later contributor simplifies back out —
+scanning only for `ork.*.png` and ignoring deeper Lineages looks equivalent and
+is cheaper. It is not equivalent. The adoption hazard is the entire reason the
+scan goes deep.
+
+Rejected: gap-filling, reusing the lowest free index. It keeps numbers small
+and tidy, but resurrecting a deleted `ork.4` is precisely the adoption case
+above.
+
+## Consequences
+
+- **Numbers drift upward and are not a count.** A heavily curated Target
+  reaches `ork.23` with three Candidates on disk. A Lineage is a coordinate;
+  `spf assets list --candidates` is what says which actually exist.
+- **Deleting Candidates never reclaims coordinates.** Cleaning up is safe —
+  it can only ever free disk, never renumber what is left.
+- **Concurrent generate runs would collide.** Two simultaneous
+  `spf assets image` invocations compute the same maximum and write the same
+  indices. `spf` is a single-user CLI and locking is not worth its cost, so
+  this is accepted rather than solved.

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "codetiming>=1.4.0",
     "configaroo>=0.6.1",
     "cyclopts>=4.10.1",
     "jinja2>=3.1.6",

--- a/v3/src/spf/assets/__init__.py
+++ b/v3/src/spf/assets/__init__.py
@@ -16,7 +16,13 @@ from spf.assets.kinds import (
     get_kind,
     register_kind,
 )
-from spf.assets.spine import generate, promote, refine, validate_lineage
+from spf.assets.spine import (
+    generate,
+    promote,
+    refine,
+    stage_promoted,
+    validate_lineage,
+)
 from spf.assets.survey import Coverage, Survey, survey
 from spf.assets.targets import Target, targets
 
@@ -33,6 +39,7 @@ __all__ = [
     "promote",
     "refine",
     "register_kind",
+    "stage_promoted",
     "survey",
     "targets",
     "validate_lineage",

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -226,3 +226,30 @@ def promote(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fou
     asset.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(candidate, asset)
     return asset
+
+
+def stage_promoted(
+    kind: Kind,
+    *,
+    race: str,
+    name: str,
+    candidates_root: Path = config.paths.candidates,
+    assets_root: Path = config.paths.assets,
+) -> str:
+    """Copy the promoted Asset back into the Candidate store, returning its Lineage.
+
+    The exact inverse of `promote`: a plain `copyfile` the other way, taking
+    the next free index (see `_next_index`) so the Asset becomes an ordinary
+    Candidate addressable by Lineage. Raises `ValueError` when the Target has
+    no promoted Asset.
+    """
+    asset = _asset_dir(assets_root, kind, race=race) / f"{name}.{kind.extension}"
+    if not asset.is_file():
+        msg = f"No promoted asset to stage at {asset}"
+        raise ValueError(msg)
+
+    directory = _asset_dir(candidates_root, kind, race=race)
+    directory.mkdir(parents=True, exist_ok=True)
+    lineage = str(_next_index(directory, kind, name=name))
+    shutil.copyfile(asset, directory / f"{name}.{lineage}.{kind.extension}")
+    return lineage

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -3,8 +3,10 @@
 All three are kind-agnostic — behavior comes entirely from the `Kind`
 record. A Kind's layout is `<race>/[<subdir>/]<name>.<extension>`; Candidates
 insert a 1-based `.<index>` before the extension so the same layout addresses
-both stores. A Refinement generates under the derived name `<name>.<lineage>`,
-which is that same rule applied twice, so Lineage needs no store of its own.
+both stores. The index is allocated past whatever is already on disk rather
+than restarting each run, so a Candidate is never overwritten (ADR 0013).
+A Refinement generates under the derived name `<name>.<lineage>`, which is
+that same rule applied twice, so Lineage needs no store of its own.
 
 `refine` is available only for Kinds whose Service implements the optional
 `Refiner` protocol; the others raise a clean `TypeError`.
@@ -63,6 +65,25 @@ def _asset_dir(root: Path, kind: Kind, *, race: str) -> Path:
     return directory
 
 
+def _next_index(directory: Path, kind: Kind, *, name: str) -> int:
+    """Return the index a new Candidate of `name` should take.
+
+    One past the highest first-component Lineage already present *anywhere*
+    under `name`, so a surviving refinement (`ork.4.1`) reserves its parent's
+    number even when the parent itself was deleted. Indices are never reused
+    and gaps are never filled (see ADR 0013).
+    """
+    highest = 0
+    # The `.` separator keeps prefix-siblings apart: globbing `grunt.*` will
+    # not match `grunt_carrier.1.txt`.
+    for path in directory.glob(f"{name}.*.{kind.extension}"):
+        split = _split_lineage(path.name[: -len(kind.extension) - 1])
+        if split is None:
+            continue
+        highest = max(highest, int(split[1].split(".")[0]))
+    return highest + 1
+
+
 def _candidate_writer(
     directory: Path,
     kind: Kind,
@@ -72,16 +93,20 @@ def _candidate_writer(
 ) -> tuple[list[Path], Callable[[bytes | str], None]]:
     """Return `(paths, persist)` for writing Candidates as a Service yields them.
 
-    `persist` writes each value to `<name>.<index>.<extension>` with a 1-based
-    index, inferring text-vs-binary mode from the value's type, and appends the
-    path to `paths`. Shared by `generate` and `refine`, which differ only in
-    which Service call drives it.
+    `persist` writes each value to `<name>.<index>.<extension>`, inferring
+    text-vs-binary mode from the value's type, and appends the path to `paths`.
+    The first index comes from `_next_index`, so a run appends past whatever is
+    already on disk instead of overwriting it. It is computed once, up front:
+    the files this writer itself creates must not shift the numbering. Shared
+    by `generate` and `refine`, which differ only in which Service call drives
+    it.
     """
     directory.mkdir(parents=True, exist_ok=True)
+    start = _next_index(directory, kind, name=name)
     paths: list[Path] = []
 
     def persist(value: bytes | str) -> None:
-        path = directory / f"{name}.{len(paths) + 1}.{kind.extension}"
+        path = directory / f"{name}.{start + len(paths)}.{kind.extension}"
         if isinstance(value, bytes):
             path.write_bytes(value)
         else:
@@ -107,12 +132,13 @@ def generate(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fo
     """Generate `count` Candidates for `source` and write them to disk.
 
     Each generated value is written to
-    `candidates_root/<race>/[<subdir>/]<name>.<index>.<extension>` with a
-    1-based index, inferring text-vs-binary mode from the value's type, *as soon
-    as the Service produces it* — so a slow batch persists each Candidate rather
-    than waiting for the whole run. Existing candidate files are overwritten
-    silently. `on_candidate` (when given) is called with each path right after
-    it is written. Returns the written paths in order. `seed` is threaded
+    `candidates_root/<race>/[<subdir>/]<name>.<index>.<extension>`, inferring
+    text-vs-binary mode from the value's type, *as soon as the Service produces
+    it* — so a slow batch persists each Candidate rather than waiting for the
+    whole run. Indices append past the highest Lineage already present under
+    `name`, so an existing Candidate is never overwritten and gaps are never
+    filled (ADR 0013). `on_candidate` (when given) is called with each path
+    right after it is written. Returns the written paths in order. `seed` is threaded
     straight to the Service (see `Service`).
     """
     directory = _asset_dir(candidates_root, kind, race=race)
@@ -142,10 +168,11 @@ def refine(  # noqa: PLR0913  mirrors `generate`, plus the Lineage being refined
     Correction as its whole prompt (ADR 0010).
 
     The new Candidates are generated under the *derived* name
-    `<name>.<lineage>`, so refining Candidate `2` of `grunt` writes
-    `grunt.2.1`, `grunt.2.2`, … The source Candidate is never overwritten, and
-    the derivation reads straight off the filename. Chaining follows the same
-    rule, so `2.1` refines to `2.1.1`.
+    `<name>.<lineage>`, so a first refinement of Candidate `2` of `grunt`
+    writes `grunt.2.1`, `grunt.2.2`, … and a second one continues at
+    `grunt.2.3` rather than restarting. The source Candidate is never
+    overwritten, and the derivation reads straight off the filename. Chaining
+    follows the same rule, so `2.1` refines to `2.1.1`.
 
     Raises `ValueError` when `lineage` is malformed or its Candidate is
     missing, and `TypeError` when the Kind's Service cannot refine.

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -19,6 +19,7 @@ from spf.assets.kinds import Kind, Refiner
 from spf.config import config
 
 LINEAGE_PATTERN = re.compile(r"^[1-9][0-9]*(\.[1-9][0-9]*)*$")
+_INDEX_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 def validate_lineage(lineage: str) -> str:
@@ -36,6 +37,22 @@ def validate_lineage(lineage: str) -> str:
         )
         raise ValueError(msg)
     return lineage
+
+
+def _split_lineage(stem: str) -> tuple[str, str] | None:
+    """Return `(target_name, lineage)` for a Candidate stem, or `None`.
+
+    Splits from the *right* on components that are whole 1-based indices, so a
+    Target name that itself ends in digits (`ork_char_b1`, `e34`) keeps them.
+    `None` means the stem carries no Lineage at all.
+    """
+    parts = stem.split(".")
+    cut = len(parts)
+    while cut > 1 and _INDEX_PATTERN.match(parts[cut - 1]):
+        cut -= 1
+    if cut == len(parts):
+        return None
+    return ".".join(parts[:cut]), ".".join(parts[cut:])
 
 
 def _asset_dir(root: Path, kind: Kind, *, race: str) -> Path:

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -65,6 +65,16 @@ def _asset_dir(root: Path, kind: Kind, *, race: str) -> Path:
     return directory
 
 
+def _asset_path(root: Path, kind: Kind, *, race: str, name: str) -> Path:
+    """Return the path of `name`'s committed Asset under `root` for `race`.
+
+    The Asset side of the layout, carrying no Lineage — that is what
+    distinguishes it from a Candidate. Shared by `promote`, `stage_promoted`,
+    and the Survey, so the three cannot drift apart.
+    """
+    return _asset_dir(root, kind, race=race) / f"{name}.{kind.extension}"
+
+
 def _next_index(directory: Path, kind: Kind, *, name: str) -> int:
     """Return the index a new Candidate of `name` should take.
 
@@ -222,7 +232,7 @@ def promote(  # noqa: PLR0913  the seam's parameters are fixed by the assets-fou
         msg = f"No candidate to promote at {candidate} (pick {pick})"
         raise ValueError(msg)
 
-    asset = _asset_dir(assets_root, kind, race=race) / f"{name}.{kind.extension}"
+    asset = _asset_path(assets_root, kind, race=race, name=name)
     asset.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(candidate, asset)
     return asset
@@ -243,7 +253,7 @@ def stage_promoted(
     Candidate addressable by Lineage. Raises `ValueError` when the Target has
     no promoted Asset.
     """
-    asset = _asset_dir(assets_root, kind, race=race) / f"{name}.{kind.extension}"
+    asset = _asset_path(assets_root, kind, race=race, name=name)
     if not asset.is_file():
         msg = f"No promoted asset to stage at {asset}"
         raise ValueError(msg)

--- a/v3/src/spf/assets/spine.py
+++ b/v3/src/spf/assets/spine.py
@@ -21,7 +21,7 @@ from spf.assets.kinds import Kind, Refiner
 from spf.config import config
 
 LINEAGE_PATTERN = re.compile(r"^[1-9][0-9]*(\.[1-9][0-9]*)*$")
-_INDEX_PATTERN = re.compile(r"^[1-9][0-9]*$")
+INDEX_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 def validate_lineage(lineage: str) -> str:
@@ -50,7 +50,7 @@ def _split_lineage(stem: str) -> tuple[str, str] | None:
     """
     parts = stem.split(".")
     cut = len(parts)
-    while cut > 1 and _INDEX_PATTERN.match(parts[cut - 1]):
+    while cut > 1 and INDEX_PATTERN.match(parts[cut - 1]):
         cut -= 1
     if cut == len(parts):
         return None

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -10,18 +10,15 @@ the only part that touches disk.
 """
 
 import hashlib
-import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from spf.assets.kinds import Kind
-from spf.assets.spine import _asset_dir
+from spf.assets.spine import _asset_dir, _split_lineage
 from spf.assets.targets import Target, targets
 from spf.config import config
 from spf.schemas import type_aliases as t
-
-_INDEX_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 @dataclass(frozen=True)
@@ -130,22 +127,6 @@ def _digest(path: Path) -> bytes:
 def _lineage_key(lineage: str) -> tuple[int, ...]:
     """Return the sort key for a Lineage: `2.1` sorts before `10`, not after."""
     return tuple(int(part) for part in lineage.split("."))
-
-
-def _split_lineage(stem: str) -> tuple[str, str] | None:
-    """Return `(target_name, lineage)` for a Candidate stem, or `None`.
-
-    Splits from the *right* on components that are whole 1-based indices, so a
-    Target name that itself ends in digits (`ork_char_b1`, `e34`) keeps them.
-    `None` means the stem carries no Lineage at all.
-    """
-    parts = stem.split(".")
-    cut = len(parts)
-    while cut > 1 and _INDEX_PATTERN.match(parts[cut - 1]):
-        cut -= 1
-    if cut == len(parts):
-        return None
-    return ".".join(parts[:cut]), ".".join(parts[cut:])
 
 
 def _candidates_by_name(candidate_dir: Path, kind: Kind) -> dict[str, list[str]]:

--- a/v3/src/spf/assets/survey.py
+++ b/v3/src/spf/assets/survey.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from spf.assets.kinds import Kind
-from spf.assets.spine import _asset_dir, _split_lineage
+from spf.assets.spine import _asset_dir, _asset_path, _split_lineage
 from spf.assets.targets import Target, targets
 from spf.config import config
 from spf.schemas import type_aliases as t
@@ -61,7 +61,7 @@ def survey(
     found = targets(kind, race)
     rows = []
     for target in found:
-        asset = _asset_for(asset_dir, kind, target)
+        asset = _asset_for(assets_root, kind, target, race=race)
         lineages = sorted(waiting.get(target.name, []), key=_lineage_key)
         rows.append(
             Coverage(
@@ -90,9 +90,9 @@ def survey(
     return Survey(rows=rows, orphans=orphans)
 
 
-def _asset_for(asset_dir: Path, kind: Kind, target: Target) -> Path | None:
+def _asset_for(root: Path, kind: Kind, target: Target, *, race: str) -> Path | None:
     """Return the committed Asset for `target`, or `None` when there is none."""
-    path = asset_dir / f"{target.name}.{kind.extension}"
+    path = _asset_path(root, kind, race=race, name=target.name)
     return path if path.is_file() else None
 
 

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -266,7 +266,7 @@ def _timed_candidates() -> Iterator[Callable[[Path], None]]:
 
 
 def _refine_source(
-    kind: str, *, race: t.RaceName, name: str, from_: str | None, promoted: bool
+    kind: AssetKind, *, race: t.RaceName, name: str, from_: str | None, promoted: bool
 ) -> str:
     """Return the Lineage a refinement starts from, staging the Asset if asked.
 
@@ -277,21 +277,19 @@ def _refine_source(
     """
     if not promoted:
         if from_ is None:
-            # _SOURCE already requires exactly one of the two, so this guards
-            # that group being loosened, not a path a user can reach.
+            # Narrows `from_` to `str`; _SOURCE already rules this out.
             msg = "either --from or --promoted is required"
             raise ValueError(msg)
         return from_
 
-    asset_kind = get_kind(kind)
     lineage = stage_promoted(
-        asset_kind,
+        kind,
         race=race,
         name=name,
         candidates_root=config.paths.candidates,
         assets_root=config.paths.assets,
     )
-    stdout.print(f"Copied promoted asset to {name}.{lineage}.{asset_kind.extension}")
+    stdout.print(f"Copied promoted asset to {name}.{lineage}.{kind.extension}")
     return lineage
 
 
@@ -321,6 +319,7 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     instructions. Results land under the derived name `NAME.LINEAGE`, so
     refining `2` writes `2.1`, `2.2`, … and the original is left alone.
     """
+    asset_kind = get_kind(kind)
     count, seed = (opts or AssetOpts()).resolve()
     stdout.print(f"Seed: {seed}  (rerun with --seed {seed} to reproduce)")
 
@@ -328,16 +327,16 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     # the Correction. The Negative Prompt is an image concern, so name its file
     # only when an image is what is being refined.
     stdout.print(correction, style="dim", markup=False)
-    if kind == "image":
+    if asset_kind.name == "image":
         stdout.print(_negative_prompt_echo(), style="dim", soft_wrap=True)
 
     try:
         lineage = _refine_source(
-            kind, race=race, name=name, from_=from_, promoted=promoted
+            asset_kind, race=race, name=name, from_=from_, promoted=promoted
         )
         with _timed_candidates() as on_candidate:
             refine(
-                get_kind(kind),
+                asset_kind,
                 correction,
                 race=race,
                 name=name,

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -21,6 +21,7 @@ from spf.assets import (
     get_kind,
     promote,
     refine,
+    stage_promoted,
     survey,
     targets,
     validate_lineage,
@@ -38,6 +39,13 @@ _SEED_BOUND = 2**31
 # UNIT, --all and --missing pick *which* Targets to generate for, so at most one
 # may be given. LimitedChoice() defaults to min=0, max=1: exactly that rule.
 _SELECTION = cyclopts.Group("Selection", validator=cyclopts.validators.LimitedChoice())
+
+# `refine` always needs a Candidate to start from, and --from and --promoted are
+# the two ways to name one — so unlike _SELECTION this group takes min=1,
+# requiring exactly one rather than at most one.
+_SOURCE = cyclopts.Group(
+    "Source", validator=cyclopts.validators.LimitedChoice(min=1, max=1)
+)
 
 
 def add_commands(app: cyclopts.App) -> None:
@@ -78,8 +86,14 @@ def _negative_prompt_echo() -> str:
     return f"Negative: {shown}"
 
 
-def _validate_lineage(_type: type, value: str) -> None:
-    """Reject a Lineage that is not a dotted 1-based index."""
+def _validate_lineage(_type: type, value: str | None) -> None:
+    """Reject a Lineage that is not a dotted 1-based index.
+
+    `None` is an omitted optional `--from`, which `refine --promoted` resolves
+    for itself — the validator must let it through rather than parse it.
+    """
+    if value is None:
+        return
     validate_lineage(value)  # raises ValueError describing the expected shape
 
 
@@ -218,13 +232,46 @@ def promote_asset(race: t.RaceName, kind: Kind, name: str, *, pick: Lineage) -> 
     )
 
 
+def _refine_source(
+    kind: str, *, race: t.RaceName, name: str, from_: str | None, promoted: bool
+) -> str:
+    """Return the Lineage a refinement starts from, staging the Asset if asked.
+
+    With `--promoted` the committed Asset is copied back into the Candidate
+    store first and reported by name, so the refinement itself stays the
+    ordinary Candidate-to-Candidate operation. Raises `ValueError` when there
+    is no promoted Asset to stage.
+    """
+    if not promoted:
+        if from_ is None:
+            # _SOURCE already requires exactly one of the two, so this guards
+            # that group being loosened, not a path a user can reach.
+            msg = "either --from or --promoted is required"
+            raise ValueError(msg)
+        return from_
+
+    asset_kind = get_kind(kind)
+    lineage = stage_promoted(
+        asset_kind,
+        race=race,
+        name=name,
+        candidates_root=config.paths.candidates,
+        assets_root=config.paths.assets,
+    )
+    stdout.print(f"Copied promoted asset to {name}.{lineage}.{asset_kind.extension}")
+    return lineage
+
+
 def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opts
     race: t.RaceName,
     kind: Kind,
     name: str,
     correction: str,
     *,
-    from_: Annotated[Lineage, cyclopts.Parameter(name="--from")],
+    from_: Annotated[
+        Lineage | None, cyclopts.Parameter(name="--from", group=_SOURCE)
+    ] = None,
+    promoted: Annotated[bool, cyclopts.Parameter(group=_SOURCE)] = False,
     opts: Annotated[AssetOpts | None, cyclopts.Parameter(name="*")] = None,
 ) -> None:
     """Refine an existing Candidate by applying a CORRECTION to it.
@@ -232,7 +279,9 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
     RACE is the race the Asset belongs to, KIND its Asset kind, NAME its base
     file name, and CORRECTION the edit to apply ("make the hat brass instead
     of leather"). `--from` picks the Candidate to refine by Lineage, the same
-    dotted index `promote --pick` takes.
+    dotted index `promote --pick` takes; `--promoted` instead refines the
+    committed Asset, staging a copy of it into the Candidate store first.
+    Exactly one of the two is required.
 
     The Correction is the whole prompt — no `prompts/image.txt` preamble and no
     race description, because an instruction-edit model is trained on
@@ -250,12 +299,15 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
         stdout.print(_negative_prompt_echo(), style="dim", soft_wrap=True)
 
     try:
+        lineage = _refine_source(
+            kind, race=race, name=name, from_=from_, promoted=promoted
+        )
         refine(
             get_kind(kind),
             correction,
             race=race,
             name=name,
-            lineage=from_,
+            lineage=lineage,
             count=count,
             seed=seed,
             candidates_root=config.paths.candidates,
@@ -265,8 +317,10 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
         stderr.print(f"[red]Error:[/] refinement failed: {err}")
         raise SystemExit(1) from None
 
+    # The *resolved* Lineage: with --promoted there is no `from_` to name, and
+    # interpolating it would render `--pick None.N`.
     stdout.print(
-        f"Promote one with: spf assets promote {race} {kind} {name} --pick {from_}.N"
+        f"Promote one with: spf assets promote {race} {kind} {name} --pick {lineage}.N"
     )
 
 

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -7,11 +7,15 @@ subcommands accept, and the first concrete generate subcommand,
 """
 
 import random
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated
 
 import cyclopts
 import pydantic
+from codetiming import Timer
 
 from spf import races
 from spf.assets import (
@@ -232,6 +236,35 @@ def promote_asset(race: t.RaceName, kind: Kind, name: str, *, pick: Lineage) -> 
     )
 
 
+@contextmanager
+def _timed_candidates() -> Iterator[Callable[[Path], None]]:
+    """Yield an `on_candidate` reporting each Candidate with its elapsed time.
+
+    The interval is the gap between two Service callbacks, so it is stopped and
+    restarted per candidate rather than wrapped in a scope of its own. A job
+    yielding several images reports the elapsed time against the first.
+    """
+    timer = Timer(logger=None)
+
+    def report(path: Path) -> None:
+        stdout.print(
+            f"Wrote {path} ({timer.stop():.1f}s)",
+            highlight=False,
+            soft_wrap=True,  # a path is copied or piped, never reflowed
+        )
+        timer.start()
+
+    timer.start()
+    try:
+        yield report
+    finally:
+        # `report` restarts the timer after the last Candidate and the Service
+        # can raise mid-batch, so the timer is always still running here. The
+        # Timer is per-context, so stopping it is hygiene rather than a fix for
+        # anything observable.
+        timer.stop()
+
+
 def _refine_source(
     kind: str, *, race: t.RaceName, name: str, from_: str | None, promoted: bool
 ) -> str:
@@ -302,17 +335,18 @@ def refine_asset(  # noqa: PLR0913  mirrors promote, plus the Correction and opt
         lineage = _refine_source(
             kind, race=race, name=name, from_=from_, promoted=promoted
         )
-        refine(
-            get_kind(kind),
-            correction,
-            race=race,
-            name=name,
-            lineage=lineage,
-            count=count,
-            seed=seed,
-            candidates_root=config.paths.candidates,
-            on_candidate=lambda path: stdout.print(f"Wrote {path}"),
-        )
+        with _timed_candidates() as on_candidate:
+            refine(
+                get_kind(kind),
+                correction,
+                race=race,
+                name=name,
+                lineage=lineage,
+                count=count,
+                seed=seed,
+                candidates_root=config.paths.candidates,
+                on_candidate=on_candidate,
+            )
     except (OSError, ComfyUIError, TypeError, ValueError) as err:
         stderr.print(f"[red]Error:[/] refinement failed: {err}")
         raise SystemExit(1) from None
@@ -401,16 +435,17 @@ def _generate_image(
     stdout.print(_negative_prompt_echo(), style="dim", soft_wrap=True)
 
     try:
-        generate(
-            kind,
-            prompt,
-            race=race,
-            name=target.name,
-            count=count,
-            seed=seed,
-            candidates_root=config.paths.candidates,
-            on_candidate=lambda path: stdout.print(f"Wrote {path}"),
-        )
+        with _timed_candidates() as on_candidate:
+            generate(
+                kind,
+                prompt,
+                race=race,
+                name=target.name,
+                count=count,
+                seed=seed,
+                candidates_root=config.paths.candidates,
+                on_candidate=on_candidate,
+            )
     except (OSError, ComfyUIError) as err:
         stderr.print(f"[red]Error:[/] image generation failed: {err}")
         raise SystemExit(1) from None

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -84,7 +84,7 @@ def test_promote_command_unknown_kind_errors(
         )
 
 
-# --- Cycle 8: the refine command --------------------------------------------
+# --- the refine command -----------------------------------------------------
 
 
 @pytest.fixture
@@ -349,7 +349,7 @@ def test_list_command_defaults_to_every_registered_kind(
     assert "Ork" in capsys.readouterr().out
 
 
-# --- Cycle 9: refining an already-promoted Asset -----------------------------
+# --- refining an already-promoted Asset -------------------------------------
 
 
 def _promote_asset(content: bytes = b"the committed asset") -> Path:
@@ -427,7 +427,7 @@ def test_refine_promoted_errors_cleanly_without_an_asset(
     assert "grunt.txt" in capsys.readouterr().err
 
 
-# --- Cycle 10: elapsed time per Candidate ------------------------------------
+# --- elapsed time per Candidate ---------------------------------------------
 
 
 @pytest.mark.usefixtures("refinable_registered_kind")

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -1,11 +1,14 @@
 """S5: the shared `spf assets promote` CLI command over a throwaway kind."""
 
+import re
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
 from cyclopts.exceptions import CycloptsError
 
 from spf.assets import Kind, generate, promote
+from spf.assets.comfyui import ComfyUIError
 from spf.assets.kinds import KINDS
 from spf.config import config
 from spf.frontends.cli import app
@@ -422,3 +425,72 @@ def test_refine_promoted_errors_cleanly_without_an_asset(
         app(argv, exit_on_error=False, result_action="return_value")
 
     assert "grunt.txt" in capsys.readouterr().err
+
+
+# --- Cycle 10: elapsed time per Candidate ------------------------------------
+
+
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_command_reports_elapsed_time_per_candidate(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The shape, never a duration: a real timing assertion would need a sleep
+    # to be meaningful, which buys nothing.
+    app(_refine_argv("--count", "2"), exit_on_error=False, result_action="return_value")
+
+    wrote = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if line.startswith("Wrote")
+    ]
+    assert len(wrote) == 2
+    assert all(re.fullmatch(r"Wrote .* \(\d+\.\ds\)", line) for line in wrote)
+
+
+def test_refine_command_survives_a_service_raising_mid_batch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The stopwatch wraps the whole batch, so a Service dying part-way through
+    # it must still leave the Candidates that did land reported, and the
+    # failure surfacing as the ordinary error line.
+    class HalfwayFailingRefiner(FakeRefiner):
+        """Yield every Candidate but the last, then lose the ComfyUI queue."""
+
+        def refine(
+            self,
+            source: str,
+            init: bytes,
+            count: int,
+            *,
+            seed: int | None = None,
+            on_result: Callable[[bytes | str], None] | None = None,
+        ) -> Sequence[bytes | str]:
+            super().refine(source, init, count - 1, seed=seed, on_result=on_result)
+            msg = "the queue went away"
+            raise ComfyUIError(msg)
+
+    kind = Kind(
+        name="_refinable",
+        service=HalfwayFailingRefiner(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+    )
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    candidates = config.paths.candidates / "ork" / "_test"
+    candidates.mkdir(parents=True)
+    (candidates / "grunt.2.txt").write_bytes(b"the original")
+
+    with pytest.raises(SystemExit):
+        app(
+            _refine_argv("--count", "2"),
+            exit_on_error=False,
+            result_action="return_value",
+        )
+
+    captured = capsys.readouterr()
+    # The Candidate that did land is still reported, and the failure surfaces
+    # as the ordinary error line rather than a timer traceback.
+    assert "Wrote" in captured.out
+    assert "the queue went away" in captured.err

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -344,3 +344,81 @@ def test_list_command_defaults_to_every_registered_kind(
     app(["assets", "list", "ork"], exit_on_error=False, result_action="return_value")
 
     assert "Ork" in capsys.readouterr().out
+
+
+# --- Cycle 9: refining an already-promoted Asset -----------------------------
+
+
+def _promote_asset(content: bytes = b"the committed asset") -> Path:
+    """Write a committed Asset for `grunt` under the test kind's layout."""
+    asset = config.paths.assets / "ork" / "_test" / "grunt.txt"
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(content)
+    return asset
+
+
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_command_rejects_both_from_and_promoted() -> None:
+    _promote_asset()
+    argv = [
+        "assets",
+        "refine",
+        "ork",
+        "_refinable",
+        "grunt",
+        "--from",
+        "2",
+        "--promoted",
+        "fix it",
+    ]
+    with pytest.raises(CycloptsError):
+        app(argv, exit_on_error=False, result_action="return_value")
+
+
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_command_requires_from_or_promoted() -> None:
+    argv = ["assets", "refine", "ork", "_refinable", "grunt", "fix it"]
+    with pytest.raises(CycloptsError):
+        app(argv, exit_on_error=False, result_action="return_value")
+
+
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_promoted_stages_the_asset_and_refines_it(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _promote_asset()
+    argv = [
+        "assets",
+        "refine",
+        "ork",
+        "_refinable",
+        "grunt",
+        "--promoted",
+        "make the hat brass",
+        "--count",
+        "1",
+    ]
+    app(argv, exit_on_error=False, result_action="return_value")
+
+    # `grunt.2` is already on disk, so the staged Asset takes 3 and its
+    # refinements hang off that.
+    candidates = config.paths.candidates / "ork" / "_test"
+    assert (candidates / "grunt.3.txt").read_bytes() == b"the committed asset"
+    assert (candidates / "grunt.3.1.txt").read_bytes() == b"one"
+
+    out = capsys.readouterr().out
+    assert "Copied promoted asset to grunt.3.txt" in out
+    # The hint interpolates the resolved Lineage; there is no --from to use.
+    assert "--pick 3.N" in out
+
+
+@pytest.mark.usefixtures("refinable_registered_kind")
+def test_refine_promoted_errors_cleanly_without_an_asset(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    argv = ["assets", "refine", "ork", "_refinable", "grunt", "--promoted", "fix it"]
+
+    with pytest.raises(SystemExit):
+        app(argv, exit_on_error=False, result_action="return_value")
+
+    assert "grunt.txt" in capsys.readouterr().err

--- a/v3/tests/assets/test_comfyui.py
+++ b/v3/tests/assets/test_comfyui.py
@@ -151,7 +151,7 @@ def _service_for(
     return _service(scripted, monkeypatch, workflow_path=workflow)
 
 
-# --- Cycle 1: sub-seed derivation (ported from PollinationsService) ---------
+# --- sub-seed derivation (ported from PollinationsService) ------------------
 
 
 def test_generate_derives_deterministic_distinct_seeds(
@@ -174,7 +174,7 @@ def test_generate_derives_deterministic_distinct_seeds(
     assert len(set(seeds_a)) == 3  # three distinct sub-seeds from one base
 
 
-# --- Cycle 2: graph-follow patching -----------------------------------------
+# --- graph-follow patching --------------------------------------------------
 
 
 def test_patches_prompt_onto_positive_leaving_the_rest_authored(
@@ -340,7 +340,7 @@ def test_patches_an_encoder_that_names_its_input_prompt(
     assert submitted["n"]["inputs"]["prompt"] == _NEGATIVE_TEXT
 
 
-# --- Cycle 3: happy-path flow (N blobs, in order) ---------------------------
+# --- happy-path flow (N blobs, in order) ------------------------------------
 
 
 def test_generate_returns_one_blob_per_job_in_order(
@@ -360,7 +360,7 @@ def test_generate_returns_one_blob_per_job_in_order(
     assert all(g["4"]["inputs"]["batch_size"] == 1 for _, g in scripted.submissions)
 
 
-# --- Cycle 4: poll try-both-and-cache ---------------------------------------
+# --- poll try-both-and-cache ------------------------------------------------
 
 
 def test_poll_tries_both_routes_then_caches_the_winner(
@@ -378,7 +378,7 @@ def test_poll_tries_both_routes_then_caches_the_winner(
     assert polls == ["/api/jobs/pid-1", "/history/pid-1", "/history/pid-2"]
 
 
-# --- Cycle 5: retry vs fail-fast --------------------------------------------
+# --- retry vs fail-fast -----------------------------------------------------
 
 
 class _FakeResponse:
@@ -441,7 +441,7 @@ def test_request_fails_fast_on_client_error(
     assert sleeps == []
 
 
-# --- Cycle 3: multipart upload of a Refinement's init image ------------------
+# --- multipart upload of a Refinement's init image --------------------------
 
 
 def _captured_multipart(
@@ -573,7 +573,7 @@ def test_generate_raises_on_poll_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
         service.generate("a prompt", 1, seed=1)
 
 
-# --- Cycle 6: lazy API key --------------------------------------------------
+# --- lazy API key -----------------------------------------------------------
 
 
 def test_sends_api_key_header_when_env_var_is_set(
@@ -614,7 +614,7 @@ def test_api_key_is_read_lazily_at_generate_time(
     assert {key for _, key in scripted.calls} == {"exported-later"}
 
 
-# --- Cycle 5: refine (upload -> patch init image -> submit/poll/fetch) ------
+# --- refine (upload -> patch init image -> submit/poll/fetch) ---------------
 
 _INIT = _PNG + b"the candidate being refined"
 

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -221,7 +221,7 @@ def test_promote_overwrites_existing_asset_silently(
     assert asset.read_bytes() == b"three"
 
 
-# --- Cycle 6: refine ---------------------------------------------------------
+# --- refine: generating from an existing Candidate --------------------------
 
 
 def _seed_candidate(
@@ -374,7 +374,7 @@ def test_refine_rejects_a_malformed_lineage(
         )
 
 
-# --- Cycle 7: kinds whose Service cannot refine ------------------------------
+# --- kinds whose Service cannot refine --------------------------------------
 
 
 def test_refine_rejects_a_kind_whose_service_cannot_refine(
@@ -395,7 +395,7 @@ def test_refine_rejects_a_kind_whose_service_cannot_refine(
         )
 
 
-# --- Cycle 8: candidate indices are allocated past what is already on disk ---
+# --- candidate indices are allocated past what is already on disk -----------
 
 
 def test_generate_twice_appends_rather_than_overwriting(
@@ -519,7 +519,7 @@ def test_refining_the_same_candidate_twice_continues_the_numbering(
     assert second == [base / "grunt.2.3.txt", base / "grunt.2.4.txt"]
 
 
-# --- Cycle 9: staging a promoted Asset back as a Candidate -------------------
+# --- staging a promoted Asset back as a Candidate ---------------------------
 
 
 def test_stage_promoted_copies_the_asset_into_the_candidate_store(

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -393,3 +393,127 @@ def test_refine_rejects_a_kind_whose_service_cannot_refine(
             count=1,
             candidates_root=tmp_path,
         )
+
+
+# --- Cycle 8: candidate indices are allocated past what is already on disk ---
+
+
+def test_generate_twice_appends_rather_than_overwriting(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    # The bug this repeals: a second run used to restart at 1 and silently
+    # clobber the first run's Candidates.
+    first = generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=tmp_path,
+    )
+    second = generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=tmp_path,
+    )
+
+    base = tmp_path / "orks" / "_test"
+    assert second == [
+        base / "grunt.4.txt",
+        base / "grunt.5.txt",
+        base / "grunt.6.txt",
+    ]
+    assert [p.read_bytes() for p in first] == [b"one", b"two", b"three"]
+
+
+def test_generate_reserves_a_deleted_parent_of_a_surviving_refinement(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    # The adoption guard. `grunt.4` is gone but its refinement `grunt.4.1`
+    # survives, so 4 stays taken: a new Candidate landing on 4 would silently
+    # adopt an orphan derived from different bytes, and `promote --pick 4.1`
+    # would hand back an image from a parent that no longer exists.
+    base = tmp_path / "orks" / "_test"
+    base.mkdir(parents=True)
+    (base / "grunt.4.1.txt").write_bytes(b"an orphaned refinement")
+
+    paths = generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=1,
+        candidates_root=tmp_path,
+    )
+
+    assert paths == [base / "grunt.5.txt"]
+
+
+def test_generate_does_not_fill_gaps(tmp_path: Path, test_kind: Kind) -> None:
+    base = tmp_path / "orks" / "_test"
+    base.mkdir(parents=True)
+    (base / "grunt.1.txt").write_bytes(b"kept")
+    (base / "grunt.3.txt").write_bytes(b"kept")
+
+    paths = generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=1,
+        candidates_root=tmp_path,
+    )
+
+    assert paths == [base / "grunt.4.txt"]
+
+
+def test_generate_ignores_a_prefix_sibling_target(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    # `grunt_carrier` is a different Target that merely starts with `grunt`.
+    # The `.` separator keeps the two apart.
+    base = tmp_path / "orks" / "_test"
+    base.mkdir(parents=True)
+    (base / "grunt_carrier.9.txt").write_bytes(b"another target")
+
+    paths = generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=1,
+        candidates_root=tmp_path,
+    )
+
+    assert paths == [base / "grunt.1.txt"]
+
+
+def test_refining_the_same_candidate_twice_continues_the_numbering(
+    tmp_path: Path, refinable_kind: Kind
+) -> None:
+    _seed_candidate(tmp_path)
+
+    refine(
+        refinable_kind,
+        source="make the hat brass",
+        race="orks",
+        name="grunt",
+        lineage="2",
+        count=2,
+        candidates_root=tmp_path,
+    )
+    second = refine(
+        refinable_kind,
+        source="now make the boots brass",
+        race="orks",
+        name="grunt",
+        lineage="2",
+        count=2,
+        candidates_root=tmp_path,
+    )
+
+    base = tmp_path / "orks" / "_test"
+    assert second == [base / "grunt.2.3.txt", base / "grunt.2.4.txt"]

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from spf.assets import Kind, generate, promote, refine
+from spf.assets import Kind, generate, promote, refine, stage_promoted
 from tests.assets.conftest import FakeRefiner, FakeService
 
 
@@ -517,3 +517,106 @@ def test_refining_the_same_candidate_twice_continues_the_numbering(
 
     base = tmp_path / "orks" / "_test"
     assert second == [base / "grunt.2.3.txt", base / "grunt.2.4.txt"]
+
+
+# --- Cycle 9: staging a promoted Asset back as a Candidate -------------------
+
+
+def test_stage_promoted_copies_the_asset_into_the_candidate_store(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    candidates = tmp_path / "candidates"
+    store = tmp_path / "assets"
+    asset = store / "orks" / "_test" / "grunt.txt"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"the committed asset")
+
+    lineage = stage_promoted(
+        test_kind,
+        race="orks",
+        name="grunt",
+        candidates_root=candidates,
+        assets_root=store,
+    )
+
+    assert lineage == "1"
+    staged = candidates / "orks" / "_test" / "grunt.1.txt"
+    assert staged.read_bytes() == b"the committed asset"
+
+
+def test_stage_promoted_takes_the_next_free_index(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    candidates = tmp_path / "candidates"
+    store = tmp_path / "assets"
+    asset = store / "orks" / "_test" / "grunt.txt"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"the committed asset")
+    generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=candidates,
+    )
+
+    lineage = stage_promoted(
+        test_kind,
+        race="orks",
+        name="grunt",
+        candidates_root=candidates,
+        assets_root=store,
+    )
+
+    assert lineage == "4"
+
+
+def test_stage_promoted_without_an_asset_raises(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    with pytest.raises(ValueError, match="asset"):
+        stage_promoted(
+            test_kind,
+            race="orks",
+            name="grunt",
+            candidates_root=tmp_path / "candidates",
+            assets_root=tmp_path / "assets",
+        )
+
+
+def test_promote_then_stage_promoted_round_trips_the_bytes(
+    tmp_path: Path, test_kind: Kind
+) -> None:
+    candidates = tmp_path / "candidates"
+    store = tmp_path / "assets"
+    generate(
+        test_kind,
+        source="a grunt description",
+        race="orks",
+        name="grunt",
+        count=3,
+        candidates_root=candidates,
+    )
+    promote(
+        test_kind,
+        race="orks",
+        name="grunt",
+        pick="2",
+        candidates_root=candidates,
+        assets_root=store,
+    )
+
+    lineage = stage_promoted(
+        test_kind,
+        race="orks",
+        name="grunt",
+        candidates_root=candidates,
+        assets_root=store,
+    )
+
+    base = candidates / "orks" / "_test"
+    assert lineage == "4"
+    assert (base / f"grunt.{lineage}.txt").read_bytes() == (
+        base / "grunt.2.txt"
+    ).read_bytes()

--- a/v3/tests/assets/test_survey.py
+++ b/v3/tests/assets/test_survey.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from spf.assets import Kind, survey
+from spf.assets import Kind, stage_promoted, survey
 
 
 @pytest.fixture
@@ -168,3 +168,33 @@ def test_survey_extends_orphans_to_candidates_when_asked(
     # By default the Unknown section covers Assets only.
     assert default.orphans == []
     assert detailed.orphans == [stray]
+
+
+def test_survey_recognizes_a_staged_promoted_asset_as_promoted(
+    test_kind: Kind, stores: tuple[Path, Path]
+) -> None:
+    # `stage_promoted` is a plain copy, so the staged Candidate is
+    # byte-identical to the Asset and `--candidates` renders it as
+    # "N (promoted)" with no labelling code of its own (ADR 0012).
+    assets_root, candidates_root = stores
+    _write(assets_root, "grunt.txt", b"the committed asset")
+    _write(candidates_root, "grunt.1.txt", b"something else")
+
+    lineage = stage_promoted(
+        test_kind,
+        race="ork",
+        name="grunt",
+        candidates_root=candidates_root,
+        assets_root=assets_root,
+    )
+    found = survey(
+        test_kind,
+        "ork",
+        assets_root=assets_root,
+        candidates_root=candidates_root,
+        with_candidates=True,
+    )
+
+    by_name = {row.target.name: row for row in found.rows}
+    assert lineage == "2"
+    assert by_name["grunt"].promoted_from == [lineage]

--- a/v3/uv.lock
+++ b/v3/uv.lock
@@ -167,6 +167,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codetiming"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/4e/c40bf151af20ba2748bd6ea24e484d7b6196b1056ba3a1a4ee33b6939c37/codetiming-1.4.0.tar.gz", hash = "sha256:4937bf913a2814258b87eaaa43d9a1bb24711ffd3557a9ab6934fa1fe3ba0dbc", size = 14899, upload-time = "2022-11-08T07:12:29.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/91/e4a2b7c64e738beefddfa24b409d6eecb16c378bde01578918b6ea722a09/codetiming-1.4.0-py3-none-any.whl", hash = "sha256:3b80f409bef00941a9755c5524071ce2f72eaa4520f4bc35b33869cde024ccbd", size = 7165, upload-time = "2022-11-08T07:12:23.553Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -651,7 +660,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1248,6 +1257,7 @@ name = "spf"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "codetiming" },
     { name = "configaroo" },
     { name = "cyclopts" },
     { name = "jinja2" },
@@ -1269,6 +1279,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "codetiming", specifier = ">=1.4.0" },
     { name = "configaroo", specifier = ">=0.6.1" },
     { name = "cyclopts", specifier = ">=4.10.1" },
     { name = "jinja2", specifier = ">=3.1.6" },


### PR DESCRIPTION
Closes #52.

Three independent improvements to the asset generation flow, landed as six commits.

### Unique Candidate numbers (must go first — item 2 builds on its allocator)

`_candidate_writer` hardcoded a 1-based index per run, so a second `spf assets image` over the same Target silently overwrote the first run's Candidates. Indices now append past the highest Lineage already on disk.

The maximum runs over the **whole subtree**, not just single-component Lineages: a surviving `ork.4.1.png` reserves `4` even when `ork.4.png` was deleted. Otherwise a new Candidate landing on `4` silently adopts the orphan as its own Refinement, and `promote --pick 4.1` hands back an image derived from a parent that no longer exists. ADR 0013 records this, because it is the sort of rule a later contributor simplifies back out.

`_split_lineage` moved from `survey.py` into `spine.py` (first commit, pure refactor) — the import direction runs survey → spine, so the allocator can't reach it where it was.

### `spf assets refine --promoted`

Refines the committed Asset rather than a Candidate. A new `stage_promoted` seam copies the Asset back into the Candidate store at the next free index — the exact inverse of `promote` — so the refinement itself stays the ordinary Candidate-to-Candidate operation. `--from` and `--promoted` form a Source group requiring exactly one.

Because staging is a plain copy, `survey` digest-matches it and `assets list --candidates` renders it as `6 (promoted)` with no labelling code of its own (ADR 0012). Pinned by a test rather than implemented.

### Elapsed time per Candidate

```console
Wrote candidates/goblin/images/goblin_infantry.4.png (18.4s)
```

A CLI-side stopwatch (`codetiming`) reporting the inter-callback delta, used by both `image` and `refine`. Kept out of the `Service`/`Refiner` protocols deliberately — threading seconds through `on_result` would change both spine seams and every fake.

Known limitation, noted in the helper's docstring and not engineered around: a ComfyUI job returning several images reports the elapsed time against the first. Every workflow in `workflows/` is one-image-per-job today.

### Notes for review

- Tests assert the *shape* of the timing line, never a duration — no sleeps.
- The plan expected the batch's `finally` to guard against a double `Timer.start()`. It doesn't: each context builds a fresh `Timer`, so a leaked running one is unobservable. The `finally` is kept as hygiene and the comment says so rather than claiming more.
- `just check` green at every commit; verified against the real CLI with a deliberately slow fake Service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJf3iJXzuUNdpWHucnTizs