### PR TITLE
Put unit art on the back of the Order Cards

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -173,6 +173,10 @@ whole resolved Army as one **deck** file (in PDF, nine cards to an A4 page).
 Each Unit's orders are the *merged* orders: its base `orders` unioned per Speed
 with any orders gained from equipment (`orders_gained`), appending the gained
 rows. Units that produce identical cards collapse to one set (no duplicates).
+
+The back of a card carries the Unit's Image Asset, with the Unit name above it
+and the order kind below; a Unit with no committed art keeps the same layout
+minus the picture, so the back still identifies the card.
 _Avoid_: order sheet, unit card (a card is one option, not one Unit)
 
 **Army Reference**:
@@ -217,9 +221,9 @@ short prose field, the seed — not the Lore)
 
 **Image** (asset):
 A 2D image Asset depicting a Race or Unit, generated from its `description`.
-Stored under `assets/<race>/images/`. Embedded by the Army Reference Rendering,
-which references the committed file where it lies rather than copying it
-(ADR 0017).
+Stored under `assets/<race>/images/`. Embedded by the Army Reference Rendering
+and on the back of the Order Cards, both of which reference the committed file
+where it lies rather than copying it (ADR 0017).
 
 **Model** (asset):
 A 3D-mesh Asset (for on-demand printing) depicting a Unit or Model, stored

--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -177,6 +177,7 @@ rows. Units that produce identical cards collapse to one set (no duplicates).
 The back of a card carries the Unit's Image Asset, with the Unit name above it
 and the order kind below; a Unit with no committed art keeps the same layout
 minus the picture, so the back still identifies the card.
+
 _Avoid_: order sheet, unit card (a card is one option, not one Unit)
 
 **Army Reference**:

--- a/v3/docs/adr/0017-renderings-reference-assets-in-place.md
+++ b/v3/docs/adr/0017-renderings-reference-assets-in-place.md
@@ -83,6 +83,14 @@ finds nothing, so the templates need no opt-out conditional of their own.
 - **Layout is the template family's business.** The view-model carries a path
   and nothing about size or placement, so Markdown's lead image and LaTeX's
   side-by-side minipages can differ without the two negotiating.
-- `--no-images` lives on the shared `RenderOpts` but currently affects
-  `army-rules` only; it starts working for `cards` when that Product embeds
-  Assets.
+- `--no-images` lives on the shared `RenderOpts` and affects every Product that
+  embeds Assets.
+
+## Addendum: the seam generalised to a second Product
+
+The decision above is unchanged; only its reach is. When the Order Cards began
+carrying the Unit's art on the card back, `ImageLookup`, `committed_image` and
+`no_image` moved out of `spf/render/army_rules.py` into **`spf/render/images.py`**,
+so that no Product has to import another to ask what art is committed. They are
+now injected into `build_deck` exactly as into `build_reference`, and
+`--no-images` passes `no_image` to both.

--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -14,9 +14,10 @@ import cyclopts
 from spf.armies import io
 from spf.console import stderr, stdout
 from spf.render import Product, render
-from spf.render.army_rules import build_reference, committed_image, no_image
+from spf.render.army_rules import build_reference
 from spf.render.cards import build_deck
 from spf.render.formats import FORMATS, get_format
+from spf.render.images import committed_image, no_image
 from spf.render.products import register_product
 
 DEFAULT_FORMAT = "pdf"

--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -58,10 +58,7 @@ class RenderOpts:
         cyclopts.Parameter(
             # The auto-derived negative would read `--no-no-images`.
             negative="",
-            help=(
-                "Leave committed Image Assets out of the document "
-                "(currently affects 'army-rules' only)."
-            ),
+            help="Leave committed Image Assets out of the document.",
         ),
     ] = False
 
@@ -85,7 +82,9 @@ def render_cards(
         raise SystemExit(1) from None
 
     stem = _safe_stem(army_name)
-    deck = build_deck(army, stem=stem)
+    deck = build_deck(
+        army, stem=stem, image_for=no_image if opts.no_images else committed_image
+    )
     fmt = get_format(opts.format)
     out = render(CARDS, deck, fmt=fmt, name=stem, out=opts.out)
     stdout.print(f"Wrote {out}")

--- a/v3/src/spf/render/army_rules.py
+++ b/v3/src/spf/render/army_rules.py
@@ -5,9 +5,9 @@ It reads only the resolved `Army` — no `race_config`,
 no rules loading, no full special-rule text (that belongs to the Rulebook
 product). No templates.
 
-Its one touch of disk is the `ImageLookup`, which asks the committed Asset
-store whether a Target has art (ADR 0017); it is injected, so a test can build
-a reference without a filesystem at all.
+Its one touch of disk is the `ImageLookup` from `spf.render.images`, which asks
+the committed Asset store whether a Target has art (ADR 0017); it is injected,
+so a test can build a reference without a filesystem at all.
 """
 
 from collections.abc import Callable, Sequence
@@ -17,24 +17,11 @@ from pathlib import Path
 from spf.armies.army import Army
 from spf.armies.model import Model
 from spf.armies.unit import Unit
-from spf.assets.image import IMAGE
-from spf.assets.spine import asset_for
+from spf.render.images import ImageLookup, committed_image
 from spf.schemas import type_aliases as t
 from spf.schemas.race import EquipmentConfig
 
 type _Specials = list[tuple[str, str]]
-
-type ImageLookup = Callable[[t.RaceName, str], Path | None]
-"""Answers "what art is committed for this Target?" — see `committed_image`."""
-
-
-def committed_image(race: t.RaceName, name: str) -> Path | None:
-    """Return the committed Image Asset for `name`, or `None` when there is none."""
-    return asset_for(IMAGE, race, name=name)
-
-
-def no_image(race: t.RaceName, name: str) -> None:
-    """Lookup that finds nothing — what `--no-images` passes."""
 
 
 def _roll_text(roll: t.DamageRoll) -> str:

--- a/v3/src/spf/render/cards.py
+++ b/v3/src/spf/render/cards.py
@@ -3,15 +3,20 @@
 This is a *presentation* transposition (ADR 0007). The core model exposes merged
 orders via `spf.armies.unit.Unit.orders`; this module turns those into the
 two shapes the render families need: a flat per-Unit table (Markdown family) and
-an option-index-transposed card list (LaTeX 9-per-page grid). No I/O, no
-templates.
+an option-index-transposed card list (LaTeX 9-per-page grid). No templates.
+
+Its one touch of disk is the `ImageLookup` from `spf.render.images`, which asks
+the committed Asset store whether a Target has art (ADR 0017); it is injected,
+so a test can build a deck without a filesystem at all.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from spf.armies.army import Army
 from spf.armies.unit import Unit
+from spf.render.images import ImageLookup, committed_image
 from spf.schemas import type_aliases as t
 
 type _Rows = list[tuple[str, list[str]]]  # (speed, cells) per row
@@ -23,6 +28,7 @@ class OrderCard:
     """One order-type and one option-index for a Unit, Speeds as rows."""
 
     unit_name: str
+    image: Path | None  # the Unit's art, printed on the back of the card
     kind: Literal["Movement", "Fire"]
     rows: _Rows  # (speed, cells) per Speed
 
@@ -32,6 +38,7 @@ class UnitOrders:
     """A Unit's merged orders as flat tables, for the Markdown family."""
 
     name: str
+    image: Path | None
     size: str
     movement_rows: _Rows  # every (speed, cells) option, flat
     fire_rows: _Rows
@@ -59,8 +66,9 @@ def _flat_rows(orders: _Orders) -> _Rows:
 
 def _cards(
     unit_name: str,
-    kind: Literal["Movement", "Fire"],
     *,
+    image: Path | None,
+    kind: Literal["Movement", "Fire"],
     orders: _Orders,
 ) -> list[OrderCard]:
     """Transpose one order-type by option-index: card i = option i across Speeds."""
@@ -75,16 +83,25 @@ def _cards(
             if i < len(options)
         ]
         if rows:
-            cards.append(OrderCard(unit_name=unit_name, kind=kind, rows=rows))
+            cards.append(
+                OrderCard(unit_name=unit_name, image=image, kind=kind, rows=rows)
+            )
     return cards
 
 
-def _unit_orders(unit: Unit) -> tuple[UnitOrders, list[OrderCard]]:
+def _unit_orders(
+    unit: Unit, *, race: t.RaceName, image_for: ImageLookup
+) -> tuple[UnitOrders, list[OrderCard]]:
     """Build the flat table and card list for a single Unit."""
     merged = unit.orders()
     shaken = unit.config.shaken
+    # `unit.name` is the TOML key, which is what addresses an Asset;
+    # `unit.config.name` is the display name. One lookup serves the flat
+    # table and every card the Unit produces.
+    image = image_for(race, unit.name)
     unit_orders = UnitOrders(
         name=unit.config.name,
+        image=image,
         size=unit.config.size,
         movement_rows=_flat_rows(merged.movement),
         fire_rows=_flat_rows(merged.fire),
@@ -92,24 +109,35 @@ def _unit_orders(unit: Unit) -> tuple[UnitOrders, list[OrderCard]]:
         shaken_fire=shaken.fire_order,
     )
     cards = [
-        *_cards(unit.config.name, "Movement", orders=merged.movement),
-        *_cards(unit.config.name, "Fire", orders=merged.fire),
+        *_cards(unit.config.name, image=image, kind="Movement", orders=merged.movement),
+        *_cards(unit.config.name, image=image, kind="Fire", orders=merged.fire),
     ]
     return unit_orders, cards
 
 
-def build_deck(army: Army, *, stem: str) -> OrderCardDeck:
+def build_deck(
+    army: Army, *, stem: str, image_for: ImageLookup = committed_image
+) -> OrderCardDeck:
     """Build an `OrderCardDeck` from a resolved Army.
 
     Each Unit contributes a flat `UnitOrders` and its transposed
     `OrderCard` set. Units producing an identical flat view (same name and
     merged movement/fire rows) collapse to one entry.
+
+    `image_for` resolves Image Assets; it defaults to the committed store and
+    is swapped for `no_image` by `--no-images`. A Unit with no committed art
+    simply gets `None` — the card back then falls back to text.
     """
     units: list[UnitOrders] = []
     cards: list[OrderCard] = []
+    # The dedup key stays the *display* name, deliberately: art is addressed by
+    # TOML key, and no race has two Unit keys sharing a display name, so the
+    # "same name, different art" collision cannot arise today.
     seen: list[tuple[str, _Rows, _Rows]] = []
     for unit in army.units:
-        unit_orders, unit_cards = _unit_orders(unit)
+        unit_orders, unit_cards = _unit_orders(
+            unit, race=army.race, image_for=image_for
+        )
         key = (unit_orders.name, unit_orders.movement_rows, unit_orders.fire_rows)
         if key in seen:
             continue

--- a/v3/src/spf/render/cards.py
+++ b/v3/src/spf/render/cards.py
@@ -92,12 +92,14 @@ def _cards(
 def _unit_orders(
     unit: Unit, *, race: t.RaceName, image_for: ImageLookup
 ) -> tuple[UnitOrders, list[OrderCard]]:
-    """Build the flat table and card list for a single Unit."""
+    """Build the flat table and card list for a single Unit.
+
+    The Asset is addressed by `unit.name`, the TOML key, not by
+    `unit.config.name`, the display name. One lookup serves the flat table and
+    every card the Unit produces.
+    """
     merged = unit.orders()
     shaken = unit.config.shaken
-    # `unit.name` is the TOML key, which is what addresses an Asset;
-    # `unit.config.name` is the display name. One lookup serves the flat
-    # table and every card the Unit produces.
     image = image_for(race, unit.name)
     unit_orders = UnitOrders(
         name=unit.config.name,
@@ -122,7 +124,10 @@ def build_deck(
 
     Each Unit contributes a flat `UnitOrders` and its transposed
     `OrderCard` set. Units producing an identical flat view (same name and
-    merged movement/fire rows) collapse to one entry.
+    merged movement/fire rows) collapse to one entry. That key is the *display*
+    name and deliberately ignores the art: an Asset is addressed by TOML key,
+    and no race has two Unit keys sharing a display name, so the "same name,
+    different art" collision cannot arise today.
 
     `image_for` resolves Image Assets; it defaults to the committed store and
     is swapped for `no_image` by `--no-images`. A Unit with no committed art
@@ -130,9 +135,6 @@ def build_deck(
     """
     units: list[UnitOrders] = []
     cards: list[OrderCard] = []
-    # The dedup key stays the *display* name, deliberately: art is addressed by
-    # TOML key, and no race has two Unit keys sharing a display name, so the
-    # "same name, different art" collision cannot arise today.
     seen: list[tuple[str, _Rows, _Rows]] = []
     for unit in army.units:
         unit_orders, unit_cards = _unit_orders(

--- a/v3/src/spf/render/images.py
+++ b/v3/src/spf/render/images.py
@@ -1,0 +1,27 @@
+"""The seam between a Rendering and the committed Image Asset store.
+
+One place asks "what art is committed for this Target?" (ADR 0017), neutral
+between Products so that no Product has to import another to find out. A
+Product takes an `ImageLookup` as an argument, defaulting to `committed_image`;
+`--no-images` swaps in `no_image`, and a test swaps in its own fake and needs
+no filesystem at all.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from spf.assets.image import IMAGE
+from spf.assets.spine import asset_for
+from spf.schemas import type_aliases as t
+
+type ImageLookup = Callable[[t.RaceName, str], Path | None]
+"""Answers "what art is committed for this Target?" — see `committed_image`."""
+
+
+def committed_image(race: t.RaceName, name: str) -> Path | None:
+    """Return the committed Image Asset for `name`, or `None` when there is none."""
+    return asset_for(IMAGE, race, name=name)
+
+
+def no_image(race: t.RaceName, name: str) -> None:
+    """Lookup that finds nothing — what `--no-images` passes."""

--- a/v3/templates/latex/cards/main.tex.jinja
+++ b/v3/templates/latex/cards/main.tex.jinja
@@ -1,16 +1,29 @@
 \documentclass[frontgrid,a4,12pt]{flacards}
 \usepackage{textcomp}
+\usepackage{graphicx}
 \pagesetup{3}{3}
 \setlength{\cardwidth}{63mm}
 \setlength{\cardheight}{88mm}
+% `\cardbox` insets the body by `\fboxsep` on each side, so art at the full
+% `\cardwidth` would overfull the line. Set this *after* `\cardwidth` above.
+\newlength{\cardartwidth}
+\setlength{\cardartwidth}{\dimexpr\cardwidth-2\fboxsep\relax}
 \renewcommand{\cardtextstylef}{\small}
 \renewcommand{\cardtextstyleb}{\small}
 \renewcommand{\brfoot}{}
 
 \begin{document}
+% Card backs: the Unit name and the order kind sit in flacards' own
+% `\bchead`/`\bcfoot` slots, so the body below is the art alone. That body must
+% never be empty — `\cardtext` appends `\\`, and `\\` in vertical mode is the
+% classic "There's no line here to end" error. Hence the `\strut` fallback.
+% Image paths are emitted raw: `latex_escape` would turn `_` into `\_` and
+% break the graphics include.
 \BLOCK{for card in source.cards}
 \renewcommand{\frfoot}{\VAR{card.unit_name | latex_escape}}
 \renewcommand{\flhead}{\VAR{card.kind}}
+\renewcommand{\bchead}{\VAR{card.unit_name | latex_escape}}
+\renewcommand{\bcfoot}{\VAR{card.kind}}
 \card{%
 \begin{tabular}{ll}
 \BLOCK{for speed, cells in card.rows}
@@ -18,7 +31,11 @@
 \BLOCK{endfor}
 \end{tabular}%
 }{%
-\VAR{card.unit_name | latex_escape} \\ \VAR{card.kind}%
+\BLOCK{if card.image}
+\includegraphics[width=\cardartwidth]{\VAR{card.image | posix_path}}%
+\BLOCK{else}
+\strut%
+\BLOCK{endif}
 }
 
 \BLOCK{endfor}

--- a/v3/templates/markdown/cards/main.md.jinja
+++ b/v3/templates/markdown/cards/main.md.jinja
@@ -15,6 +15,10 @@
 {% for unit in source.units -%}
 ## {{ unit.name }}
 
+{% if unit.image -%}
+![{{ unit.name }}]({{ unit.image | relative_to(output_dir) }})
+
+{% endif -%}
 {{ order_table("Movement", unit.movement_rows, unit.shaken_movement) }}
 {{ order_table("Fire", unit.fire_rows, ("", unit.shaken_fire, "") if unit.shaken_fire else None) }}
 {% endfor -%}

--- a/v3/tests/render/conftest.py
+++ b/v3/tests/render/conftest.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 
+ART = Path("/assets/goblin/images/art.png")
+"""A committed Image Asset that no test needs to exist on disk."""
+
 
 class FakeLookup:
     """An `ImageLookup` returning a canned path, recording every call."""

--- a/v3/tests/render/conftest.py
+++ b/v3/tests/render/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for the render suites."""
+
+from pathlib import Path
+
+
+class FakeLookup:
+    """An `ImageLookup` returning a canned path, recording every call."""
+
+    def __init__(self, path: Path | None) -> None:
+        """Answer every lookup with `path` — `None` stands for "no art"."""
+        self.path = path
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, race: str, name: str) -> Path | None:
+        """Record the Target asked about, then return the canned path."""
+        self.calls.append((race, name))
+        return self.path

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -27,7 +27,7 @@ from spf.schemas.race import (
     EquipmentRangeConfig as RangeConfig,
 )
 from spf.schemas.type_aliases import AtLeastRoll, ExactRoll, RangeRoll
-from tests.render.conftest import FakeLookup
+from tests.render.conftest import ART, FakeLookup
 
 ENGINE = config.render.latex.engine
 
@@ -461,8 +461,6 @@ def test_build_reference_leaves_images_none_when_there_is_no_art() -> None:
 
 # --- Templates: embedded Image Assets (drives the real templates) ----------
 
-_ART = Path("/assets/goblin/images/art.png")
-
 
 def test_army_rules_markdown_embeds_race_and_unit_images(tmp_path: Path) -> None:
     # Relative to the written document, not absolute: a root-absolute path
@@ -508,7 +506,7 @@ def test_army_rules_latex_puts_the_unit_image_beside_the_stat_block(
     tmp_path: Path,
 ) -> None:
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(_ART)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(ART)
     )
 
     out = render(
@@ -525,7 +523,7 @@ def test_army_rules_latex_puts_the_unit_image_beside_the_stat_block(
     # document-relative path would not resolve.
     # The path is emitted raw: `latex_escape` would turn `_` into `\_` and
     # break `\includegraphics`.
-    assert rf"\includegraphics[width=\linewidth]{{{_ART}}}" in text
+    assert rf"\includegraphics[width=\linewidth]{{{ART}}}" in text
     assert r"\begin{minipage}" in text
 
 

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -27,6 +27,7 @@ from spf.schemas.race import (
     EquipmentRangeConfig as RangeConfig,
 )
 from spf.schemas.type_aliases import AtLeastRoll, ExactRoll, RangeRoll
+from tests.render.conftest import FakeLookup
 
 ENGINE = config.render.latex.engine
 
@@ -417,21 +418,9 @@ def test_render_army_rules_missing_army_exits_nonzero(tmp_path: Path) -> None:
 # --- build_reference: Image Assets on the view-model ------------------------
 
 
-class _FakeLookup:
-    """An `ImageLookup` returning a canned path, recording every call."""
-
-    def __init__(self, path: Path | None) -> None:
-        self.path = path
-        self.calls: list[tuple[str, str]] = []
-
-    def __call__(self, race: str, name: str) -> Path | None:
-        self.calls.append((race, name))
-        return self.path
-
-
 def test_build_reference_populates_images_from_the_injected_lookup() -> None:
     image = Path("/assets/goblin/images/art.png")
-    lookup = _FakeLookup(image)
+    lookup = FakeLookup(image)
 
     reference = build_reference(
         _army(_unit(name="Squad"), race="goblin"),
@@ -446,7 +435,7 @@ def test_build_reference_populates_images_from_the_injected_lookup() -> None:
 def test_build_reference_looks_images_up_by_toml_key_not_display_name() -> None:
     # The Target that addresses an Asset is the TOML key, which `Unit.name`
     # carries; `unit.config.name` is the display name shown in the document.
-    lookup = _FakeLookup(None)
+    lookup = FakeLookup(None)
     unit = _unit(name="Goblin Infantry")
     unit = Unit(name="goblin_infantry", config=unit.config, models=unit.models)
 
@@ -463,7 +452,7 @@ def test_build_reference_leaves_images_none_when_there_is_no_art() -> None:
     reference = build_reference(
         _army(_unit()),
         stem="test",
-        image_for=_FakeLookup(None),
+        image_for=FakeLookup(None),
     )
 
     assert reference.race_image is None
@@ -481,7 +470,7 @@ def test_army_rules_markdown_embeds_race_and_unit_images(tmp_path: Path) -> None
     # such as `file://wsl.localhost/<distro>/...` (ADR 0017).
     art = tmp_path / "assets" / "art.png"
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=_FakeLookup(art)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(art)
     )
 
     out = render(
@@ -501,7 +490,7 @@ def test_army_rules_markdown_emits_no_image_markup_without_art(
     tmp_path: Path,
 ) -> None:
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=_FakeLookup(None)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(None)
     )
 
     out = render(
@@ -519,7 +508,7 @@ def test_army_rules_latex_puts_the_unit_image_beside_the_stat_block(
     tmp_path: Path,
 ) -> None:
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=_FakeLookup(_ART)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(_ART)
     )
 
     out = render(
@@ -544,7 +533,7 @@ def test_army_rules_latex_keeps_the_full_width_stat_block_without_art(
     tmp_path: Path,
 ) -> None:
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=_FakeLookup(None)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(None)
     )
 
     out = render(
@@ -570,7 +559,7 @@ def test_render_army_rules_pdf_compiles_with_an_underscored_image_path(
     # that an underscore in the filename needs no escaping.
     art = Path(__file__).parent.parent / "fixtures" / "tiny_art.png"
     reference = build_reference(
-        _army(_unit(), race="goblin"), stem="test", image_for=_FakeLookup(art)
+        _army(_unit(), race="goblin"), stem="test", image_for=FakeLookup(art)
     )
 
     out = render(

--- a/v3/tests/render/test_cards.py
+++ b/v3/tests/render/test_cards.py
@@ -20,6 +20,7 @@ from spf.schemas.race import (
     ShakenConfig,
     UnitConfig,
 )
+from tests.render.conftest import FakeLookup
 
 ENGINE = config.render.latex.engine
 
@@ -150,8 +151,8 @@ def test_orders_speeds_follow_canonical_order() -> None:
 # --- build_deck: flat rows for the Markdown family --------------------------
 
 
-def _army(*units: Unit, nick: str = "Test") -> Army:
-    return Army(race="elf", nick=nick, units=list(units))
+def _army(*units: Unit, nick: str = "Test", race: str = "elf") -> Army:
+    return Army(race=race, nick=nick, units=list(units))  # pyright: ignore[reportArgumentType]
 
 
 def test_build_deck_flat_rows_one_entry_per_option() -> None:
@@ -258,6 +259,49 @@ def test_build_deck_carries_shaken_to_units_not_cards() -> None:
     assert unit_orders.shaken_fire == "No weapons"
     # Shaken is not an order option, so it never becomes a card.
     assert all("flee" not in str(card.rows) for card in deck.cards)
+
+
+# --- build_deck: Image Assets on the view-model -----------------------------
+
+
+def test_build_deck_populates_images_from_the_injected_lookup() -> None:
+    image = Path("/assets/goblin/images/art.png")
+    unit = _unit(
+        orders=OrdersConfig(movement={"still": [["A"]]}, fire={"still": [["F"]]})
+    )
+
+    deck = build_deck(
+        _army(unit, race="goblin"), stem="test", image_for=FakeLookup(image)
+    )
+
+    assert [u.image for u in deck.units] == [image]
+    assert len(deck.cards) == 2  # one Movement card, one Fire card
+    assert all(card.image == image for card in deck.cards)
+
+
+def test_build_deck_looks_images_up_once_per_unit_by_toml_key() -> None:
+    # The Target that addresses an Asset is the TOML key, which `Unit.name`
+    # carries; `unit.config.name` is the display name printed on the card.
+    lookup = FakeLookup(None)
+    unit = _unit(
+        orders=OrdersConfig(movement={"still": [["A"]]}, fire={"still": [["F"]]}),
+        name="Goblin Infantry",
+    )
+    unit = Unit(name="goblin_infantry", config=unit.config, models=unit.models)
+
+    build_deck(_army(unit, race="goblin"), stem="test", image_for=lookup)
+
+    # One lookup per Unit, not one per card.
+    assert lookup.calls == [("goblin", "goblin_infantry")]
+
+
+def test_build_deck_leaves_images_none_when_there_is_no_art() -> None:
+    unit = _unit(orders=OrdersConfig(movement={"still": [["A"]]}))
+
+    deck = build_deck(_army(unit), stem="test", image_for=FakeLookup(None))
+
+    assert [u.image for u in deck.units] == [None]
+    assert all(card.image is None for card in deck.cards)
 
 
 # --- _safe_stem -------------------------------------------------------------

--- a/v3/tests/render/test_cards.py
+++ b/v3/tests/render/test_cards.py
@@ -9,8 +9,10 @@ from spf.armies.army import Army
 from spf.armies.model import Model
 from spf.armies.unit import Unit
 from spf.config import config
-from spf.frontends.cli.render import RenderOpts, _safe_stem, render_cards
-from spf.render.cards import build_deck
+from spf.frontends.cli.render import CARDS, RenderOpts, _safe_stem, render_cards
+from spf.render import render
+from spf.render.cards import OrderCardDeck, build_deck
+from spf.render.formats import get_format
 from spf.schemas import type_aliases as t
 from spf.schemas.race import (
     AssaultConfig,
@@ -323,6 +325,7 @@ def test_safe_stem_collapses_runs_and_strips_ends() -> None:
 # --- CLI: render cards end-to-end (drives the real templates) ---------------
 
 DEMO_ARMY = "demo"
+_ART = Path("/assets/goblin/images/art.png")
 
 
 def test_render_cards_markdown_has_tables_and_shaken(tmp_path: Path) -> None:
@@ -360,6 +363,118 @@ def test_render_cards_pdf_compiles(tmp_path: Path) -> None:
     render_cards(DEMO_ARMY, opts=RenderOpts(format="pdf", out=out))
 
     assert out.stat().st_size > 0
+
+
+# --- Templates: the Unit's art on the card back (drives the real templates) --
+
+
+def _art_deck(image: Path | None, *, name: str = "Squad") -> OrderCardDeck:
+    unit = _unit(
+        orders=OrdersConfig(movement={"still": [["A"]]}, fire={"still": [["F"]]}),
+        name=name,
+    )
+    return build_deck(
+        _army(unit, race="goblin"), stem="test", image_for=FakeLookup(image)
+    )
+
+
+def test_cards_markdown_embeds_the_unit_image(tmp_path: Path) -> None:
+    # Relative to the written document, not absolute: a root-absolute path
+    # loses the share name across a UNC boundary (ADR 0017).
+    art = tmp_path / "assets" / "art.png"
+
+    out = render(
+        CARDS,
+        _art_deck(art),
+        fmt=get_format("markdown"),
+        name="test",
+        output_root=tmp_path,
+    )
+
+    assert "![Squad](../assets/art.png)" in out.read_text(encoding="utf-8")
+
+
+def test_cards_markdown_emits_no_image_markup_without_art(tmp_path: Path) -> None:
+    out = render(
+        CARDS,
+        _art_deck(None),
+        fmt=get_format("markdown"),
+        name="test",
+        output_root=tmp_path,
+    )
+
+    assert "![" not in out.read_text(encoding="utf-8")
+
+
+def test_cards_latex_puts_name_art_and_kind_on_the_back(tmp_path: Path) -> None:
+    out = render(
+        CARDS,
+        _art_deck(_ART),
+        fmt=get_format("latex"),
+        name="test",
+        output_root=tmp_path,
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert r"\usepackage{graphicx}" in text
+    assert r"\renewcommand{\bchead}{Squad}" in text
+    assert r"\renewcommand{\bcfoot}{Movement}" in text
+    assert r"\renewcommand{\bcfoot}{Fire}" in text
+    # The path is emitted raw: `latex_escape` would turn `_` into `\_` and
+    # break `\includegraphics`.
+    assert rf"\includegraphics[width=\cardartwidth]{{{_ART}}}" in text
+
+
+def test_cards_latex_back_falls_back_to_text_without_art(tmp_path: Path) -> None:
+    out = render(
+        CARDS,
+        _art_deck(None),
+        fmt=get_format("latex"),
+        name="test",
+        output_root=tmp_path,
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert r"\includegraphics" not in text
+    # The name and kind still identify the back of an art-less card.
+    assert r"\renewcommand{\bchead}{Squad}" in text
+    assert r"\renewcommand{\bcfoot}{Movement}" in text
+    # `\cardtext` ends the body with `\\`, so an empty body is a LaTeX error.
+    assert r"\strut" in text
+
+
+@pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
+def test_cards_pdf_compiles_with_a_mixed_deck(tmp_path: Path) -> None:
+    # A deck where one Unit has art and one does not is the case that breaks if
+    # the art-less back leaves `\cardtext`'s body empty.
+    art = Path(__file__).parent.parent / "fixtures" / "tiny_art.png"
+    orders = OrdersConfig(movement={"still": [["A"]]}, fire={"still": [["F"]]})
+    with_art = _unit(orders=orders, name="Painted")
+    without_art = _unit(orders=orders, name="Bare")
+
+    def image_for(_race: str, name: str) -> Path | None:
+        return art if name == "Painted" else None
+
+    deck = build_deck(
+        _army(with_art, without_art, race="goblin"), stem="test", image_for=image_for
+    )
+
+    out = render(CARDS, deck, fmt=get_format("pdf"), name="test", output_root=tmp_path)
+
+    assert out.stat().st_size > 0
+
+
+def test_render_cards_no_images_omits_committed_art(tmp_path: Path) -> None:
+    # The demo army's race has committed Unit art, so the default render does
+    # embed images — `--no-images` is what removes them.
+    with_art = tmp_path / "with-art.md"
+    render_cards(DEMO_ARMY, opts=RenderOpts(format="markdown", out=with_art))
+    assert "![" in with_art.read_text(encoding="utf-8")
+
+    out = tmp_path / "no-art.md"
+    render_cards(DEMO_ARMY, opts=RenderOpts(format="markdown", out=out, no_images=True))
+
+    assert "![" not in out.read_text(encoding="utf-8")
 
 
 def test_render_cards_missing_army_exits_nonzero(tmp_path: Path) -> None:

--- a/v3/tests/render/test_cards.py
+++ b/v3/tests/render/test_cards.py
@@ -422,7 +422,7 @@ def test_cards_latex_puts_name_art_and_kind_on_the_back(tmp_path: Path) -> None:
     assert r"\renewcommand{\bcfoot}{Fire}" in text
     # The path is emitted raw: `latex_escape` would turn `_` into `\_` and
     # break `\includegraphics`.
-    assert rf"\includegraphics[width=\cardartwidth]{{{_ART}}}" in text
+    assert rf"\includegraphics[width=\cardartwidth]{{{_ART.as_posix()}}}" in text
 
 
 def test_cards_latex_back_falls_back_to_text_without_art(tmp_path: Path) -> None:

--- a/v3/tests/render/test_cards.py
+++ b/v3/tests/render/test_cards.py
@@ -22,7 +22,7 @@ from spf.schemas.race import (
     ShakenConfig,
     UnitConfig,
 )
-from tests.render.conftest import FakeLookup
+from tests.render.conftest import ART, FakeLookup
 
 ENGINE = config.render.latex.engine
 
@@ -325,7 +325,6 @@ def test_safe_stem_collapses_runs_and_strips_ends() -> None:
 # --- CLI: render cards end-to-end (drives the real templates) ---------------
 
 DEMO_ARMY = "demo"
-_ART = Path("/assets/goblin/images/art.png")
 
 
 def test_render_cards_markdown_has_tables_and_shaken(tmp_path: Path) -> None:
@@ -409,7 +408,7 @@ def test_cards_markdown_emits_no_image_markup_without_art(tmp_path: Path) -> Non
 def test_cards_latex_puts_name_art_and_kind_on_the_back(tmp_path: Path) -> None:
     out = render(
         CARDS,
-        _art_deck(_ART),
+        _art_deck(ART),
         fmt=get_format("latex"),
         name="test",
         output_root=tmp_path,
@@ -422,7 +421,7 @@ def test_cards_latex_puts_name_art_and_kind_on_the_back(tmp_path: Path) -> None:
     assert r"\renewcommand{\bcfoot}{Fire}" in text
     # The path is emitted raw: `latex_escape` would turn `_` into `\_` and
     # break `\includegraphics`.
-    assert rf"\includegraphics[width=\cardartwidth]{{{_ART.as_posix()}}}" in text
+    assert rf"\includegraphics[width=\cardartwidth]{{{ART.as_posix()}}}" in text
 
 
 def test_cards_latex_back_falls_back_to_text_without_art(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #72 (part of #16, #22). Same wiring as #68, for the second Product.

The back of an Order Card now carries the Unit's committed art, using flacards'
own layout slots: **Unit name in `\bchead`, art centred in the body, `Movement` /
`Fire` in `\bcfoot`**. A Unit with no committed art keeps the same layout minus
the picture, so a mixed deck stays consistent and every back still identifies
its card. The Markdown cards family gets the same art under each `## <unit>`
heading, which is what makes `--no-images` honest in every Format rather than
just PDF.

## What changed

- **`src/spf/render/images.py`** (new) — `ImageLookup`, `committed_image` and
  `no_image` move out of `render/army_rules.py`. Neutral between Products, so
  neither imports the other to ask what art is committed.
- **`render/cards.py`** — `OrderCard.image` and `UnitOrders.image`.
  `_unit_orders` resolves the art **once per Unit**, by TOML key
  (`unit.name`, not the display name), and stamps it onto the flat table and
  every card. `build_deck` takes `image_for`, defaulting to `committed_image`.
  `_cards` stays a pure transposer that never sees a race, a key, or the asset
  store.
- **`templates/latex/cards/main.tex.jinja`** — `graphicx`, a `\cardartwidth` of
  `\cardwidth - 2\fboxsep` (set *after* `\cardwidth`, or it captures
  `\pagesetup`'s computed value), the two back slots, and a `\strut` fallback.
  The `\strut` is load-bearing: `\cardtext` appends `\\`, so an empty body is
  the classic *"There's no line here to end"* error.
- **`--no-images`** now passes `no_image` to `build_deck` too; the help text's
  "(currently affects 'army-rules' only)" parenthetical is gone.
- **Docs** — CONTEXT.md's *Image (asset)* entry names both consumers, its
  *Order Card* entry gains a card-back line, and ADR 0017 gets an addendum
  recording that the lookup seam generalised to a second Product.

The `build_deck` dedup key is deliberately unchanged (still the display name),
with a comment recording why: art is addressed by TOML key, and no race has two
Unit keys sharing a display name, so the collision cannot arise today.

## Verification

- `just check` green — 446 passed, pyright clean.
- Real deck rendered and eyeballed: backs show the name above, the art centred,
  and the kind below; the art-less *Heavy Carrier* backs read correctly.
  **No overfull-hbox warnings** on the card backs.
- New PDF-compile test covers a **mixed deck** (one Unit with art, one without)
  — the homogeneous case would not catch the empty-body error.

### Deck PDF size, `spf render cards demo --format pdf`

| | Size |
|---|---|
| before | 32 KB |
| after | 2.36 MB |

That is one distinct Unit with art. pdfTeX shares one image XObject per file,
so the cost is per *distinct Unit with art*, not per card — and it is the
concrete argument for #71 (downscaled variants). When #71 lands, only
`committed_image` changes: not `cards.py`, not the templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
