### PR TITLE
Pin console colour and width for the test suite

### DIFF
--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -367,9 +367,6 @@ def test_list_command_marks_only_the_rows_with_no_brief(
     assert "no brief" not in grunt_line
 
 
-_ANSI = re.compile(r"\x1b\[[0-9;]*m")
-
-
 def test_list_command_keeps_the_candidate_count_aligned(
     partly_briefed_kind: Kind, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -391,7 +388,7 @@ def test_list_command_keeps_the_candidate_count_aligned(
         result_action="return_value",
     )
 
-    lines = [_ANSI.sub("", line) for line in capsys.readouterr().out.splitlines()]
+    lines = capsys.readouterr().out.splitlines()
     marked = next(line for line in lines if "troll" in line)
     unmarked = next(line for line in lines if "grunt" in line)
     assert "no brief" in marked  # the two cases the slot has to line up
@@ -471,7 +468,7 @@ def test_list_command_prints_the_brief_before_the_lineages(
         result_action="return_value",
     )
 
-    lines = [_ANSI.sub("", line) for line in capsys.readouterr().out.splitlines()]
+    lines = capsys.readouterr().out.splitlines()
     grunt_at = next(i for i, line in enumerate(lines) if "grunt" in line)
     rest = lines[grunt_at + 1 :]
     # The Brief reflows over as many lines as it needs, so this is an ordering

--- a/v3/tests/assets/test_cli.py
+++ b/v3/tests/assets/test_cli.py
@@ -14,6 +14,7 @@ from spf.assets.kinds import KINDS
 from spf.config import config
 from spf.frontends.cli import app
 from tests.assets.conftest import FakeRefiner, fake_kind, register_kind
+from tests.conftest import unwrapped
 
 
 @pytest.fixture
@@ -176,7 +177,7 @@ def test_refine_command_errors_cleanly_on_a_kind_that_cannot_refine(
     with pytest.raises(SystemExit):
         app(argv, exit_on_error=False, result_action="return_value")
 
-    assert "does not support refinement" in capsys.readouterr().err
+    assert "does not support refinement" in unwrapped(capsys.readouterr().err)
 
 
 def test_image_command_errors_cleanly_on_an_unknown_unit(
@@ -642,4 +643,4 @@ def test_refine_command_survives_a_service_raising_mid_batch(
     # The Candidate that did land is still reported, and the failure surfaces
     # as the ordinary error line rather than a timer traceback.
     assert "Wrote" in captured.out
-    assert "the queue went away" in captured.err
+    assert "the queue went away" in unwrapped(captured.err)

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -19,6 +19,7 @@ from spf.assets import comfyui, get_kind
 from spf.assets import image as img
 from spf.config import config
 from spf.frontends.cli import app
+from tests.conftest import unwrapped
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 _MINI = _FIXTURES / "mini_workflow.json"
@@ -262,7 +263,7 @@ def test_cli_unit_image_writes_candidates(
     written = sorted(p.name for p in images.glob("*.png"))
     assert written == ["ogre_grunt.1.png", "ogre_grunt.2.png", "ogre_grunt.3.png"]
     assert (images / "ogre_grunt.1.png").read_bytes().startswith(_PNG)
-    out = capsys.readouterr().out
+    out = unwrapped(capsys.readouterr().out)
     assert "5" in out  # the seed is printed
     # The composed prompt is echoed before the request goes out.
     assert "A stout ogre grunt hefting a huge wrench" in out
@@ -381,9 +382,7 @@ def test_cli_failed_job_surfaces_red_error(
         _run("assets", "image", "ogre", "ogre_grunt", "--seed", "5")
 
     assert excinfo.value.code == 1
-    # Unwrapped: the subject is that the detail reaches the user, not where
-    # Rich happened to break the line for the current terminal width.
-    err = " ".join(capsys.readouterr().err.split())
+    err = unwrapped(capsys.readouterr().err)
     assert "image generation failed" in err
     assert "CUDA out of memory" in err  # ComfyUI's node_errors surfaced
 

--- a/v3/tests/assets/test_image.py
+++ b/v3/tests/assets/test_image.py
@@ -381,7 +381,9 @@ def test_cli_failed_job_surfaces_red_error(
         _run("assets", "image", "ogre", "ogre_grunt", "--seed", "5")
 
     assert excinfo.value.code == 1
-    err = capsys.readouterr().err
+    # Unwrapped: the subject is that the detail reaches the user, not where
+    # Rich happened to break the line for the current terminal width.
+    err = " ".join(capsys.readouterr().err.split())
     assert "image generation failed" in err
     assert "CUDA out of memory" in err  # ComfyUI's node_errors surfaced
 

--- a/v3/tests/conftest.py
+++ b/v3/tests/conftest.py
@@ -16,7 +16,22 @@ for _var in ("FORCE_COLOR", "COLORTERM"):
     os.environ.pop(_var, None)
 os.environ["TERM"] = "dumb"
 
-# Rich otherwise takes its width from the invoking terminal, so anything that
-# wraps — a Brief, a long error — depends on the size of the window the suite
-# happens to be run from. Pin it, or `COLUMNS=60` fails three tests.
+# Rich otherwise takes its width from the invoking terminal, so where a message
+# wraps depends on the window the suite happens to be run from. Pinning it makes
+# a run reproducible — but it is deliberately *not* what makes these tests pass:
+# they are green with this line deleted at every width from 40 to 250, because
+# the ones that match on a message compare it `unwrapped`. Keep it that way. A
+# test that only passes at 100 is a test that will fail on someone's laptop.
 os.environ["COLUMNS"] = "100"
+
+
+def unwrapped(text: str) -> str:
+    """Collapse Rich's line breaks so a message can be matched as one string.
+
+    Rich wraps console output to the terminal width, and the break can land
+    inside the very phrase a test is looking for, splitting "does not support
+    refinement" across two lines. Where the subject is *that the message
+    reached the user*, rather than how it was laid out, assert against this
+    instead of the raw capture.
+    """
+    return " ".join(text.split())

--- a/v3/tests/conftest.py
+++ b/v3/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Test-suite-wide setup.
+
+Pytest imports this before any test module, and therefore before
+`spf.console` constructs its Rich Consoles — which is what makes the
+environment pinning below effective. A Console reads its colour and width
+settings once, at construction, so none of this works as a fixture.
+"""
+
+import os
+
+# Rich emits colour and bold when FORCE_COLOR is set, and those escapes land in
+# `capsys` output — where a test asserting on layout sees `'\x1b[32m4.1'`
+# instead of `'4.1'`. Some terminals, CI runners and agent harnesses set it.
+# These tests assert on text, not styling, so the suite runs uncoloured.
+for _var in ("FORCE_COLOR", "COLORTERM"):
+    os.environ.pop(_var, None)
+os.environ["TERM"] = "dumb"
+
+# Rich otherwise takes its width from the invoking terminal, so anything that
+# wraps — a Brief, a long error — depends on the size of the window the suite
+# happens to be run from. Pin it, or `COLUMNS=60` fails three tests.
+os.environ["COLUMNS"] = "100"


### PR DESCRIPTION
Follow-up to the review of #64, where three tests appeared to fail on `master`
but were actually failing only in my shell.

## The bug is in the tests, not the code

Rich reads colour and width from the environment **once, at `Console`
construction**. `src/spf/console.py` builds both at import, so whatever the
environment says when `spf` is first imported is what the whole test run gets.

Two independent fragilities followed:

- **Colour.** With `FORCE_COLOR` set (some terminals, some CI runners, and
  Claude Code's harness all set it), Rich emits ANSI into `capsys` output, so a
  test asserting on layout sees `'\x1b[32m4.1'` instead of `'4.1'`. Three tests
  failed this way; two others already worked around it with a hand-rolled
  `_ANSI` regex.
- **Width.** Rich wraps to the terminal, and the break can land inside the very
  phrase a test matches on — `"does not support \nrefinement"`.

Neither says anything about the CLI. The tests were asserting on presentation
they don't care about.

## Two commits, and the second is the important one

**1 — pin the environment.** `tests/conftest.py` scrubs `FORCE_COLOR` and pins
`COLUMNS` before `spf.console` is imported. It has to be module-level code in
`conftest.py`, not a fixture: by the time a fixture runs, the Consoles exist.

**2 — make the tests sturdy anyway.** Pinning alone *masks* width fragility
rather than removing it. With the pin deleted, `COLUMNS=60` still failed two
tests and `COLUMNS=40` one. So this adds an `unwrapped()` helper and routes the
four wrap-sensitive assertions through it.

The pin now stays for **reproducibility, not correctness** — and the conftest
comment says so, to stop a future test quietly coming to depend on it.

## Net effect

A deletion overall: `_ANSI` and both its call sites are gone, replaced by one
shared helper. No production code changed.

## Verification

357 tests pass under `FORCE_COLOR=3`, `NO_COLOR=1`, `TERM=dumb`, and `COLUMNS`
at 40 / 50 / 60 / 80 / 100 / 140 / 250 — **and with the `COLUMNS` pin deleted
entirely** at every one of those widths, which is the check that shows the
tests are sturdy rather than merely pinned.

Below 40 columns six tests still fail. Deliberately not chased: the CLI prints
paths and tables that can't survive a 30-column terminal anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3fGBMXKyQ69raYpkziaFE