### PR TITLE
Show Brief coverage in `spf assets list` (#60)

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -227,6 +227,18 @@ for the generation step.
 _Note_: overloads the domain **Model** (a single figure in a Unit); a Model
 asset is the printable mesh *of* such a figure.
 
+**Brief** (asset generation):
+The authored TOML text a Kind generates a Target's Candidates from — for an
+Image, the Target's `description` field. Which text that is, is declared by the
+Kind itself (`Kind.brief`), so a Kind that generates from something other than
+`description` needs no change to the Targets or the listing code (ADR 0014).
+Distinct from the Prompt, which is *composed* from the Brief plus the configured
+preamble. A Target without a Brief cannot be generated for, so `spf assets list`
+marks it `no brief`.
+_Avoid_: prompt (that's the composed string), seed (that's the RNG seed),
+description (the TOML field name; for an Image the two coincide, for another
+Kind they may not)
+
 **Environment** (image generation):
 A configured ComfyUI target — `local` (a contributor's own ComfyUI) or `cloud`
 (Comfy Cloud) — the Image Service submits to, selected by

--- a/v3/docs/adr/0014-brief-is-a-kind-declared-generation-input.md
+++ b/v3/docs/adr/0014-brief-is-a-kind-declared-generation-input.md
@@ -1,0 +1,117 @@
+# The Brief is a Kind-declared generation input
+
+ADR 0011 made `spf assets list` answer "which Targets have an Asset?". It could
+not answer the question a curator asks next — "which Targets *could* have one?"
+Of 101 Targets, **39 have no description at all**, and three races (darkelf,
+dwarf, gnome) are essentially unbriefed entirely. A red ✗ on those rows means
+*blocked*, not *queued*, and the listing rendered the two identically:
+
+```console
+$ spf assets list dwarf --kind image
+Dwarf
+  Image
+  - dwarf                    Dwarf                    ✗ no brief
+  - dwarf_infantry           Dwarf Infantry           ✗ no brief 2 candidates
+```
+
+So more than a third of the worklist was noise: generating for any of those
+rows fails, and nothing on screen said so before the GPU time was spent.
+
+## The Brief is a thing, and the Kind declares it
+
+**Decision: a `Kind.brief` field naming the authored text that Kind generates
+its Candidates from.** For an Image that is the Target's `description`; Lore
+and Model will declare their own when they register.
+
+This is the same argument `Kind.targets` won in ADR 0011. Which text a kind
+generates from is exactly the sort of per-kind fact the registry already holds,
+so the listing code — and `--missing`, and the generate guard — never change
+when a Kind lands. `Target` carries the resolved Brief, so nothing downstream
+of `targets()` knows which field it came from.
+
+The term is **Brief**, not *prompt*: `assets.image.prompt` is already the
+preamble *file*, "Negative Prompt" is already a glossary term, and the composed
+positive prompt is a third thing. The Brief is an *ingredient* of the Prompt.
+Nor *seed* — `--seed` is the RNG seed.
+
+Rejected: *Prerequisite* (names a status, not a thing, and is unwieldy as a
+flag); *Source* (collides with `Service.generate(source=…)`, which is the
+composed prompt, not the Brief).
+
+## A callable, not a field name
+
+**Decision: `brief` is an extractor, `Callable[[Described], str]`, rather than
+the *name* of a field to read.**
+
+This is the paragraph that matters most to a later reader, because a field name
+is obviously simpler and this looks like over-engineering. It is not: when this
+was written, **Lore's Brief shape was unknown**. Lore plausibly generates from
+the whole `RaceConfig` — units, equipment and all — rather than from one string
+field, and `brief_field: str` cannot express that. The callable is the escape
+hatch that keeps Lore from being boxed in by a decision made before anyone knew
+what Lore needed.
+
+`Kind` is a frozen dataclass holding a callable, so it is no longer trivially
+`repr`-comparable in a test failure. Accepted.
+
+Rejected: `brief_field: str` (see above). Rejected: a presence-only `bool` —
+it answers the column's question but kills `--briefs`, which needs the text.
+
+## Required, with no default
+
+**Decision: `brief` has no default, so every Kind must declare it.**
+
+ADR 0011 made the same call for `Kind.targets`, and here the failure mode is
+sharper. A default of `attrgetter("description")` would not error on a Lore
+Kind that forgot to set it — it would silently generate Lore from the race's
+one-line blurb instead of its real Brief, and the output would look plausible.
+A default also *assumes* the single-field shape that the callable exists to
+avoid assuming.
+
+The cost is 10 construction sites updated in one commit, 9 of them in tests.
+
+## Normalization happens at `targets()`, not at display
+
+**Decision: `targets()` collapses newlines and runs of whitespace to single
+spaces and strips both ends, so `Target.brief` is always one clean paragraph.**
+
+Briefs are authored as multi-line TOML strings. Normalizing at display would
+leave the Service receiving the ragged original while the screen showed the
+tidy version — two different strings under one name. Normalizing at resolution
+means the text shown by `--briefs` *is* the text sent to the Service, which is
+the entire point of proofreading it there.
+
+## The seam holds
+
+**Decision: `survey.py` is unchanged; the CLI reads `row.target.brief`.**
+
+ADR 0011 split these two on whether they touch disk: `targets()` is pure TOML,
+`survey()` reads the filesystem. A Brief is a TOML fact, so it stays on the
+pure side and rides into the listing on the `Target` that `Coverage` already
+holds. Lifting a `has_brief` onto `Coverage` would have put a TOML question on
+the filesystem side of that split for no gain.
+
+## Consequences
+
+- **Candidates generated before this change from a multi-line Brief will not
+  reproduce byte-identically from the same `--seed`.** The normalized Brief is
+  a different string, so the composed prompt differs and the Service returns
+  different images. This is accepted deliberately, and is called out here
+  because a reader will otherwise reasonably assume a *listing* change could
+  not affect generation.
+- **A fully-briefed race renders almost as it did before.** The marker is
+  asymmetric — only Brief-less rows carry it — so briefed rows gain no word.
+  They do gain the marker's fixed-width slot, which shifts the candidate count
+  right by its width; that slot is what keeps the count aligned between marked
+  and unmarked rows.
+- **`--briefs` prints for every row**, unlike `--candidates`, which is gated on
+  a non-empty list. Proofreading wants the briefed rows most of all.
+- **A Brief is printed with markup disabled.** It is arbitrary authored prose,
+  and a `[` in it would otherwise parse as a Rich tag and swallow the line.
+- **The 39 gaps are now visible and will be filled over time**, so tests must
+  not reach for a race that happens to be unbriefed today — they force the
+  state through a Kind's own extractor instead.
+
+Out of scope: the `--missing` interaction, where a Brief-less Target aborts the
+whole batch (filed as issue #61); any `spf` command that *writes* Briefs; and
+Lore's and Model's actual Brief extractors, which land with those Kinds.

--- a/v3/src/spf/assets/image.py
+++ b/v3/src/spf/assets/image.py
@@ -9,6 +9,8 @@ and registers the Kind. The provider — one stdlib client across local ComfyUI
 and Comfy Cloud — lives in `spf.assets.comfyui` (see ADR 0009).
 """
 
+import operator
+
 from spf.assets.comfyui import ComfyUIService
 from spf.assets.kinds import Kind, register_kind
 from spf.config import config
@@ -39,5 +41,6 @@ IMAGE = register_kind(
         subdir="images",
         extension="png",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
 )

--- a/v3/src/spf/assets/kinds.py
+++ b/v3/src/spf/assets/kinds.py
@@ -16,6 +16,13 @@ from typing import Literal, Protocol, runtime_checkable
 TargetLevel = Literal["race", "unit", "model"]
 
 
+class Described(Protocol):
+    """The shape every level's entries share: a display name and a blurb."""
+
+    name: str
+    description: str
+
+
 class Service(Protocol):
     """Generates the raw content for a Kind's Candidates."""
 
@@ -77,6 +84,13 @@ class Kind:
     extension: str
     targets: frozenset[TargetLevel]
     """The levels this Kind can depict: an Image targets a Race or a Unit."""
+
+    brief: Callable[[Described], str]
+    """Extracts the Brief — the authored text this Kind generates from.
+
+    A callable rather than a field name because a Kind may compose its Brief
+    from several fields, or from the whole entry (ADR 0014).
+    """
 
 
 KINDS: dict[str, Kind] = {}

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -11,10 +11,9 @@ actually on disk is `survey`'s job.
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Protocol
 
 from spf import races
-from spf.assets.kinds import Kind, TargetLevel
+from spf.assets.kinds import Described, Kind, TargetLevel
 from spf.schemas import type_aliases as t
 
 
@@ -24,21 +23,19 @@ class Target:
 
     name: str
     human_name: str
-    description: str
+    brief: str
+    """The authored text this Target's Kind generates from (ADR 0014).
+
+    Empty when the Target has no Brief.
+    """
+
     level: TargetLevel
-
-
-class _Described(Protocol):
-    """The shape every level's entries share: a display name and a blurb."""
-
-    name: str
-    description: str
 
 
 # Every level resolves to a mapping of key to described entry, so the race
 # level -- a single object -- is wrapped in one to match. Insertion order is
 # the order Targets come back in: race, then units, then models.
-_LEVELS: dict[TargetLevel, Callable[[t.RaceName], Mapping[str, _Described]]] = {
+_LEVELS: dict[TargetLevel, Callable[[t.RaceName], Mapping[str, Described]]] = {
     "race": lambda race: {race: races.get_metadata(race)},
     "unit": races.get_units,
     "model": races.get_models,
@@ -55,7 +52,7 @@ def targets(kind: Kind, race: t.RaceName) -> list[Target]:
         Target(
             name=name,
             human_name=entry.name,
-            description=entry.description,
+            brief=kind.brief(entry),
             level=level,
         )
         for level, getter in _LEVELS.items()

--- a/v3/src/spf/assets/targets.py
+++ b/v3/src/spf/assets/targets.py
@@ -26,7 +26,8 @@ class Target:
     brief: str
     """The authored text this Target's Kind generates from (ADR 0014).
 
-    Empty when the Target has no Brief.
+    Always whitespace-normalized: newlines and runs of spaces collapsed to a
+    single space, both ends stripped. Empty when the Target has no Brief.
     """
 
     level: TargetLevel
@@ -52,7 +53,7 @@ def targets(kind: Kind, race: t.RaceName) -> list[Target]:
         Target(
             name=name,
             human_name=entry.name,
-            brief=kind.brief(entry),
+            brief=" ".join(kind.brief(entry).split()),
             level=level,
         )
         for level, getter in _LEVELS.items()

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -7,6 +7,7 @@ subcommands accept, and the first concrete generate subcommand,
 """
 
 import random
+import textwrap
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -43,6 +44,10 @@ _SEED_BOUND = 2**31
 # Marks a Target that cannot be generated for at all. A plain literal of known
 # width, so the fixed-width slot it reserves is padded exactly.
 _NO_BRIEF = "no brief"
+
+# A Brief is printed under its row, indented past the "  - " bullet.
+_BRIEF_INDENT = " " * 6
+_BRIEF_MIN_WIDTH = 20
 
 # UNIT, --all and --missing pick *which* Targets to generate for, so at most one
 # may be given. LimitedChoice() defaults to min=0, max=1: exactly that rule.
@@ -156,20 +161,25 @@ def _print_lineages(row: Coverage) -> None:
 
 
 def _print_brief(row: Coverage) -> None:
-    """Print a row's Brief, wrapped, or a red note when it has none."""
+    """Print a row's Brief, wrapped under a hanging indent, or a red note."""
     if not row.target.brief:
-        stdout.print("      [red]No brief[/]", highlight=False)
+        stdout.print(f"{_BRIEF_INDENT}[red]No brief[/]", highlight=False)
         return
-    stdout.print(
-        f"      {row.target.brief}",
-        style="dim",
-        # A Brief is arbitrary authored prose: a `[` in it must not parse as a
-        # Rich tag and swallow the rest of the line.
-        markup=False,
-        highlight=False,
-        # Deliberately no soft_wrap: unlike a coverage row or a Lineage list, a
-        # Brief is read rather than copied or piped, so it should reflow.
-    )
+    # Wrapped here rather than by Rich so the continuation lines carry the same
+    # indent as the first without the block being right-filled to the terminal
+    # width. A Brief is already normalized to a single paragraph by `targets()`,
+    # so there are no blank lines or hard breaks for `wrap` to mangle.
+    width = max(stdout.width - len(_BRIEF_INDENT), _BRIEF_MIN_WIDTH)
+    for line in textwrap.wrap(row.target.brief, width=width):
+        stdout.print(
+            f"{_BRIEF_INDENT}{line}",
+            style="dim",
+            # A Brief is arbitrary authored prose: a `[` in it must not parse
+            # as a Rich tag and swallow the rest of the line.
+            markup=False,
+            highlight=False,
+            soft_wrap=True,  # already wrapped; let it through untouched
+        )
 
 
 def _print_coverage(row: Coverage) -> None:

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -185,8 +185,11 @@ def _print_coverage(row: Coverage) -> None:
     # padding an already-marked-up string counts the tag characters and
     # misaligns every column after it.
     stdout.print(
+        # rstrip so an unmarked row with no count does not trail the empty
+        # slot's padding; a row that has a count is unaffected, so the slot
+        # still lines the counts up.
         f"  - {row.target.name:<32} [dim]{row.target.human_name:<32}[/]"
-        f" {status} {brief} {count}",
+        f" {status} {brief} {count}".rstrip(),
         highlight=False,
         soft_wrap=True,  # a coverage row is scanned or piped, never reflowed
     )

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -155,6 +155,23 @@ def _print_lineages(row: Coverage) -> None:
     stdout.print(f"      {', '.join(parts)}", highlight=False, soft_wrap=True)
 
 
+def _print_brief(row: Coverage) -> None:
+    """Print a row's Brief, wrapped, or a red note when it has none."""
+    if not row.target.brief:
+        stdout.print("      [red]No brief[/]", highlight=False)
+        return
+    stdout.print(
+        f"      {row.target.brief}",
+        style="dim",
+        # A Brief is arbitrary authored prose: a `[` in it must not parse as a
+        # Rich tag and swallow the rest of the line.
+        markup=False,
+        highlight=False,
+        # Deliberately no soft_wrap: unlike a coverage row or a Lineage list, a
+        # Brief is read rather than copied or piped, so it should reflow.
+    )
+
+
 def _print_coverage(row: Coverage) -> None:
     """Print one Coverage row: key first, human name dimmed, then status."""
     status = "[green]\N{CHECK MARK}[/]" if row.asset else "[red]\N{BALLOT X}[/]"
@@ -180,6 +197,7 @@ def list_assets(
     *,
     kind: Kind | None = None,
     candidates: bool = False,
+    briefs: bool = False,
 ) -> None:
     """Report which Targets have Assets, and how many Candidates are waiting.
 
@@ -187,6 +205,11 @@ def list_assets(
     covered. `--kind` restricts it to one registered Asset kind, and
     `--candidates` expands each row into its Candidate Lineages, marking the
     one the Asset was promoted from.
+
+    A Target with no Brief — the authored text its kind generates from — is
+    marked `no brief`: nothing can be generated for it until one is written.
+    `--briefs` expands each row into its Brief, for proofreading the text
+    before spending generation time on it.
 
     Missing Assets are a normal state, so reporting coverage always exits 0.
     A RACE named explicitly but failing to validate cannot be reported at all,
@@ -220,6 +243,9 @@ def list_assets(
             stdout.print(f"  {asset_kind.name.title()}", highlight=False)
             for row in found.rows:
                 _print_coverage(row)
+                # Brief first, then Lineages: mirrors the row's own columns.
+                if briefs:
+                    _print_brief(row)
                 if candidates and row.candidates:
                     _print_lineages(row)
             if found.orphans:

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -430,7 +430,7 @@ def image(
 
     The prompt is composed from the configured preamble file
     (`assets.image.prompt`, by default `prompts/image.txt`) plus the target's
-    name and description; a target without a description is a hard error.
+    name and Brief; a target without a Brief is a hard error.
     """
     opts = opts or AssetOpts()
     kind = get_kind("image")
@@ -451,10 +451,9 @@ def _generate_image(
     kind: AssetKind, race: t.RaceName, target: Target, opts: AssetOpts
 ) -> None:
     """Generate Candidates for one Target, reporting each as it lands."""
-    if not target.brief.strip():
+    if not target.brief:  # already normalized by targets(), so no .strip()
         stderr.print(
-            f"[red]Error:[/] no description for {target.name!r}, "
-            "cannot generate an image"
+            f"[red]Error:[/] no brief for {target.name!r}, cannot generate an image"
         )
         raise SystemExit(1)
 

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -40,6 +40,10 @@ from spf.schemas import type_aliases as t
 
 _SEED_BOUND = 2**31
 
+# Marks a Target that cannot be generated for at all. A plain literal of known
+# width, so the fixed-width slot it reserves is padded exactly.
+_NO_BRIEF = "no brief"
+
 # UNIT, --all and --missing pick *which* Targets to generate for, so at most one
 # may be given. LimitedChoice() defaults to min=0, max=1: exactly that rule.
 _SELECTION = cyclopts.Group("Selection", validator=cyclopts.validators.LimitedChoice())
@@ -154,13 +158,18 @@ def _print_lineages(row: Coverage) -> None:
 def _print_coverage(row: Coverage) -> None:
     """Print one Coverage row: key first, human name dimmed, then status."""
     status = "[green]\N{CHECK MARK}[/]" if row.asset else "[red]\N{BALLOT X}[/]"
+    # Asymmetric (ADR 0014): only a Brief-less row is marked, so a fully
+    # briefed race renders exactly as it did before the column existed. The
+    # slot is still occupied when there is nothing to say, so the candidate
+    # count starts at the same column on every row.
+    brief = " " * len(_NO_BRIEF) if row.target.brief else f"[red]{_NO_BRIEF}[/]"
     count = f"{len(row.candidates)} candidates" if row.candidates else ""
     # The name columns pad the *plain* value before the markup wraps it:
     # padding an already-marked-up string counts the tag characters and
     # misaligns every column after it.
     stdout.print(
         f"  - {row.target.name:<32} [dim]{row.target.human_name:<32}[/]"
-        f" {status} {count}",
+        f" {status} {brief} {count}",
         highlight=False,
         soft_wrap=True,  # a coverage row is scanned or piped, never reflowed
     )

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -416,7 +416,7 @@ def _generate_image(
     kind: AssetKind, race: t.RaceName, target: Target, opts: AssetOpts
 ) -> None:
     """Generate Candidates for one Target, reporting each as it lands."""
-    if not target.description.strip():
+    if not target.brief.strip():
         stderr.print(
             f"[red]Error:[/] no description for {target.name!r}, "
             "cannot generate an image"
@@ -424,7 +424,7 @@ def _generate_image(
         raise SystemExit(1)
 
     system = config.assets.image.prompt.read_text(encoding="utf-8")
-    prompt = f"Subject: {target.human_name}.\nDetails: {target.description}\n{system}"
+    prompt = f"Subject: {target.human_name}.\nDetails: {target.brief}\n{system}"
 
     count, seed = opts.resolve()
     stdout.print(f"Seed: {seed}  (rerun with --seed {seed} to reproduce)")

--- a/v3/tests/assets/conftest.py
+++ b/v3/tests/assets/conftest.py
@@ -8,10 +8,13 @@ that land in the child issues. Nothing here lives in `src/`.
 import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
 from spf.assets import Kind
+from spf.assets.kinds import KINDS, Described, Service
+from spf.config import config
 
 
 @dataclass
@@ -63,27 +66,47 @@ class FakeRefiner(FakeService):
         return self.generate(source, count, seed=seed, on_result=on_result)
 
 
-@pytest.fixture
-def test_kind() -> Kind:
-    """Return a throwaway binary kind laid out at `<race>/_test/<name>.txt`."""
+def fake_kind(
+    *,
+    name: str = "_test",
+    service: Service | None = None,
+    brief: Callable[[Described], str] = operator.attrgetter("description"),
+) -> Kind:
+    """Build a throwaway binary kind laid out at `<race>/_test/<name>.txt`.
+
+    Only for tests whose subject is something *other* than the Kind's own
+    shape; a test that pins how a field behaves should spell that Kind out in
+    full, so the field under test sits next to the assertion. That is why the
+    layout fields are fixed here rather than exposed as arguments: the tests
+    that vary them are exactly the ones that should not be using this.
+    """
     return Kind(
-        name="_test",
-        service=FakeService(),
+        name=name,
+        # Built per call, not shared as a default: a `FakeService` records the
+        # seed it last saw, so one instance across tests would leak that.
+        service=FakeService() if service is None else service,
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
-        brief=operator.attrgetter("description"),
+        brief=brief,
     )
+
+
+def register_kind(kind: Kind, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
+    """Register `kind` in `KINDS` and point both config roots under `tmp_path`."""
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    return kind
+
+
+@pytest.fixture
+def test_kind() -> Kind:
+    """Return a throwaway binary kind laid out at `<race>/_test/<name>.txt`."""
+    return fake_kind()
 
 
 @pytest.fixture
 def refinable_kind() -> Kind:
     """Return a throwaway kind whose Service can refine as well as generate."""
-    return Kind(
-        name="_refinable",
-        service=FakeRefiner(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=operator.attrgetter("description"),
-    )
+    return fake_kind(name="_refinable", service=FakeRefiner())

--- a/v3/tests/assets/conftest.py
+++ b/v3/tests/assets/conftest.py
@@ -5,6 +5,7 @@ A throwaway `FakeService` returning canned bytes and a matching throwaway
 that land in the child issues. Nothing here lives in `src/`.
 """
 
+import operator
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
@@ -71,6 +72,7 @@ def test_kind() -> Kind:
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
 
 
@@ -83,4 +85,5 @@ def refinable_kind() -> Kind:
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -489,6 +489,36 @@ def test_list_command_prints_a_brief_containing_brackets_intact(
     assert "A raider in [brass] plate." in capsys.readouterr().out
 
 
+def test_list_command_prints_the_brief_before_the_lineages(
+    partly_briefed_kind: Kind, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Mirrors the row's own left-to-right column order.
+    generate(
+        partly_briefed_kind,
+        source="a description",
+        race="ork",
+        name="grunt",
+        count=2,
+        candidates_root=config.paths.candidates,
+    )
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--briefs", "--candidates"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    lines = [_ANSI.sub("", line) for line in capsys.readouterr().out.splitlines()]
+    grunt_at = next(i for i, line in enumerate(lines) if "grunt" in line)
+    rest = lines[grunt_at + 1 :]
+    # The Brief reflows over as many lines as it needs, so this is an ordering
+    # assertion rather than a fixed offset from the row.
+    brief = races.get_units("ork")["grunt"].description.split()[0]
+    brief_at = next(i for i, line in enumerate(rest) if brief in line)
+    lineage_at = next(i for i, line in enumerate(rest) if line.strip() == "1, 2")
+    assert brief_at < lineage_at
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -1,6 +1,5 @@
 """S5: the shared `spf assets promote` CLI command over a throwaway kind."""
 
-import operator
 import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -14,24 +13,13 @@ from spf.assets.comfyui import ComfyUIError
 from spf.assets.kinds import KINDS
 from spf.config import config
 from spf.frontends.cli import app
-from tests.assets.conftest import FakeRefiner, FakeService
+from tests.assets.conftest import FakeRefiner, fake_kind, register_kind
 
 
 @pytest.fixture
 def registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
     """Register a throwaway kind and point the config roots under tmp."""
-    kind = Kind(
-        name="_test",
-        service=FakeService(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=operator.attrgetter("description"),
-    )
-    monkeypatch.setitem(KINDS, kind.name, kind)
-    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
-    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
-    return kind
+    return register_kind(fake_kind(), monkeypatch, tmp_path)
 
 
 def test_promote_command_lands_picked_candidate(registered_kind: Kind) -> None:
@@ -93,17 +81,9 @@ def test_promote_command_unknown_kind_errors(
 @pytest.fixture
 def refinable_registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
     """Register a throwaway refinable kind with a Candidate already on disk."""
-    kind = Kind(
-        name="_refinable",
-        service=FakeRefiner(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=operator.attrgetter("description"),
+    kind = register_kind(
+        fake_kind(name="_refinable", service=FakeRefiner()), monkeypatch, tmp_path
     )
-    monkeypatch.setitem(KINDS, kind.name, kind)
-    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
-    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
     candidates = config.paths.candidates / "ork" / "_test"
     candidates.mkdir(parents=True)
     (candidates / "grunt.2.txt").write_bytes(b"the original")
@@ -361,18 +341,10 @@ def partly_briefed_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind
     from a race that happens to be unbriefed today, so briefing that race in
     the TOML cannot silently stop exercising the no-Brief path.
     """
-    kind = Kind(
-        name="_test",
-        service=FakeService(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=lambda entry: "" if entry.name == "Troll" else entry.description,
+    kind = fake_kind(
+        brief=lambda entry: "" if entry.name == "Troll" else entry.description
     )
-    monkeypatch.setitem(KINDS, kind.name, kind)
-    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
-    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
-    return kind
+    return register_kind(kind, monkeypatch, tmp_path)
 
 
 @pytest.mark.usefixtures("partly_briefed_kind")
@@ -468,17 +440,8 @@ def test_list_command_prints_a_brief_containing_brackets_intact(
 ) -> None:
     # A Brief is arbitrary authored prose, so a `[` in it must reach the
     # terminal rather than being parsed as a Rich markup tag.
-    kind = Kind(
-        name="_test",
-        service=FakeService(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=lambda _entry: "A raider in [brass] plate.",
-    )
-    monkeypatch.setitem(KINDS, kind.name, kind)
-    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
-    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    kind = fake_kind(brief=lambda _entry: "A raider in [brass] plate.")
+    register_kind(kind, monkeypatch, tmp_path)
 
     app(
         ["assets", "list", "ork", "--kind", "_test", "--briefs"],
@@ -526,17 +489,7 @@ def test_list_command_indents_a_wrapped_brief_under_its_row(
 ) -> None:
     # A Brief long enough to wrap must carry the same indent on every line,
     # rather than falling back to the left margin on the continuations.
-    kind = Kind(
-        name="_test",
-        service=FakeService(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=lambda _entry: "brass " * 60,
-    )
-    monkeypatch.setitem(KINDS, kind.name, kind)
-    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
-    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    register_kind(fake_kind(brief=lambda _entry: "brass " * 60), monkeypatch, tmp_path)
 
     app(
         ["assets", "list", "ork", "--kind", "_test", "--briefs"],
@@ -674,14 +627,7 @@ def test_refine_command_survives_a_service_raising_mid_batch(
             msg = "the queue went away"
             raise ComfyUIError(msg)
 
-    kind = Kind(
-        name="_refinable",
-        service=HalfwayFailingRefiner(),
-        subdir="_test",
-        extension="txt",
-        targets=frozenset({"race", "unit"}),
-        brief=operator.attrgetter("description"),
-    )
+    kind = fake_kind(name="_refinable", service=HalfwayFailingRefiner())
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
     candidates = config.paths.candidates / "ork" / "_test"

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -445,6 +445,22 @@ def test_list_command_expands_briefs_under_briefs(
     assert races.get_units("ork")["grunt"].description.split()[0] in lines[grunt_at + 1]
 
 
+@pytest.mark.usefixtures("partly_briefed_kind")
+def test_list_command_says_so_when_briefs_finds_no_brief(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--briefs"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    lines = capsys.readouterr().out.splitlines()
+    troll_at = next(i for i, line in enumerate(lines) if "troll" in line)
+    # A blank line would read as a rendering bug rather than a missing Brief.
+    assert "No brief" in lines[troll_at + 1]
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -394,6 +394,38 @@ def test_list_command_marks_only_the_rows_with_no_brief(
     assert "no brief" not in grunt_line
 
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def test_list_command_keeps_the_candidate_count_aligned(
+    partly_briefed_kind: Kind, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The marker occupies a fixed-width slot, so the count starts at the same
+    # column whether or not the row is marked (ADR 0014).
+    for name in ("troll", "grunt"):
+        generate(
+            partly_briefed_kind,
+            source="a description",
+            race="ork",
+            name=name,
+            count=2,
+            candidates_root=config.paths.candidates,
+        )
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    lines = [_ANSI.sub("", line) for line in capsys.readouterr().out.splitlines()]
+    marked = next(line for line in lines if "troll" in line)
+    unmarked = next(line for line in lines if "grunt" in line)
+    assert "no brief" in marked  # the two cases the slot has to line up
+    assert "no brief" not in unmarked
+    assert marked.index("2 candidates") == unmarked.index("2 candidates")
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -461,6 +461,34 @@ def test_list_command_says_so_when_briefs_finds_no_brief(
     assert "No brief" in lines[troll_at + 1]
 
 
+def test_list_command_prints_a_brief_containing_brackets_intact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A Brief is arbitrary authored prose, so a `[` in it must reach the
+    # terminal rather than being parsed as a Rich markup tag.
+    kind = Kind(
+        name="_test",
+        service=FakeService(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+        brief=lambda _entry: "A raider in [brass] plate.",
+    )
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--briefs"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    assert "A raider in [brass] plate." in capsys.readouterr().out
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -352,6 +352,48 @@ def test_list_command_defaults_to_every_registered_kind(
     assert "Ork" in capsys.readouterr().out
 
 
+@pytest.fixture
+def partly_briefed_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
+    """Register a throwaway kind whose Troll Target has no Brief.
+
+    The missing Brief is forced by the Kind's own extractor rather than taken
+    from a race that happens to be unbriefed today, so briefing that race in
+    the TOML cannot silently stop exercising the no-Brief path.
+    """
+    kind = Kind(
+        name="_test",
+        service=FakeService(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+        brief=lambda entry: "" if entry.name == "Troll" else entry.description,
+    )
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+    return kind
+
+
+@pytest.mark.usefixtures("partly_briefed_kind")
+def test_list_command_marks_only_the_rows_with_no_brief(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A red X on a Brief-less row means "blocked", not "queued": nothing can be
+    # generated for it until someone writes the Brief.
+    app(
+        ["assets", "list", "ork", "--kind", "_test"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    troll_line = next(line for line in out.splitlines() if "troll" in line)
+    assert "no brief" in troll_line
+    # Asymmetric (D6): a briefed row is left exactly as it was.
+    grunt_line = next(line for line in out.splitlines() if "grunt" in line)
+    assert "no brief" not in grunt_line
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -1,5 +1,6 @@
 """S5: the shared `spf assets promote` CLI command over a throwaway kind."""
 
+import operator
 import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -24,6 +25,7 @@ def registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
@@ -96,6 +98,7 @@ def refinable_registered_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
@@ -475,6 +478,7 @@ def test_refine_command_survives_a_service_raising_mid_batch(
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
     monkeypatch.setitem(KINDS, kind.name, kind)
     monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -519,6 +519,41 @@ def test_list_command_prints_the_brief_before_the_lineages(
     assert brief_at < lineage_at
 
 
+def test_list_command_indents_a_wrapped_brief_under_its_row(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A Brief long enough to wrap must carry the same indent on every line,
+    # rather than falling back to the left margin on the continuations.
+    kind = Kind(
+        name="_test",
+        service=FakeService(),
+        subdir="_test",
+        extension="txt",
+        targets=frozenset({"race", "unit"}),
+        brief=lambda _entry: "brass " * 60,
+    )
+    monkeypatch.setitem(KINDS, kind.name, kind)
+    monkeypatch.setattr(config.paths, "candidates", tmp_path / "candidates")
+    monkeypatch.setattr(config.paths, "assets", tmp_path / "assets")
+
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--briefs"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    wrapped = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if line.lstrip().startswith("brass")
+    ]
+    assert len(wrapped) > 1  # it really did wrap, so continuations exist
+    assert all(line.startswith(" " * 6) for line in wrapped)
+    assert not any(line.endswith(" ") for line in wrapped)
+
+
 # --- refining an already-promoted Asset -------------------------------------
 
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from cyclopts.exceptions import CycloptsError
 
+from spf import races
 from spf.assets import Kind, generate, promote
 from spf.assets.comfyui import ComfyUIError
 from spf.assets.kinds import KINDS
@@ -424,6 +425,24 @@ def test_list_command_keeps_the_candidate_count_aligned(
     assert "no brief" in marked  # the two cases the slot has to line up
     assert "no brief" not in unmarked
     assert marked.index("2 candidates") == unmarked.index("2 candidates")
+
+
+@pytest.mark.usefixtures("partly_briefed_kind")
+def test_list_command_expands_briefs_under_briefs(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Unlike --candidates, --briefs prints for every row: the job is
+    # proofreading the text before spending GPU time on it.
+    app(
+        ["assets", "list", "ork", "--kind", "_test", "--briefs"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    grunt_at = next(i for i, line in enumerate(lines) if "grunt" in line)
+    assert races.get_units("ork")["grunt"].description.split()[0] in lines[grunt_at + 1]
 
 
 # --- refining an already-promoted Asset -------------------------------------

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -348,7 +348,7 @@ def test_cli_count_override_beats_config(image_env: _ImageEnv) -> None:
     assert [p.name for p in images.glob("*.png")] == ["ogre_grunt.1.png"]
 
 
-def test_cli_blank_unit_description_exits_without_writing(
+def test_cli_blank_unit_brief_exits_without_writing(
     image_env: _ImageEnv, capsys: pytest.CaptureFixture[str]
 ) -> None:
     with pytest.raises(SystemExit) as excinfo:
@@ -356,10 +356,10 @@ def test_cli_blank_unit_description_exits_without_writing(
 
     assert excinfo.value.code == 1
     assert not image_env.candidates.exists()
-    assert "no description" in capsys.readouterr().err
+    assert "no brief" in capsys.readouterr().err
 
 
-def test_cli_blank_race_description_exits_without_writing(
+def test_cli_blank_race_brief_exits_without_writing(
     image_env: _ImageEnv,
 ) -> None:
     with pytest.raises(SystemExit) as excinfo:

--- a/v3/tests/assets/test_spine.py
+++ b/v3/tests/assets/test_spine.py
@@ -1,5 +1,6 @@
 """S2 + S3: the generate and promote spine functions."""
 
+import operator
 from pathlib import Path
 
 import pytest
@@ -58,6 +59,7 @@ def test_generate_threads_seed_to_service(tmp_path: Path) -> None:
         subdir="_test",
         extension="txt",
         targets=frozenset({"race", "unit"}),
+        brief=operator.attrgetter("description"),
     )
     generate(
         kind,
@@ -90,6 +92,7 @@ def test_generate_without_subdir_writes_flat_text(tmp_path: Path) -> None:
         subdir=None,
         extension="md",
         targets=frozenset({"race"}),
+        brief=operator.attrgetter("description"),
     )
     paths = generate(
         lore_kind,

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -1,5 +1,7 @@
 """The Targets a Kind covers for a Race, resolved from the Race TOML alone."""
 
+import operator
+
 from spf.assets import Kind, targets
 from tests.assets.conftest import FakeService
 
@@ -11,6 +13,7 @@ def test_race_level_kind_covers_the_race_itself() -> None:
         subdir="_lore",
         extension="txt",
         targets=frozenset({"race"}),
+        brief=operator.attrgetter("description"),
     )
 
     found = targets(kind, "ork")
@@ -51,6 +54,7 @@ def test_model_level_kind_covers_the_races_models() -> None:
         subdir="_model",
         extension="stl",
         targets=frozenset({"model"}),
+        brief=operator.attrgetter("description"),
     )
 
     found = targets(kind, "ork")
@@ -61,3 +65,20 @@ def test_model_level_kind_covers_the_races_models() -> None:
         "ork_elite_infantry",
     ]
     assert {target.level for target in found} == {"model"}
+
+
+def test_kind_declares_which_text_its_targets_are_briefed_from() -> None:
+    # The Brief is whatever the Kind says it is, so a Kind that generates from
+    # something other than `description` needs no change here (ADR 0014).
+    kind = Kind(
+        name="_named",
+        service=FakeService(),
+        subdir="_named",
+        extension="txt",
+        targets=frozenset({"race"}),
+        brief=lambda entry: entry.name.upper(),
+    )
+
+    found = targets(kind, "ork")
+
+    assert found[0].brief == "ORK"

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -82,3 +82,21 @@ def test_kind_declares_which_text_its_targets_are_briefed_from() -> None:
     found = targets(kind, "ork")
 
     assert found[0].brief == "ORK"
+
+
+def test_brief_is_whitespace_normalized() -> None:
+    # Briefs are authored as multi-line TOML strings, but a Brief is one
+    # paragraph of prose: it is normalized here rather than at display, so the
+    # text sent to the Service is the text shown (ADR 0014).
+    kind = Kind(
+        name="_ragged",
+        service=FakeService(),
+        subdir="_ragged",
+        extension="txt",
+        targets=frozenset({"race"}),
+        brief=lambda _entry: "  A brutal raider,\n  clad in   brass plate.\n",
+    )
+
+    found = targets(kind, "ork")
+
+    assert found[0].brief == "A brutal raider, clad in brass plate."

--- a/v3/tests/assets/test_targets.py
+++ b/v3/tests/assets/test_targets.py
@@ -100,3 +100,21 @@ def test_brief_is_whitespace_normalized() -> None:
     found = targets(kind, "ork")
 
     assert found[0].brief == "A brutal raider, clad in brass plate."
+
+
+def test_a_kind_can_compose_its_brief_from_several_fields() -> None:
+    # Regression guard for the callable (ADR 0014): a Kind's Brief need not be
+    # one field, so `brief` cannot be narrowed to a field name or a bool.
+    kind = Kind(
+        name="_composed",
+        service=FakeService(),
+        subdir="_composed",
+        extension="txt",
+        targets=frozenset({"race"}),
+        brief=lambda entry: f"{entry.name}: {entry.description}",
+    )
+
+    found = targets(kind, "ork")
+
+    assert found[0].brief.startswith("Ork: ")
+    assert len(found[0].brief) > len("Ork: ")


### PR DESCRIPTION
Closes #60.

`spf assets list` could answer "which Targets have an Asset?" but not "which
Targets *could* have one?" — **39 of 101 Targets have no Brief**, so more than a
third of the red ✗ rows were not actionable by generating anything. Three races
(darkelf, dwarf, gnome) are essentially unbriefed entirely.

```console
$ spf assets list dwarf --kind image
Dwarf
  Image
  - dwarf                            Dwarf                            ✗ no brief
  - dwarf_infantry                   Dwarf Infantry                   ✗ no brief

$ spf assets list ork --kind image --briefs
  - troll                            Troll                            ✓
      Giant brown bloodthirsty troll wielding a gatling gun
```

## What changed

The **Brief** is the authored text a Kind generates from, declared by the Kind
itself as an extractor callable (`Kind.brief`), so a Kind that generates from
something other than `description` needs no change to Targets or listing code.
`Target.description` is replaced by `Target.brief`, normalized to one paragraph
at `targets()`. See **ADR 0014** and the `CONTEXT.md` glossary entry.

`survey.py` is deliberately untouched: a Brief is a TOML fact, so it stays on
the pure-TOML side of ADR 0011's split.

## Verification

- `just check` green — 357 tests, ruff, typos, pyright all clean.
- Coverage numbers reproduce the plan's table exactly: 39/101 total,
  darkelf 16/17, dwarf 12/12, gnome 11/11.
- The four guard tests were mutation-checked (padding removed, `markup=True`,
  order swapped, indent dropped) and each fails as intended.

## One deviation worth a look

**The ork "byte-identical" check needs a caveat.** With the fixed-width slot
(D6a), a row that *has* a candidate count necessarily shifts right by the slot
width — the plan's §8 claim can't hold alongside D6a. I kept D6a, since it is
the explicit requirement, and added an `.rstrip()` so rows *without* a count
are byte-identical (in fact tidier: the pre-existing trailing space is gone).
§5.4 left that choice open.

The `--briefs` hanging indent (raised and resolved in review) wraps with
`textwrap` rather than Rich's `Padding`, which indents continuations but
right-fills the block to the terminal width — reintroducing exactly the
trailing whitespace the coverage rows just lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K95QJnnfioCFRzGtpsD2TS