### PR TITLE
Warn and skip Brief-less Targets in `spf assets image` (#61)

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -234,7 +234,7 @@ Kind itself (`Kind.brief`), so a Kind that generates from something other than
 `description` needs no change to the Targets or the listing code (ADR 0014).
 Distinct from the Prompt, which is *composed* from the Brief plus the configured
 preamble. A Target without a Brief cannot be generated for, so `spf assets list`
-marks it `no brief`.
+marks it `no brief` and `spf assets image` warns and skips it (ADR 0015).
 _Avoid_: prompt (that's the composed string), seed (that's the RNG seed),
 description (the TOML field name; for an Image the two coincide, for another
 Kind they may not)

--- a/v3/docs/adr/0010-refinement-of-candidates.md
+++ b/v3/docs/adr/0010-refinement-of-candidates.md
@@ -61,8 +61,9 @@ This follows from the choice above and stands or falls with it — under classic
 img2img, prompt replacement would be actively wrong, since a bare "remove one
 arm" gives the sampler nothing to reconstruct from at high denoise.
 
-Consequently `refine` never looks up a description, and the "no description ⇒
-hard error" rule that `spf assets image` enforces does not apply to it.
+Consequently `refine` never looks up a description, and the "no Brief ⇒ warn
+and skip" rule that `spf assets image` enforces (ADR 0015; a hard error when
+this was written) does not apply to it.
 
 **The negative prompt stays unpatched** (ADR 0009), so a Correction is always a
 *positive* statement. This is not a limitation to work around: the negative

--- a/v3/docs/adr/0015-a-missing-brief-is-a-skip-not-a-failure.md
+++ b/v3/docs/adr/0015-a-missing-brief-is-a-skip-not-a-failure.md
@@ -1,0 +1,111 @@
+# A missing Brief is a skip, not a failure
+
+ADR 0014 made Brief-less Targets *visible* in `spf assets list` and left their
+interaction with generation explicitly out of scope. That interaction was
+broken: `_generate_image` exited 1 on the first Target with no Brief, so
+`spf assets image dwarf --missing` — which selects every Target without an
+Asset, and on dwarf that is all of them — printed one name and stopped. On a
+partly-briefed race it generated up to the first gap and abandoned the rest of
+the batch, GPU time already queued.
+
+With 39 of 101 Targets unbriefed, the state that aborts the run is the
+*ordinary* state of this repo, not an exceptional one.
+
+## Warn and skip, uniformly
+
+**Decision: a Target with no Brief is warned about on stderr and skipped. The
+rule does not vary with the selector or with how many Targets were selected.**
+
+The originating issue proposed a narrower rule — warn on multi-Target runs, but
+keep the hard error when the user names a single Target, since "the user asked
+for that specific one." Rejected. It makes the exit code depend on something
+the user is not thinking about:
+
+- Branching on the *count* (`len(selected) > 1`, which the progress heading
+  already used) means `spf assets image dwarf --missing` hard-errors on the day
+  one Target is left to fill and warns on the day two are. The contract would
+  flip as a side effect of curating, which is the one thing that should not
+  change it.
+- Branching on the *selector* is stable, but still asks a reader to hold two
+  behaviors and a rule for choosing between them. The distinction buys nothing:
+  a curator who names an unbriefed Target learns the same fact from a warning
+  as from an error, and nothing downstream depends on the difference.
+
+One rule, one sentence in `--help`.
+
+## Always exit 0
+
+**Decision: skipping every selected Target is still a successful run.**
+
+Reserve non-zero for a broken world — ComfyUI unreachable, a malformed Workflow
+file, an unknown unit name. A gap in authored data is a worklist item
+that `spf assets list` already reports; making it an exit code puts the repo's
+normal condition permanently in the failure channel, where it drowns the
+signal.
+
+This does change the contract for callers: a script running
+`spf assets image $race && …` will now proceed where it used to stop. That is
+the intended correction — it used to stop on a *partial* batch too, which no
+caller wanted.
+
+## Service errors still abort the batch
+
+**Decision: the `OSError`/`ComfyUIError` exit in `_generate_image` is left
+exactly as it is.**
+
+This looks asymmetric with the rule above, and deliberately is. A missing Brief
+is a per-Target fact about *authored data*, knowable before anything is spent
+and carrying no information about the next Target. A Service failure is
+evidence about *the world*, and the likeliest explanation for one is the
+condition that will fail the remaining nineteen — continuing would spend the
+run producing a wall of identical errors.
+
+If a genuinely transient mid-batch failure is ever observed, the answer is a
+consecutive-failure threshold, not making this symmetric. Nobody has seen one
+yet, so it is not built.
+
+## `--missing` keeps meaning "no promoted Asset"
+
+**Decision: the selector is unchanged. It is not narrowed to "no Asset *and*
+has a Brief".**
+
+Narrowing it would make `spf assets image dwarf --missing` quietly select
+nothing instead of warning twenty times, which is tempting and wrong. One flag
+would then answer two questions, and the curator could no longer distinguish
+"nothing is missing" from "everything missing is blocked" — precisely the
+distinction ADR 0014 built the ✗ marker to preserve. The warnings *are* the
+blocked worklist, surfaced at the moment someone tried to act on it.
+
+## Partition before generating
+
+**Decision: `image()` splits the selection into briefed and Brief-less before
+the generation loop, rather than skipping inline as it walks.**
+
+Same argument ADR 0014 made for the listing marker: the shape of the batch
+should be on screen before GPU time is spent on it. Skipping inline would
+scatter the warnings through several minutes of generation output, so you would
+learn what was skipped only once the run was over and the decision to run it
+was long past.
+
+It also leaves `_generate_image` meaning exactly "generate one Target", with no
+reporting branch inside it, and makes the existing multi-Target progress
+heading honest — it counted Targets that could never generate.
+
+Its `SystemExit(1)` on an empty Brief stays as the genuine error path. The
+caller no longer reaches it; a runtime `assert` in its place was rejected as
+production code asserting something the type system cannot express anyway.
+
+## Consequences
+
+- **`Nothing to generate.` is printed when every selected Target is skipped**,
+  on stdout. Exiting 0 in silence would read as a crash rather than as an
+  outcome. It is not printed after a partial batch, where the generated output
+  speaks for itself.
+- **One warning line per Target, not a grouped list.** A fully-unbriefed race
+  under `--all` therefore produces a column of warnings. That is accepted: it
+  matches how the rest of this CLI reports, stays greppable, and the volume is
+  itself a fair signal about the race.
+- **Warnings go to stderr, generation output to stdout**, so a caller piping
+  the run still gets seeds and promote hints uncontaminated.
+- **ADR 0010's cross-reference was updated.** It contrasted `refine` against
+  the old "hard error" rule, which no longer exists under that name.

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -456,9 +456,11 @@ def image(
 
     # Partition before generating rather than skipping mid-loop (ADR 0015), so
     # the batch's real shape is on screen before any GPU time is spent on it.
-    briefed = [target for target in selected if target.brief]
+    briefed: list[Target] = []
     for target in selected:
-        if not target.brief:
+        if target.brief:
+            briefed.append(target)
+        else:
             stderr.print(f"[yellow]Warning:[/] no brief for {target.name!r}, skipping")
 
     if not briefed:
@@ -476,6 +478,9 @@ def _generate_image(
     kind: AssetKind, race: t.RaceName, target: Target, opts: AssetOpts
 ) -> None:
     """Generate Candidates for one Target, reporting each as it lands."""
+    # Unreachable from `image()`, which partitions Brief-less Targets out and
+    # warns instead (ADR 0015). Kept as the genuine error path for any other
+    # caller rather than replaced by an assert.
     if not target.brief:  # already normalized by targets(), so no .strip()
         stderr.print(
             f"[red]Error:[/] no brief for {target.name!r}, cannot generate an image"

--- a/v3/src/spf/frontends/cli/assets.py
+++ b/v3/src/spf/frontends/cli/assets.py
@@ -443,7 +443,7 @@ def image(
 
     The prompt is composed from the configured preamble file
     (`assets.image.prompt`, by default `prompts/image.txt`) plus the target's
-    name and Brief; a target without a Brief is a hard error.
+    name and Brief; a target without a Brief is warned about and skipped.
     """
     opts = opts or AssetOpts()
     kind = get_kind("image")
@@ -454,8 +454,20 @@ def image(
         stderr.print(f"[red]Error:[/] {err}")
         raise SystemExit(1) from None
 
+    # Partition before generating rather than skipping mid-loop (ADR 0015), so
+    # the batch's real shape is on screen before any GPU time is spent on it.
+    briefed = [target for target in selected if target.brief]
     for target in selected:
-        if len(selected) > 1:
+        if not target.brief:
+            stderr.print(f"[yellow]Warning:[/] no brief for {target.name!r}, skipping")
+
+    if not briefed:
+        # Exiting 0 in silence would read as a crash rather than an outcome.
+        stdout.print("Nothing to generate.")
+        return
+
+    for target in briefed:
+        if len(briefed) > 1:
             stdout.print(f"[green]{target.name}[/]")
         _generate_image(kind, race, target, opts)
 

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -646,3 +646,53 @@ def test_refine_command_survives_a_service_raising_mid_batch(
     # as the ordinary error line rather than a timer traceback.
     assert "Wrote" in captured.out
     assert "the queue went away" in captured.err
+
+
+@pytest.fixture
+def partly_briefed_image_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Kind:
+    """Stand in for the image Kind with the Troll Target left Brief-less.
+
+    `image` resolves its Kind by name rather than taking `--kind`, so the
+    substitution happens in `KINDS` under the real name. As with
+    `partly_briefed_kind`, the gap is forced by the extractor rather than
+    borrowed from a race that happens to be unbriefed today.
+    """
+    kind = fake_kind(
+        name="image",
+        brief=lambda entry: "" if entry.name == "Troll" else entry.description,
+    )
+    return register_kind(kind, monkeypatch, tmp_path)
+
+
+@pytest.mark.usefixtures("partly_briefed_image_kind")
+def test_image_command_skips_a_brief_less_target_without_dying(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Issue 61: the Brief-less Troll must not cost the rest of the batch the
+    # GPU time it was queued for.
+    app(
+        ["assets", "image", "ork", "--all"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    captured = capsys.readouterr()
+    assert "troll" in captured.err  # said so, rather than skipping silently
+    assert "Promote one with" in captured.out  # and the briefed rows still ran
+
+
+@pytest.mark.usefixtures("partly_briefed_image_kind")
+def test_image_command_reports_an_entirely_brief_less_batch_as_nothing_to_do(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Exiting 0 in silence would read as a crash; the closing line is what
+    # makes "there was nothing to generate" a deliberate outcome.
+    app(
+        ["assets", "image", "ork", "troll"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    captured = capsys.readouterr()
+    assert "troll" in captured.err
+    assert "Nothing to generate." in captured.out

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -679,6 +679,55 @@ def test_image_command_skips_a_brief_less_target_without_dying(
     captured = capsys.readouterr()
     assert "troll" in captured.err  # said so, rather than skipping silently
     assert "Promote one with" in captured.out  # and the briefed rows still ran
+    # A partial batch has generated output to speak for itself (ADR 0015).
+    assert "Nothing to generate." not in captured.out
+
+
+@pytest.mark.usefixtures("partly_briefed_image_kind")
+def test_image_command_skips_brief_less_targets_under_missing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The case that opened issue 61: --missing selects every Asset-less Target,
+    # so the Brief-less one used to abort the batch on its way past.
+    app(
+        ["assets", "image", "ork", "--missing"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    captured = capsys.readouterr()
+    assert "troll" in captured.err
+    assert "Promote one with" in captured.out
+
+
+def test_image_command_warns_once_per_brief_less_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # One line per Target, not one grouped line for the batch (ADR 0015), so
+    # two gaps have to produce two warnings.
+    register_kind(
+        fake_kind(
+            name="image",
+            brief=lambda entry: (
+                "" if entry.name in {"Troll", "Grunt"} else entry.description
+            ),
+        ),
+        monkeypatch,
+        tmp_path,
+    )
+
+    app(
+        ["assets", "image", "ork", "--all"],
+        exit_on_error=False,
+        result_action="return_value",
+    )
+
+    warnings = [
+        line for line in capsys.readouterr().err.splitlines() if "no brief" in line
+    ]
+    assert len(warnings) == 2
 
 
 @pytest.mark.usefixtures("partly_briefed_image_kind")

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -366,8 +366,10 @@ def test_cli_blank_race_brief_warns_without_writing(
 ) -> None:
     _run("assets", "image", "gnome")
 
+    captured = capsys.readouterr()
     assert not image_env.candidates.exists()
-    assert "Nothing to generate." in capsys.readouterr().out
+    assert "no brief" in captured.err
+    assert "Nothing to generate." in captured.out
 
 
 def test_cli_failed_job_surfaces_red_error(

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -348,25 +348,26 @@ def test_cli_count_override_beats_config(image_env: _ImageEnv) -> None:
     assert [p.name for p in images.glob("*.png")] == ["ogre_grunt.1.png"]
 
 
-def test_cli_blank_unit_brief_exits_without_writing(
+def test_cli_blank_unit_brief_warns_without_writing(
     image_env: _ImageEnv, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    with pytest.raises(SystemExit) as excinfo:
-        _run("assets", "image", "ogre", "ogre_blank")
+    # A Brief-less Target is an ordinary, expected state (ADR 0015), so naming
+    # one is a warning and exit 0 — but still writes nothing.
+    _run("assets", "image", "ogre", "ogre_blank")
 
-    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
     assert not image_env.candidates.exists()
-    assert "no brief" in capsys.readouterr().err
+    assert "no brief" in captured.err
+    assert "Nothing to generate." in captured.out
 
 
-def test_cli_blank_race_brief_exits_without_writing(
-    image_env: _ImageEnv,
+def test_cli_blank_race_brief_warns_without_writing(
+    image_env: _ImageEnv, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    with pytest.raises(SystemExit) as excinfo:
-        _run("assets", "image", "gnome")
+    _run("assets", "image", "gnome")
 
-    assert excinfo.value.code == 1
     assert not image_env.candidates.exists()
+    assert "Nothing to generate." in capsys.readouterr().out
 
 
 def test_cli_failed_job_surfaces_red_error(


### PR DESCRIPTION
Closes #61.

`spf assets image` hard-exited on the first Target with no Brief, so
`spf assets image dwarf --missing` printed one name and stopped, and a
partly-briefed race generated up to its first gap then abandoned the rest of
the batch. With 39 of 101 Targets unbriefed, that is the ordinary state of the
repo, not an exceptional one.

A Brief-less Target is now warned about on stderr and skipped, and the run
exits 0.

## Decisions

Recorded in **ADR 0015**, which is the thing worth reviewing first.

The issue proposed warning only on multi-Target runs and keeping the hard error
for a single named Target. That was **overridden during design**: the rule is
uniform across `--all`, `--missing` and a named Target. Branching on the count
would flip the contract as a side effect of curating; branching on the selector
is stable but buys nothing, since a curator learns the same fact from a warning
as from an error.

Deliberately *not* changed:

- **Service errors (`OSError`/`ComfyUIError`) still abort the batch.** Asymmetric
  on purpose — a missing Brief is a per-Target data fact, while one ComfyUI
  failure is usually the condition that will fail the next nineteen.
- **`--missing` still means "no promoted Asset".** Narrowing it to "and has a
  Brief" would make the command quietly select nothing, collapsing "nothing is
  missing" into "everything missing is blocked" — the distinction ADR 0014
  built the `no brief` marker to preserve.

## Verification

`just check` passes clean: 361 tests pass, pyright reports 0 errors, and ruff,
typos and TOML validation are all green.

Checked against real data: `spf assets image dwarf --missing` now warns 12
times, prints `Nothing to generate.`, and exits 0.

Both old-contract tests in `test_image.py` were updated rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3fGBMXKyQ69raYpkziaFE