### PR TITLE
Default new PRs to ready-for-review, not draft

### DIFF
--- a/v3/docs/agents/workflow.md
+++ b/v3/docs/agents/workflow.md
@@ -17,7 +17,10 @@ For non-trivial features and fixes, follow this workflow:
 
 ## Wrapping up
 
-- When the implementation is done, push the commits to a **new PR**.
+- When the implementation is done, push the commits to a **new PR**. Open it
+  **ready for review, not as a draft** — `gh pr create` (no `--draft`). A plan
+  or issue that says to open a draft is overridden by this default unless the
+  human asks for a draft explicitly.
 - **Don't clean anything up** (worktree, branch, scratch files) until told to —
   the PR is reviewed before merging.
 - The human squash-merges the PR at the end.


### PR DESCRIPTION
Updates `docs/agents/workflow.md` so the wrap-up step is explicit: agents open
new PRs **ready for review**, not as drafts, and a plan or issue that says
`--draft` does not override this unless the human asks for it.

Motivated by #66, which opened as a draft only because its handoff plan said
`gh pr create --draft` and the workflow doc didn't state a default either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)