### PR TITLE
Rulebook, plan 1: index-driven general-rules product

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -188,8 +188,29 @@ A Rendering covering all Units, Models, and Equipment of one Race. Built from a
 Race's `RaceConfig` (unresolved, for now).
 
 **Rulebook**:
-A Rendering of the general, army-agnostic rules. Built from the `rules/*.toml`
-configs.
+A Rendering of the general, army-agnostic rules. Built from a **Rulebook
+Index** — an ordered, authored list of Sections — not from whatever happens to
+sit in `rules/` (ADR 0018). Its sources are the rules TOML files and free-text
+Markdown files beside them.
+
+**Rulebook Index**:
+The authored TOML file listing, in order, the Sections a Rulebook contains
+(`rules/rulebook.toml`). The editorial decision of what the rulebook *is*, kept
+beside the rules as game data rather than in developer config.
+_Avoid_: manifest, table of contents (the TOC is generated *from* the index)
+
+**Section**:
+One entry in a Rulebook Index: a source file, the Section Kind that reads it,
+and the title it appears under. The title comes from the Index, never from the
+source, and the source's own headings nest beneath it.
+_Avoid_: chapter, part
+
+**Section Kind**:
+The shape of a Section's source, declared by the Section and bound to one parser
+and one template partial per family (`markdown`, and in future `specials`,
+`tokens`, `hexes`). The extension point for a new rules file: adding one is a
+registration, never a change to the pipeline.
+_Avoid_: type, format (Format is the output syntax)
 
 ### Generated assets (AI-authored color & atmosphere)
 

--- a/v3/docs/adr/0005-rendering-pipeline.md
+++ b/v3/docs/adr/0005-rendering-pipeline.md
@@ -7,7 +7,9 @@ Formats (markdown, html, latex, pdf). The decisions:
 **Resolved data is the view-model.** Each Product is rendered from a
 source-of-truth object passed straight into the templates — the resolved `Army`
 for Order Cards and Army Reference, the `RaceConfig` for Race Overview, the
-`rules/*.toml` configs for the Rulebook. The *same* data goes to every Format's
+`rules/*.toml` configs for the Rulebook (**superseded for the Rulebook by
+ADR 0018**: it is built from an authored index naming its sections, not from
+the contents of `rules/`). The *same* data goes to every Format's
 templates; templates stay dumb (read attributes, iterate) and carry no lookup or
 computation logic.
 

--- a/v3/docs/adr/0005-rendering-pipeline.md
+++ b/v3/docs/adr/0005-rendering-pipeline.md
@@ -43,3 +43,30 @@ the prose layout, so one source cannot serve both well.
   deferred to the Markdown→HTML derivation, where `markdown-it-py` escapes text
   correctly. (Source data is designer-authored TOML, so injection risk is low
   regardless.)
+
+## Addendum: `md_to_latex` is not the rejected Pandoc approach
+
+The Rulebook (ADR 0018) introduced `spf.render.md_latex.md_to_latex`, a
+Markdown-to-LaTeX converter. Read against the rejection above — "we rejected a
+single-source/Pandoc approach (author Markdown, convert to LaTeX)" — that looks
+like a reversal. It is not, and the line between them is worth drawing
+explicitly.
+
+What was rejected was authoring **templates** in one family and deriving the
+other. That still holds: every template is authored per family, Markdown and
+LaTeX, and the card layout still differs from the prose layout because it
+genuinely should.
+
+The converter serves Markdown that arrives **inside the data**: the free-text
+Rulebook Sections, and the prose fields inside the rules TOML. That content has
+no per-family authored form and never will — a designer writes one paragraph of
+rules text, not a Markdown one and a LaTeX one. Something has to give it a
+LaTeX form, and doing it in a filter puts that rule in exactly one place, which
+is the same principle the rest of this ADR rests on.
+
+So: **templates are authored per family; Markdown embedded in data is
+converted.** The converter's reach is deliberately small — no tables, no
+images, no link targets, and raw LaTeX in a Markdown source is escaped rather
+than passed through. If it ever grows to where a Markdown source can express a
+whole authored layout, that is the boundary being crossed, and this decision
+should be revisited rather than stretched.

--- a/v3/docs/adr/0018-rulebook-driven-by-an-authored-index.md
+++ b/v3/docs/adr/0018-rulebook-driven-by-an-authored-index.md
@@ -1,0 +1,65 @@
+# The Rulebook is driven by an authored index, not by the contents of `rules/`
+
+ADR 0005 named the Rulebook as a Product "built from the `rules/*.toml`
+configs". Building it forced the question that phrasing hides: *which* files, in
+*what order*, and how does the pipeline know what shape each one has?
+
+"Every file in `rules/`" answers none of that. It has no order, it silently
+promotes a scratch file into a published chapter, and it cannot express the one
+thing a rulebook most needs — an editorial decision about what the rulebook
+*is*. It also does not survive contact with the data: `rules/` today holds four
+TOML files of which only three have a schema and a loader.
+
+## An ordered index that names a kind per section
+
+**Decision: the Rulebook is an authored index file, `rules/rulebook.toml`,
+listing in order the Sections it contains. Each Section names its source, the
+title it appears under, and a **Section Kind**.**
+
+A Kind is the shape of a Section's source. It binds to exactly two things: one
+parser, registered in `spf.render.rulebook`, and one template partial per
+family, found by name at `templates/<family>/general-rules/<kind>.<ext>.jinja`.
+Nothing about a partial is registered — the convention *is* the binding, which
+keeps `main.<ext>.jinja` dumb, per ADR 0005: it loops over Sections, emits the
+heading, and includes.
+
+The index lives in `rules/` and not in `configs/spf.toml` because it is game
+data — an editorial statement about the game — not developer configuration. It
+is TOML because every other authored data file is, so it loads through the
+existing configaroo + `StrictModel` path and needs no new dependency.
+
+The registry deliberately copies the Product and Format registries: a frozen
+record in a module-level dict, a `register_*`, and a `get_*` that fails with
+"Unknown kind 'x'; known kinds: …". Three registries with one shape is cheaper
+to learn than three with three.
+
+**A bad index fails the build**, naming the Section's 1-based position as a
+human would count it down the file. A Rulebook that silently drops a chapter is
+worse than one that refuses to build: the missing chapter is invisible in the
+output, and the reader it fails is a player at a table.
+
+## Alternatives rejected
+
+**Infer the Kind from the filename** (`special.toml` → the specials shape). It
+makes the filename load-bearing: renaming a data file would silently change how
+it renders, and two files could never share a shape — which is exactly what the
+`markdown` Kind exists to allow, since every future free-text section uses it.
+
+**Render any table generically, from column declarations in the index.** This
+throws away the Pydantic schemas that already describe these files precisely,
+and with them every per-shape nicety — a damage table and a token list are not
+the same document even though both are "essentially a table".
+
+## Consequences
+
+- Adding a rules file to the Rulebook is a **data edit** (a new `[[sections]]`
+  entry). Adding a *new shape* is that plus a Kind registration and two
+  partials. Neither touches `build_rulebook` or `main.<ext>.jinja`.
+- The rules format can keep moving without the pipeline moving with it, which
+  is the point while the rules are still in development.
+- `assaultretreat.toml` stays out of the Rulebook until it has a schema and a
+  loader. The index makes that omission explicit rather than accidental.
+- The index is validated in CI by `spf rules rulebook`, wired into
+  `just validate`: resolving the index *is* validating it.
+- Section titles come from the index, so a Markdown source's H1 is dropped and
+  its remaining headings nest beneath the index's title.

--- a/v3/justfile
+++ b/v3/justfile
@@ -49,6 +49,7 @@ validate:
     uv run spf rules hexes > /dev/null
     uv run spf rules specials > /dev/null
     uv run spf rules tokens > /dev/null
+    uv run spf rules rulebook > /dev/null
 
 # Lint race data for name and key consistency.
 lint-races:

--- a/v3/rules/round.md
+++ b/v3/rules/round.md
@@ -2,7 +2,7 @@
 
 A battle is fought over a sequence of **Rounds**. Every Round runs through the
 same fixed list of **Phases**, in the same order, for every Army on the table.
-Nobody takes "their turn" — both sides act inside each Phase, and the Phase
+Nobody takes “their turn” — both sides act inside each Phase, and the Phase
 order is what decides who shoots before who moves.
 
 Play Rounds until the scenario's end condition is met.

--- a/v3/rules/round.md
+++ b/v3/rules/round.md
@@ -1,0 +1,92 @@
+# The Round
+
+A battle is fought over a sequence of **Rounds**. Every Round runs through the
+same fixed list of **Phases**, in the same order, for every Army on the table.
+Nobody takes "their turn" — both sides act inside each Phase, and the Phase
+order is what decides who shoots before who moves.
+
+Play Rounds until the scenario's end condition is met.
+
+## Phases of a Round
+
+The Phases run in this order. A Phase in which nothing can happen is skipped
+silently; you never lose a later Phase by skipping an earlier one.
+
+- **Gunnery 1** — long-range fire, before anyone has repositioned. Apply damage.
+- **Trigger hex effects** — the terrain acts: burning hexes, gas, collapsing
+  ground.
+- **Movement 1** — every Unit executes its movement order for its current Speed.
+- **Pre-assault retreat** — a Unit about to be assaulted may pull back.
+- **Pre-assault abilities** — abilities that resolve before blows land.
+- **Assault 1** — melee in every contested hex. Apply damage.
+- **Post-assault retreat** — a surviving Unit may fall back out of contact.
+- **Trigger hex effects**
+- **Movement 2**
+- **Pre-assault retreat**, **Pre-assault abilities**
+- **Assault 2** — apply damage.
+- **Post-assault retreat**
+- **Trigger hex effects**
+- **Movement 3**
+- **Pre-assault retreat**, **Pre-assault abilities**
+- **Assault 3** — apply damage.
+- **Post-assault retreat**
+- **Gunnery 2** — close-range fire, after the lines have shifted. Apply damage.
+- **Healing and repair 1** — the first of the two windows for restoring Units.
+- **Agony 0** — major acid and terror. Apply damage.
+- **Agony 1** — minor acid. Apply damage.
+- **Agony 2** — fire. Apply damage.
+- **Agony 3** — poison. Apply damage.
+- **Agony 4** — bleeding. Apply damage.
+- **Healing and repair 2** — the second restoration window.
+- **Aftermath** — remove smoke, clear expired markers, reveal what the Round
+  uncovered.
+
+---
+
+## Everything in a Phase happens at once
+
+Within a single Phase, every effect resolves **simultaneously**. Two Units that
+shoot each other in Gunnery 1 both fire; a Unit destroyed there still gets its
+shot away. In practice this means you may roll all the damage for a Phase
+together, in whatever order is convenient, and only then remove casualties.
+
+The same holds for movement: Units do not move one after another, so a hex
+vacated during Movement 2 is not available to a Unit that wanted to enter it in
+that same Phase unless the movement rules say otherwise.
+
+### Ordering within a Phase
+
+When two effects in the same Phase genuinely cannot be simultaneous — one
+creates the condition the other consumes — resolve them in this order:
+
+1. Effects that remove a Unit from the table.
+2. Effects that change a Unit's Speed or position.
+3. Everything else.
+
+## The three Movement Phases
+
+Movement is split across three Phases rather than taken as one long move. A
+Unit's Speed decides what it may do in each: a **still** Unit holds position, a
+**slow** Unit takes the cautious order, and a **fast** Unit commits to the full
+distance and gives up its options for the rest of the Round.
+
+Because Gunnery 1 lands before any Movement Phase and Gunnery 2 after all three,
+a Unit that sprints across open ground is exposed to fire on both sides of the
+run.
+
+### Changing Speed mid-Round
+
+A Unit that brakes or accelerates between Movement Phases uses the order for the
+Speed it holds **at that Phase**, read from the same Order Card it started the
+Round with. Where the card lists nothing for the new Speed, the Unit does
+nothing that Phase.
+
+## Ending the battle
+
+The scenario names the end condition — most often a fixed span of time. Finish
+the Round in progress, then resolve one final **end sequence**: repeat Agony 0
+through Agony 4 for every Unit until each Unit either has no continuing damage
+left or is destroyed. Units with healing or repair abilities may apply them
+between those Agony Phases, exactly as they would in a normal Round.
+
+Only then count up the Victory Conditions.

--- a/v3/rules/rulebook.toml
+++ b/v3/rules/rulebook.toml
@@ -1,0 +1,10 @@
+# The Rulebook Index: what the Rulebook contains, in the order it contains it
+# (ADR 0018). Each section names a Section Kind, which decides how its source
+# is read and which template partial renders it.
+
+title = "SteamPunkFantasy Rulebook"
+
+[[sections]]
+kind = "markdown"
+source = "round.md"
+title = "The Round"

--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -12,14 +12,21 @@ from typing import Annotated
 import cyclopts
 
 from spf.armies import io
+from spf.config import config
 from spf.console import stderr, stdout
 from spf.render import Product, render
 from spf.render.army_rules import build_reference, committed_image, no_image
 from spf.render.cards import build_deck
 from spf.render.formats import FORMATS, get_format
 from spf.render.products import register_product
+from spf.render.rulebook import build_rulebook
+from spf.rules import RULEBOOK_INDEX, get_rulebook
 
 DEFAULT_FORMAT = "pdf"
+
+# The Rulebook always renders to one file under this stem: unlike the Army
+# products it has no per-army name to derive one from.
+RULEBOOK_STEM = "rulebook"
 
 # The Order Card Product: templates live at `<family>/cards/main.<ext>.jinja`.
 CARDS = register_product(Product(name="cards"))
@@ -27,6 +34,10 @@ CARDS = register_product(Product(name="cards"))
 # The Army Reference Product: templates live at
 # `<family>/army-rules/main.<ext>.jinja`.
 ARMY_RULES = register_product(Product(name="army-rules"))
+
+# The Rulebook Product: templates live at
+# `<family>/general-rules/main.<ext>.jinja`, plus one partial per Section Kind.
+GENERAL_RULES = register_product(Product(name="general-rules"))
 
 
 def _validate_format(_type: type, value: str) -> None:
@@ -112,7 +123,33 @@ def render_army_rules(
     stdout.print(f"Wrote {out}")
 
 
+def render_general_rules(
+    *,
+    index: Annotated[
+        Path | None,
+        cyclopts.Parameter(help="Alternate Rulebook Index; sources resolve beside it."),
+    ] = None,
+    opts: Annotated[RenderOpts | None, cyclopts.Parameter(name="*")] = None,
+) -> None:
+    """Render the general, army-agnostic rules to a rulebook."""
+    opts = opts or RenderOpts()
+    index_path = index if index is not None else config.paths.rules / RULEBOOK_INDEX
+    try:
+        # Sources resolve beside the Index rather than in `rules/` always, so an
+        # alternate Index is self-contained — and for the committed one the two
+        # are the same directory.
+        rulebook = build_rulebook(get_rulebook(index_path), rules_dir=index_path.parent)
+    except (FileNotFoundError, ValueError) as err:
+        stderr.print(f"[red]Error:[/] {err}")
+        raise SystemExit(1) from None
+
+    fmt = get_format(opts.format)
+    out = render(GENERAL_RULES, rulebook, fmt=fmt, name=RULEBOOK_STEM, out=opts.out)
+    stdout.print(f"Wrote {out}")
+
+
 def add_commands(app: cyclopts.App) -> None:
     """Add render commands to the CLI."""
     app.command(render_cards, name="cards")
     app.command(render_army_rules, name="army-rules")
+    app.command(render_general_rules, name="general-rules")

--- a/v3/src/spf/frontends/cli/render.py
+++ b/v3/src/spf/frontends/cli/render.py
@@ -12,7 +12,6 @@ from typing import Annotated
 import cyclopts
 
 from spf.armies import io
-from spf.config import config
 from spf.console import stderr, stdout
 from spf.render import Product, render
 from spf.render.army_rules import build_reference, committed_image, no_image
@@ -20,7 +19,7 @@ from spf.render.cards import build_deck
 from spf.render.formats import FORMATS, get_format
 from spf.render.products import register_product
 from spf.render.rulebook import build_rulebook
-from spf.rules import RULEBOOK_INDEX, get_rulebook
+from spf.rules import get_rulebook, rulebook_index_path
 
 DEFAULT_FORMAT = "pdf"
 
@@ -133,7 +132,7 @@ def render_general_rules(
 ) -> None:
     """Render the general, army-agnostic rules to a rulebook."""
     opts = opts or RenderOpts()
-    index_path = index if index is not None else config.paths.rules / RULEBOOK_INDEX
+    index_path = rulebook_index_path(index)
     try:
         # Sources resolve beside the Index rather than in `rules/` always, so an
         # alternate Index is self-contained — and for the committed one the two

--- a/v3/src/spf/frontends/cli/rules.py
+++ b/v3/src/spf/frontends/cli/rules.py
@@ -3,7 +3,9 @@
 import cyclopts
 
 from spf import rules
-from spf.console import stdout
+from spf.config import config
+from spf.console import stderr, stdout
+from spf.render.rulebook import build_rulebook
 
 
 def add_commands(app: cyclopts.App) -> None:
@@ -11,6 +13,7 @@ def add_commands(app: cyclopts.App) -> None:
     app.command(list_special_rules, name="specials")
     app.command(list_token_rules, name="tokens")
     app.command(list_hex_rules, name="hexes")
+    app.command(list_rulebook, name="rulebook")
 
 
 def list_special_rules() -> None:
@@ -26,3 +29,23 @@ def list_token_rules() -> None:
 def list_hex_rules() -> None:
     """Validate and list hex rules."""
     stdout.print(rules.get_hexes())
+
+
+def list_rulebook() -> None:
+    """Validate the Rulebook Index and list its sections.
+
+    Resolving the Index is what validates it: every Kind is looked up and every
+    source located. That is why this sits in `just validate` — a broken Index
+    should fail `just check`, not the next person's `spf render general-rules`.
+    """
+    try:
+        rulebook = build_rulebook(rules.get_rulebook(), rules_dir=config.paths.rules)
+    except (FileNotFoundError, ValueError) as err:
+        stderr.print(f"[red]Error:[/] {err}")
+        raise SystemExit(1) from None
+
+    stdout.print(rulebook.title)
+    for position, section in enumerate(rulebook.sections, start=1):
+        # Parentheses, not brackets: Rich would read `[markdown]` as a style tag
+        # and swallow it.
+        stdout.print(f"{position}. {section.title} ({section.kind})")

--- a/v3/src/spf/render/environments.py
+++ b/v3/src/spf/render/environments.py
@@ -14,28 +14,8 @@ from jinja2 import Environment, FileSystemLoader
 
 from spf.config import config
 from spf.render.formats import Family
-
-# Characters that must be escaped to survive a pdflatex run. Order cells carry
-# `°` (rendered via `textcomp`'s `\textdegree`) alongside the usual TeX
-# specials; `+`, `[` and `]` are safe in text mode and pass through.
-_LATEX_SPECIAL = {
-    "\\": r"\textbackslash{}",
-    "&": r"\&",
-    "%": r"\%",
-    "$": r"\$",
-    "#": r"\#",
-    "_": r"\_",
-    "{": r"\{",
-    "}": r"\}",
-    "~": r"\textasciitilde{}",
-    "^": r"\textasciicircum{}",
-    "°": r"\textdegree{}",
-}
-
-
-def latex_escape(value: object) -> str:
-    """Escape LaTeX-special characters in `value` for safe text-mode output."""
-    return "".join(_LATEX_SPECIAL.get(char, char) for char in str(value))
+from spf.render.latex_text import latex_escape
+from spf.render.md_latex import md_to_latex, shift_headings
 
 
 def posix_path(value: PurePath | str) -> str:
@@ -85,10 +65,17 @@ def make_environments(templates_root: Path | None = None) -> dict[Family, Enviro
     )
     latex.filters["latex_escape"] = latex_escape
     latex.filters["posix_path"] = posix_path
+    # Markdown that arrives inside the *data* — free-text Rulebook Sections and
+    # prose fields in the rules TOML — has no authored per-family form, so each
+    # family converts it on the way out (ADR 0005 addendum).
+    latex.filters["md_to_latex"] = md_to_latex
     markdown = Environment(
         loader=FileSystemLoader(root / "markdown"),
         autoescape=False,  # noqa: S701  templates emit Markdown/LaTeX, not HTML (ADR 0005)
         keep_trailing_newline=True,
     )
     markdown.filters["relative_to"] = relative_to
+    # The Markdown family needs no conversion — its data is already Markdown —
+    # only the source's headings pushed below the one it renders under.
+    markdown.filters["shift_headings"] = shift_headings
     return {"markdown": markdown, "latex": latex}

--- a/v3/src/spf/render/latex_text.py
+++ b/v3/src/spf/render/latex_text.py
@@ -1,0 +1,29 @@
+r"""Escaping text for LaTeX's text mode.
+
+Its own module because both consumers need it and they sit on opposite sides of
+an import edge: `spf.render.environments` registers it as the `latex_escape`
+filter, and `spf.render.md_latex` — which `environments` imports, to register
+`md_to_latex` — escapes every text token it emits.
+"""
+
+# Characters that must be escaped to survive a pdflatex run. Order cells carry
+# `°` (rendered via `textcomp`'s `\textdegree`) alongside the usual TeX
+# specials; `+`, `[` and `]` are safe in text mode and pass through.
+_LATEX_SPECIAL = {
+    "\\": r"\textbackslash{}",
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\textasciicircum{}",
+    "°": r"\textdegree{}",
+}
+
+
+def latex_escape(value: object) -> str:
+    """Escape LaTeX-special characters in `value` for safe text-mode output."""
+    return "".join(_LATEX_SPECIAL.get(char, char) for char in str(value))

--- a/v3/src/spf/render/md_latex.py
+++ b/v3/src/spf/render/md_latex.py
@@ -20,7 +20,11 @@ raising.
 
 **Known limitations**, all deliberate for this first cut:
 
-- Tables and images are dropped rather than converted.
+- Tables are not converted. The parser runs stock `commonmark`, which has no
+  table rule at all (unlike `md_to_html`, which enables one), so a pipe table
+  arrives as ordinary paragraph text and prints with its pipes and dashes
+  intact.
+- Images are dropped entirely.
 - A link renders its text; the URL is discarded, so no `hyperref` dependency.
 - Block quotes lose their quoting and flow as ordinary paragraphs.
 - **Raw LaTeX in a Markdown source is escaped, not passed through** —
@@ -130,10 +134,12 @@ class _Converter:
                 self._start_block()
             case "bullet_list_open" | "ordered_list_open":
                 self._start_block("\n")
-                self.out.append(rf"\begin{{{_LISTS[token.type[:-5]]}}}")
+                self.out.append(
+                    rf"\begin{{{_LISTS[token.type.removesuffix('_open')]}}}"
+                )
             case "bullet_list_close" | "ordered_list_close":
                 self._start_block("\n")
-                self.out.append(rf"\end{{{_LISTS[token.type[:-6]]}}}")
+                self.out.append(rf"\end{{{_LISTS[token.type.removesuffix('_close')]}}}")
             case "list_item_open":
                 self._start_block("\n")
                 self.out.append(r"\item ")

--- a/v3/src/spf/render/md_latex.py
+++ b/v3/src/spf/render/md_latex.py
@@ -1,0 +1,178 @@
+r"""Convert Markdown that arrives inside the data into LaTeX.
+
+The Rulebook's free-text Sections and the prose fields inside the rules TOML are
+authored as Markdown. They have no per-family authored form — and never will,
+which is what keeps this from being the single-source/Pandoc approach ADR 0005
+rejected (see that ADR's addendum). Templates stay authored per family; only the
+Markdown that arrives *inside the data* is converted here.
+
+Both functions are registered as Jinja filters in `spf.render.environments`:
+`md_to_latex` on the LaTeX environment, `shift_headings` on the Markdown one.
+A Markdown template needs no conversion — its data is already Markdown — but it
+does need the source's headings pushed below the heading the section renders
+under.
+
+Headings map one level down from where the source wrote them, because the
+section's own title is already a `\section`: H2 becomes `\subsection`, H3
+`\subsubsection`, H4 `\paragraph`. An H1 should never arrive (the `markdown`
+Section Kind's parser drops them) and degrades to `\subsection` rather than
+raising.
+
+**Known limitations**, all deliberate for this first cut:
+
+- Tables and images are dropped rather than converted.
+- A link renders its text; the URL is discarded, so no `hyperref` dependency.
+- Block quotes lose their quoting and flow as ordinary paragraphs.
+- **Raw LaTeX in a Markdown source is escaped, not passed through** —
+  markdown-it reads `\pagebreak` as text and `latex_escape` turns the backslash
+  into `\textbackslash{}`. Do not put raw LaTeX in a rules Markdown file. A
+  passthrough escape hatch is future work.
+
+Anything else unsupported degrades to escaped text; nothing here raises.
+"""
+
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+
+from spf.render.latex_text import latex_escape
+
+# Heading level -> LaTeX sectioning command, one step below the `\section` the
+# Rulebook template emits for the Section's own title.
+_HEADINGS = {
+    1: r"\subsection",
+    2: r"\subsection",
+    3: r"\subsubsection",
+    4: r"\paragraph",
+    5: r"\subparagraph",
+    6: r"\subparagraph",
+}
+
+_LISTS = {"bullet_list": "itemize", "ordered_list": "enumerate"}
+
+# Inline tokens that wrap their children in a single LaTeX command.
+_WRAPPERS = {"strong": r"\textbf", "em": r"\textit"}
+
+_ATX_HEADING = re.compile(r"^(#{1,6})(\s|$)")
+_FENCE = re.compile(r"^\s*(```|~~~)")
+
+_MAX_HEADING = 6
+
+
+def md_to_latex(text: str) -> str:
+    """Convert Markdown `text` to LaTeX body content."""
+    tokens = MarkdownIt("commonmark").parse(text)
+    return _Converter().convert(tokens)
+
+
+def shift_headings(text: str, by: int) -> str:
+    """Deepen every ATX heading in Markdown `text` by `by` levels.
+
+    Line-based on purpose: the result has to stay Markdown, so re-rendering the
+    document through markdown-it would be a lossy round trip. Lines inside a
+    fenced code block are left alone, and a heading is never pushed past H6.
+    """
+    if by == 0:
+        return text
+
+    lines = text.split("\n")
+    in_fence = False
+    shifted: list[str] = []
+    for line in lines:
+        if _FENCE.match(line):
+            in_fence = not in_fence
+        match = None if in_fence else _ATX_HEADING.match(line)
+        if match is None:
+            shifted.append(line)
+        else:
+            level = min(len(match.group(1)) + by, _MAX_HEADING)
+            shifted.append("#" * level + line[match.end(1) :])
+    return "\n".join(shifted)
+
+
+class _Converter:
+    r"""A single Markdown-token walk. One instance per conversion.
+
+    The state is what makes list items work: `_fresh_item` records that an
+    `\\item` has just been emitted, so the block that follows joins it on the
+    same line instead of opening with the usual blank-line separation. Without
+    it a *loose* list — whose items wrap their content in real, non-hidden
+    paragraph tokens — would leave every `\\item` dangling alone on its line.
+    """
+
+    def __init__(self) -> None:
+        self.out: list[str] = []
+        self._fresh_item = False
+
+    def convert(self, tokens: list[Token]) -> str:
+        for token in tokens:
+            self._block(token)
+        body = "".join(self.out)
+        return f"{body}\n" if body else ""
+
+    def _start_block(self, separator: str = "\n\n") -> None:
+        """Separate the block about to be emitted from the one before it."""
+        if self._fresh_item:
+            self._fresh_item = False
+        elif self.out:
+            self.out.append(separator)
+
+    def _block(self, token: Token) -> None:  # noqa: C901  one branch per token type; a dispatch table would only move the cases
+        match token.type:
+            case "heading_open":
+                self._start_block()
+                level = int(token.tag.removeprefix("h"))
+                self.out.append(f"{_HEADINGS[level]}{{")
+            case "heading_close":
+                self.out.append("}")
+            case "paragraph_open":
+                self._start_block()
+            case "bullet_list_open" | "ordered_list_open":
+                self._start_block("\n")
+                self.out.append(rf"\begin{{{_LISTS[token.type[:-5]]}}}")
+            case "bullet_list_close" | "ordered_list_close":
+                self._start_block("\n")
+                self.out.append(rf"\end{{{_LISTS[token.type[:-6]]}}}")
+            case "list_item_open":
+                self._start_block("\n")
+                self.out.append(r"\item ")
+                self._fresh_item = True
+            case "hr":
+                self._start_block()
+                self.out.append(r"\hrulefill")
+            case "fence" | "code_block":
+                self._start_block()
+                content = token.content
+                if not content.endswith("\n"):
+                    content += "\n"
+                self.out.append(
+                    f"\\begin{{verbatim}}\n{content}\\end{{verbatim}}",
+                )
+            case "inline":
+                for child in token.children or []:
+                    self._inline(child)
+            case _:
+                # Block quotes, tables, raw HTML, and anything else markdown-it
+                # grows later: their inline children still flow through, so the
+                # text survives even when the construct does not.
+                pass
+
+    def _inline(self, token: Token) -> None:
+        match token.type:
+            case "text":
+                self.out.append(latex_escape(token.content))
+            case "code_inline":
+                self.out.append(rf"\texttt{{{latex_escape(token.content)}}}")
+            case "strong_open" | "em_open":
+                self.out.append(f"{_WRAPPERS[token.type.removesuffix('_open')]}{{")
+            case "strong_close" | "em_close":
+                self.out.append("}")
+            case "softbreak":
+                self.out.append("\n")
+            case "hardbreak":
+                self.out.append("\\\\\n")
+            case _:
+                # Links keep their text and lose their URL; images and raw
+                # inline HTML vanish entirely. See the module docstring.
+                pass

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -1,0 +1,150 @@
+"""Rulebook view-model: turn an authored Index into the object templates read.
+
+The Rulebook is not "every file in `rules/`" — it is an ordered, authored Index
+naming a **Section Kind** per Section (ADR 0018). A Kind binds a source shape to
+one parser here and one template partial per family
+(`templates/<family>/general-rules/<kind>.<ext>.jinja`, picked by name, nothing
+to register).
+
+The registry deliberately mirrors `spf.render.products` and
+`spf.render.formats`: same record-plus-dict shape, same "Unknown x; known xs"
+failure. Adding a Kind is a registration, never a change to `build_rulebook` or
+to `main.<ext>.jinja`.
+
+A bad Index **fails the build**. A Rulebook silently missing a chapter is worse
+than one that refuses to build, so every failure names the Section's 1-based
+position — what a human counts down the Index file.
+"""
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from spf.schemas.rulebook import RulebookConfig
+
+_H1 = re.compile(r"^#\s")
+_NON_SLUG = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class SectionKind:
+    """A registered kind of Rulebook Section: how its source is read."""
+
+    name: str
+    parse: Callable[[Path], object]
+    """Source path -> the Section's body, in whatever shape the Kind's partials
+    expect. Plan 2 widens this to also take a shared rules context, so that a
+    Kind can resolve cross-references; keeping the type here makes that a
+    one-line change."""
+
+
+KINDS: dict[str, SectionKind] = {}
+
+
+def register_kind(kind: SectionKind) -> SectionKind:
+    """Register a Section Kind under its name and return it."""
+    KINDS[kind.name] = kind
+    return kind
+
+
+def get_kind(name: str) -> SectionKind:
+    """Look up a registered Section Kind by name."""
+    try:
+        return KINDS[name]
+    except KeyError:
+        known = ", ".join(KINDS) or "(none registered)"
+        msg = f"Unknown kind {name!r}; known kinds: {known}"
+        raise ValueError(msg) from None
+
+
+def parse_markdown(path: Path) -> str:
+    """Read a free-text Markdown Section, dropping its H1 lines.
+
+    A Section's heading always comes from the Index's `title`, so an H1 in the
+    source would duplicate it one level too high. Dropping happens here because
+    it is family-independent; mapping the *remaining* levels is each family's
+    business (`shift_headings` and `md_to_latex`).
+    """
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    return "".join(line for line in lines if not _H1.match(line))
+
+
+MARKDOWN = register_kind(SectionKind(name="markdown", parse=parse_markdown))
+
+
+@dataclass(frozen=True)
+class Section:
+    """One resolved Section: its rendered heading and its parsed body."""
+
+    kind: str
+    """Names the partial that renders it: `general-rules/<kind>.<ext>.jinja`."""
+
+    title: str
+    anchor: str
+    """Slug of the title, unique within the Rulebook, for the Markdown TOC."""
+
+    body: object
+    """Whatever the Kind's parser returned."""
+
+
+@dataclass(frozen=True)
+class Rulebook:
+    """A whole Rulebook: a document title and its ordered Sections."""
+
+    title: str
+    sections: list[Section]
+
+
+def _slug(title: str) -> str:
+    """Reduce `title` to a lowercase, dash-separated anchor."""
+    return _NON_SLUG.sub("-", title.lower()).strip("-")
+
+
+def _anchor(title: str, taken: set[str]) -> str:
+    """Return a slug of `title` not already in `taken`.
+
+    Two Sections may legitimately share a title, but not an anchor: every link
+    to the second would otherwise land on the first.
+    """
+    slug = _slug(title)
+    anchor = slug
+    suffix = 1
+    while anchor in taken:
+        suffix += 1
+        anchor = f"{slug}-{suffix}"
+    taken.add(anchor)
+    return anchor
+
+
+def build_rulebook(index: RulebookConfig, *, rules_dir: Path) -> Rulebook:
+    """Resolve an Index into the Rulebook object the templates render.
+
+    Each Section's `kind` is looked up, its `source` located under `rules_dir`,
+    and the Kind's parser run over it. An unknown Kind raises `ValueError` and a
+    missing source `FileNotFoundError` — both naming the Section's position.
+    """
+    sections: list[Section] = []
+    taken: set[str] = set()
+    for position, config in enumerate(index.sections, start=1):
+        where = f"Rulebook Index section {position}"
+        try:
+            kind = get_kind(config.kind)
+        except ValueError as err:
+            msg = f"{where}: {err}"
+            raise ValueError(msg) from None
+
+        source = rules_dir / config.source
+        if not source.is_file():
+            msg = f"{where}: source {config.source!r} not found in {rules_dir}"
+            raise FileNotFoundError(msg)
+
+        sections.append(
+            Section(
+                kind=kind.name,
+                title=config.title,
+                anchor=_anchor(config.title, taken),
+                body=kind.parse(source),
+            )
+        )
+    return Rulebook(title=index.title, sections=sections)

--- a/v3/src/spf/rules.py
+++ b/v3/src/spf/rules.py
@@ -1,9 +1,14 @@
 """Data access functions for SteamPunkFantasy rules."""
 
+from pathlib import Path
+
 from configaroo import Configuration
 
 from spf.config import config
 from spf.schemas import rules as r
+from spf.schemas.rulebook import RulebookConfig
+
+RULEBOOK_INDEX = "rulebook.toml"
 
 
 def _get_rules(file_name: str) -> Configuration:
@@ -25,3 +30,19 @@ def get_tokens() -> r.TokenRulesConfig:
 def get_hexes() -> r.HexRulesConfig:
     """Get rules for hexes."""
     return _get_rules("hexes.toml").convert_model(r.HexRulesConfig)
+
+
+def get_rulebook(path: Path | None = None) -> RulebookConfig:
+    """Read the Rulebook Index, by default the committed `rules/rulebook.toml`.
+
+    Takes a path rather than a file name (unlike the rules loaders above) so
+    `spf render general-rules --index` can point at an alternate index
+    anywhere on disk.
+    """
+    path = path if path is not None else config.paths.rules / RULEBOOK_INDEX
+    return (
+        Configuration.from_file(path)
+        .add_envs({}, prefix="SPF_")
+        .parse_dynamic()
+        .convert_model(RulebookConfig)
+    )

--- a/v3/src/spf/rules.py
+++ b/v3/src/spf/rules.py
@@ -11,10 +11,14 @@ from spf.schemas.rulebook import RulebookConfig
 RULEBOOK_INDEX = "rulebook.toml"
 
 
-def _get_rules(file_name: str) -> Configuration:
+def _read(path: Path) -> Configuration:
     """Read one rules file."""
-    path = config.paths.rules / file_name
     return Configuration.from_file(path).add_envs({}, prefix="SPF_").parse_dynamic()
+
+
+def _get_rules(file_name: str) -> Configuration:
+    """Read one rules file from the configured rules directory."""
+    return _read(config.paths.rules / file_name)
 
 
 def get_specials() -> r.SpecialRulesConfig:
@@ -32,17 +36,20 @@ def get_hexes() -> r.HexRulesConfig:
     return _get_rules("hexes.toml").convert_model(r.HexRulesConfig)
 
 
+def rulebook_index_path(path: Path | None = None) -> Path:
+    """Resolve `path` against the committed Index, the default when it is None.
+
+    The one place that default lives: callers need the path itself, not just
+    what it loads, because a Section's sources resolve beside its Index.
+    """
+    return path if path is not None else config.paths.rules / RULEBOOK_INDEX
+
+
 def get_rulebook(path: Path | None = None) -> RulebookConfig:
     """Read the Rulebook Index, by default the committed `rules/rulebook.toml`.
 
     Takes a path rather than a file name (unlike the rules loaders above) so
-    `spf render general-rules --index` can point at an alternate index
+    `spf render general-rules --index` can point at an alternate Index
     anywhere on disk.
     """
-    path = path if path is not None else config.paths.rules / RULEBOOK_INDEX
-    return (
-        Configuration.from_file(path)
-        .add_envs({}, prefix="SPF_")
-        .parse_dynamic()
-        .convert_model(RulebookConfig)
-    )
+    return _read(rulebook_index_path(path)).convert_model(RulebookConfig)

--- a/v3/src/spf/schemas/rulebook.py
+++ b/v3/src/spf/schemas/rulebook.py
@@ -1,0 +1,27 @@
+"""Schema for the Rulebook Index (ADR 0018).
+
+The Index is the authored TOML that says what the Rulebook contains, and in
+what order.
+
+`kind` stays a plain `str` here rather than an enum: it is checked against the
+Section Kind registry when the Rulebook is built, so the failure can name the
+registered kinds in the house style (`get_format`/`get_product`) instead of
+surfacing a Pydantic enum error.
+"""
+
+from spf.schemas import StrictModel
+
+
+class SectionConfig(StrictModel):
+    """One entry in a Rulebook Index."""
+
+    kind: str
+    source: str
+    title: str
+
+
+class RulebookConfig(StrictModel):
+    """A Rulebook Index: a document title and its ordered Sections."""
+
+    title: str
+    sections: list[SectionConfig]

--- a/v3/templates/latex/general-rules/main.tex.jinja
+++ b/v3/templates/latex/general-rules/main.tex.jinja
@@ -1,0 +1,25 @@
+% The Rulebook, LaTeX family. Stays dumb (ADR 0005): title block, table of
+% contents, then one `\section` per Section, deferring each Section's shape to
+% the partial named by its Kind.
+%
+% `fontenc` with T1 is not optional here: rules prose carries em dashes and
+% other non-ASCII punctuation, which the default font encoding cannot set.
+\documentclass[a4paper,12pt]{article}
+\usepackage[margin=2cm]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage{textcomp}
+
+\title{\VAR{source.title | latex_escape}}
+\date{}
+
+\begin{document}
+\maketitle
+\tableofcontents
+\newpage
+
+\BLOCK{for section in source.sections}
+\section{\VAR{section.title | latex_escape}}
+\BLOCK{include "general-rules/" ~ section.kind ~ ".tex.jinja"}
+\newpage
+\BLOCK{endfor}
+\end{document}

--- a/v3/templates/latex/general-rules/markdown.tex.jinja
+++ b/v3/templates/latex/general-rules/markdown.tex.jinja
@@ -1,0 +1,3 @@
+% A free-text Section. Its data is Markdown with no authored LaTeX form, so the
+% converter supplies one (ADR 0005 addendum).
+\VAR{section.body | md_to_latex}

--- a/v3/templates/markdown/general-rules/main.md.jinja
+++ b/v3/templates/markdown/general-rules/main.md.jinja
@@ -1,0 +1,24 @@
+{#
+  The Rulebook, Markdown family. Stays dumb (ADR 0005): it lays out the title,
+  the contents list, and one heading per Section, then defers the Section's own
+  shape to the partial named by its Kind.
+
+  The explicit `<a id>` is required, not decorative: `md_to_html` does not
+  generate heading ids, so without it every contents link breaks in the derived
+  HTML. Raw HTML passes through CommonMark untouched and is harmless in a plain
+  `.md`.
+#}
+# {{ source.title }}
+
+## Contents
+
+{% for section in source.sections -%}
+- [{{ section.title }}](#{{ section.anchor }})
+{% endfor %}
+{% for section in source.sections %}
+<a id="{{ section.anchor }}"></a>
+
+## {{ section.title }}
+
+{% include "general-rules/" ~ section.kind ~ ".md.jinja" %}
+{% endfor %}

--- a/v3/templates/markdown/general-rules/markdown.md.jinja
+++ b/v3/templates/markdown/general-rules/markdown.md.jinja
@@ -1,0 +1,3 @@
+{# A free-text Section. Its data is already Markdown; it only needs its own
+   headings pushed one level below the `##` its title renders as. #}
+{{ section.body | shift_headings(1) }}

--- a/v3/templates/markdown/general-rules/markdown.md.jinja
+++ b/v3/templates/markdown/general-rules/markdown.md.jinja
@@ -1,3 +1,3 @@
 {# A free-text Section. Its data is already Markdown; it only needs its own
-   headings pushed one level below the `##` its title renders as. #}
+   headings pushed one level below the `##` its title renders as. -#}
 {{ section.body | shift_headings(1) }}

--- a/v3/tests/render/test_md_latex.py
+++ b/v3/tests/render/test_md_latex.py
@@ -40,6 +40,12 @@ def test_text_is_latex_escaped() -> None:
     assert r"50\% of A \& B uses snake\_case \#1" in latex
 
 
+def test_variable_placeholder_renders_literally() -> None:
+    # The rules prose carries `{N}`-style placeholders. Escaping the braces is
+    # what makes them *print* as `{N}` instead of vanishing into a TeX group.
+    assert r"roll \{N\} or better" in md_to_latex("roll {N} or better\n")
+
+
 def test_strong_becomes_textbf() -> None:
     assert r"\textbf{Gunnery}" in md_to_latex("A **Gunnery** phase\n")
 

--- a/v3/tests/render/test_md_latex.py
+++ b/v3/tests/render/test_md_latex.py
@@ -1,0 +1,159 @@
+"""Tests for the Markdown-to-LaTeX converter and the heading-shift filter."""
+
+from spf.render.md_latex import md_to_latex, shift_headings
+
+# --- Headings ---------------------------------------------------------------
+
+
+def test_h2_becomes_a_subsection() -> None:
+    assert r"\subsection{Phases}" in md_to_latex("## Phases\n")
+
+
+def test_h3_becomes_a_subsubsection() -> None:
+    assert r"\subsubsection{Speed}" in md_to_latex("### Speed\n")
+
+
+def test_h4_becomes_a_paragraph() -> None:
+    assert r"\paragraph{Detail}" in md_to_latex("#### Detail\n")
+
+
+def test_h1_degrades_to_a_subsection() -> None:
+    # The `markdown` kind's parser drops H1s, so one should never arrive here;
+    # map it defensively rather than raising.
+    assert r"\subsection{Stray}" in md_to_latex("# Stray\n")
+
+
+def test_heading_text_is_escaped() -> None:
+    assert r"\subsection{Fire \& Movement}" in md_to_latex("## Fire & Movement\n")
+
+
+# --- Paragraphs and inline markup -------------------------------------------
+
+
+def test_paragraphs_are_separated_by_a_blank_line() -> None:
+    latex = md_to_latex("First.\n\nSecond.\n")
+    assert "First.\n\nSecond." in latex
+
+
+def test_text_is_latex_escaped() -> None:
+    latex = md_to_latex("50% of A & B uses snake_case #1\n")
+    assert r"50\% of A \& B uses snake\_case \#1" in latex
+
+
+def test_strong_becomes_textbf() -> None:
+    assert r"\textbf{Gunnery}" in md_to_latex("A **Gunnery** phase\n")
+
+
+def test_emphasis_becomes_textit() -> None:
+    assert r"\textit{simultaneously}" in md_to_latex("resolve *simultaneously*\n")
+
+
+def test_inline_code_becomes_escaped_texttt() -> None:
+    assert r"\texttt{a\_b}" in md_to_latex("use `a_b` here\n")
+
+
+def test_hardbreak_becomes_a_latex_line_break() -> None:
+    # A trailing backslash in Markdown produces a `hardbreak` token.
+    latex = md_to_latex("Gunnery 1 \\\nApply damage\n")
+    assert "Gunnery 1 \\\\\nApply damage" in latex
+
+
+def test_softbreak_becomes_a_newline() -> None:
+    latex = md_to_latex("one\ntwo\n")
+    assert "one\ntwo" in latex
+
+
+def test_link_keeps_its_text_and_drops_the_url() -> None:
+    latex = md_to_latex("see [the rules](https://example.com/rules)\n")
+    assert "see the rules" in latex
+    assert "example.com" not in latex
+
+
+# --- Lists ------------------------------------------------------------------
+
+
+def test_bullet_list_becomes_itemize() -> None:
+    latex = md_to_latex("- one\n- two\n")
+    assert r"\begin{itemize}" in latex
+    assert r"\item one" in latex
+    assert r"\item two" in latex
+    assert r"\end{itemize}" in latex
+
+
+def test_ordered_list_becomes_enumerate() -> None:
+    latex = md_to_latex("1. first\n2. second\n")
+    assert r"\begin{enumerate}" in latex
+    assert r"\item first" in latex
+    assert r"\end{enumerate}" in latex
+
+
+def test_loose_list_item_keeps_its_text_on_the_item_line() -> None:
+    # A loose list wraps each item's content in a paragraph; emitting the usual
+    # blank line before it would leave `\item` dangling on its own.
+    latex = md_to_latex("- one\n\n- two\n")
+    assert r"\item one" in latex
+    assert r"\item two" in latex
+    assert "\\item\n\n" not in latex
+
+
+def test_multi_paragraph_list_item_separates_its_later_paragraphs() -> None:
+    latex = md_to_latex("- one\n\n  more\n\n- two\n")
+    assert r"\item one" in latex
+    assert "one\n\nmore" in latex
+
+
+def test_bullet_list_nested_in_an_ordered_list() -> None:
+    latex = md_to_latex("1. outer\n    - inner\n")
+    assert latex.index(r"\begin{enumerate}") < latex.index(r"\begin{itemize}")
+    assert latex.index(r"\end{itemize}") < latex.index(r"\end{enumerate}")
+    assert r"\item inner" in latex
+
+
+# --- Blocks -----------------------------------------------------------------
+
+
+def test_thematic_break_becomes_an_hrule() -> None:
+    assert r"\hrulefill" in md_to_latex("one\n\n---\n\ntwo\n")
+
+
+def test_fenced_code_is_verbatim_and_unescaped() -> None:
+    latex = md_to_latex("```\na_b & c\n```\n")
+    assert r"\begin{verbatim}" in latex
+    assert "a_b & c" in latex
+    assert r"\end{verbatim}" in latex
+    assert r"\_" not in latex
+
+
+def test_indented_code_block_is_verbatim() -> None:
+    latex = md_to_latex("    a_b & c\n")
+    assert r"\begin{verbatim}" in latex
+    assert "a_b & c" in latex
+
+
+def test_blockquote_content_survives_as_text() -> None:
+    # Unsupported constructs degrade to their escaped content, never raise.
+    assert "quoted" in md_to_latex("> quoted\n")
+
+
+def test_empty_source_converts_to_empty_text() -> None:
+    assert md_to_latex("") == ""
+
+
+# --- shift_headings ---------------------------------------------------------
+
+
+def test_shift_headings_deepens_atx_headings() -> None:
+    assert shift_headings("## Phases\n", 1) == "### Phases\n"
+
+
+def test_shift_headings_leaves_body_text_alone() -> None:
+    assert shift_headings("a # b\nplain\n", 1) == "a # b\nplain\n"
+
+
+def test_shift_headings_skips_fenced_code() -> None:
+    text = "## Real\n\n```\n## Not a heading\n```\n"
+    assert shift_headings(text, 1) == "### Real\n\n```\n## Not a heading\n```\n"
+
+
+def test_shift_headings_by_zero_is_the_identity() -> None:
+    assert shift_headings("## Phases\n", 0) == "## Phases\n"

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -151,16 +151,17 @@ def _section(
     return SectionConfig(kind=kind, source=source, title=title)
 
 
-def _rules_dir(tmp_path: Path, **files: str) -> Path:
+def _rules_dir(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Write `files` (real filenames -> content) into `tmp_path` and return it."""
     tmp_path.mkdir(parents=True, exist_ok=True)
     for name, text in files.items():
-        (tmp_path / name.replace("_", ".")).write_text(text, encoding="utf-8")
+        (tmp_path / name).write_text(text, encoding="utf-8")
     return tmp_path
 
 
 def test_build_rulebook_builds_a_section_per_index_entry(tmp_path: Path) -> None:
     rules_dir = _rules_dir(
-        tmp_path, round_md="# Dropped\n\nBody.\n", setup_md="Setup.\n"
+        tmp_path, {"round.md": "# Dropped\n\nBody.\n", "setup.md": "Setup.\n"}
     )
 
     rulebook = build_rulebook(
@@ -180,7 +181,7 @@ def test_build_rulebook_builds_a_section_per_index_entry(tmp_path: Path) -> None
 
 
 def test_build_rulebook_slugs_the_title_into_an_anchor(tmp_path: Path) -> None:
-    rules_dir = _rules_dir(tmp_path, round_md="Body.\n")
+    rules_dir = _rules_dir(tmp_path, {"round.md": "Body.\n"})
 
     rulebook = build_rulebook(
         _index(_section(title="Fire & Movement, Part 2")), rules_dir=rules_dir
@@ -193,7 +194,7 @@ def test_build_rulebook_slugs_the_title_into_an_anchor(tmp_path: Path) -> None:
 def test_build_rulebook_gives_duplicate_titles_distinct_anchors(tmp_path: Path) -> None:
     # Two same-named sections would otherwise both answer to `#the-round`, and
     # every link to the second would land on the first.
-    rules_dir = _rules_dir(tmp_path, round_md="Body.\n", setup_md="More.\n")
+    rules_dir = _rules_dir(tmp_path, {"round.md": "Body.\n", "setup.md": "More.\n"})
 
     rulebook = build_rulebook(
         _index(_section(), _section(source="setup.md")), rules_dir=rules_dir
@@ -204,7 +205,7 @@ def test_build_rulebook_gives_duplicate_titles_distinct_anchors(tmp_path: Path) 
 
 
 def test_build_rulebook_rejects_an_unknown_kind_by_position(tmp_path: Path) -> None:
-    rules_dir = _rules_dir(tmp_path, round_md="Body.\n")
+    rules_dir = _rules_dir(tmp_path, {"round.md": "Body.\n"})
 
     with pytest.raises(
         ValueError, match=r"section 2: Unknown kind 'orders'"
@@ -218,7 +219,7 @@ def test_build_rulebook_rejects_an_unknown_kind_by_position(tmp_path: Path) -> N
 
 
 def test_build_rulebook_rejects_a_missing_source_by_position(tmp_path: Path) -> None:
-    rules_dir = _rules_dir(tmp_path)
+    rules_dir = _rules_dir(tmp_path, {})
 
     with pytest.raises(FileNotFoundError) as excinfo:
         build_rulebook(_index(_section(source="absent.md")), rules_dir=rules_dir)
@@ -250,7 +251,7 @@ Intro prose with **bold**.
 
 @pytest.fixture
 def rulebook(tmp_path: Path) -> Rulebook:
-    rules_dir = _rules_dir(tmp_path / "rules", round_md=_SOURCE)
+    rules_dir = _rules_dir(tmp_path / "rules", {"round.md": _SOURCE})
     return build_rulebook(_index(_section()), rules_dir=rules_dir)
 
 
@@ -357,7 +358,7 @@ def test_cli_writes_the_rulebook(tmp_path: Path) -> None:
 
 
 def test_cli_honours_an_alternate_index(tmp_path: Path) -> None:
-    _rules_dir(tmp_path, round_md=_SOURCE)
+    _rules_dir(tmp_path, {"round.md": _SOURCE})
     index = tmp_path / "alternate.toml"
     index.write_text(VALID_INDEX, encoding="utf-8")
     out = tmp_path / "rulebook.md"

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -1,0 +1,71 @@
+"""Tests for the Rulebook product: index, kind registry, view-model, CLI."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from spf.rules import get_rulebook
+from spf.schemas.rulebook import RulebookConfig, SectionConfig
+
+VALID_INDEX = """\
+title = "Test Rulebook"
+
+[[sections]]
+kind = "markdown"
+source = "round.md"
+title = "The Round"
+"""
+
+
+# --- The index schema -------------------------------------------------------
+
+
+def test_index_parses_a_valid_document() -> None:
+    index = RulebookConfig(
+        title="Test Rulebook",
+        sections=[SectionConfig(kind="markdown", source="round.md", title="The Round")],
+    )
+
+    assert index.title == "Test Rulebook"
+    (section,) = index.sections
+    assert section.kind == "markdown"
+    assert section.source == "round.md"
+    assert section.title == "The Round"
+
+
+def test_index_requires_a_document_title() -> None:
+    with pytest.raises(ValidationError, match="title"):
+        RulebookConfig(sections=[])  # pyright: ignore[reportCallIssue]
+
+
+def test_section_requires_a_title() -> None:
+    # H1s are dropped from a source (decision 6), so the index is the only
+    # place a section heading can come from.
+    with pytest.raises(ValidationError, match="title"):
+        SectionConfig(kind="markdown", source="round.md")  # pyright: ignore[reportCallIssue]
+
+
+def test_index_rejects_an_unknown_key() -> None:
+    with pytest.raises(ValidationError, match="chapters"):
+        RulebookConfig(title="Test", sections=[], chapters=[])  # pyright: ignore[reportCallIssue]
+
+
+# --- get_rulebook -----------------------------------------------------------
+
+
+def test_get_rulebook_reads_an_explicit_path(tmp_path: Path) -> None:
+    path = tmp_path / "rulebook.toml"
+    path.write_text(VALID_INDEX, encoding="utf-8")
+
+    index = get_rulebook(path)
+
+    assert index.title == "Test Rulebook"
+    assert [section.source for section in index.sections] == ["round.md"]
+
+
+def test_get_rulebook_defaults_to_the_committed_index() -> None:
+    index = get_rulebook()
+
+    assert index.title
+    assert index.sections

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -5,6 +5,17 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from spf.render.rulebook import (
+    KINDS,
+    MARKDOWN,
+    Rulebook,
+    Section,
+    SectionKind,
+    build_rulebook,
+    get_kind,
+    parse_markdown,
+    register_kind,
+)
 from spf.rules import get_rulebook
 from spf.schemas.rulebook import RulebookConfig, SectionConfig
 
@@ -69,3 +80,144 @@ def test_get_rulebook_defaults_to_the_committed_index() -> None:
 
     assert index.title
     assert index.sections
+
+
+# --- The Section Kind registry ----------------------------------------------
+
+
+def test_markdown_kind_is_registered() -> None:
+    assert KINDS["markdown"] is MARKDOWN
+    assert get_kind("markdown") is MARKDOWN
+    assert MARKDOWN.parse is parse_markdown
+
+
+def test_registry_registers_and_looks_up() -> None:
+    kind = SectionKind(name="_probe", parse=lambda path: path.read_text())
+    try:
+        assert register_kind(kind) is kind
+        assert get_kind("_probe") is kind
+    finally:
+        KINDS.pop("_probe", None)
+
+
+def test_unknown_kind_lists_the_known_kinds() -> None:
+    with pytest.raises(
+        ValueError, match=r"Unknown kind 'orders'; known kinds: .*markdown"
+    ):
+        get_kind("orders")
+
+
+# --- The markdown kind's parser ---------------------------------------------
+
+
+def test_markdown_kind_drops_h1_lines(tmp_path: Path) -> None:
+    source = tmp_path / "round.md"
+    source.write_text("# The Round\n\nBody text.\n\n## Phases\n", encoding="utf-8")
+
+    body = parse_markdown(source)
+
+    assert "# The Round" not in body
+    assert "Body text." in body
+    assert "## Phases" in body
+
+
+def test_markdown_kind_keeps_a_hash_that_is_not_a_heading(tmp_path: Path) -> None:
+    source = tmp_path / "round.md"
+    source.write_text("Roll #1 on the table.\n", encoding="utf-8")
+
+    assert parse_markdown(source) == "Roll #1 on the table.\n"
+
+
+# --- build_rulebook ---------------------------------------------------------
+
+
+def _index(*sections: SectionConfig, title: str = "Test Rulebook") -> RulebookConfig:
+    return RulebookConfig(title=title, sections=list(sections))
+
+
+def _section(
+    *, kind: str = "markdown", source: str = "round.md", title: str = "The Round"
+) -> SectionConfig:
+    return SectionConfig(kind=kind, source=source, title=title)
+
+
+def _rules_dir(tmp_path: Path, **files: str) -> Path:
+    for name, text in files.items():
+        (tmp_path / name.replace("_", ".")).write_text(text, encoding="utf-8")
+    return tmp_path
+
+
+def test_build_rulebook_builds_a_section_per_index_entry(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(
+        tmp_path, round_md="# Dropped\n\nBody.\n", setup_md="Setup.\n"
+    )
+
+    rulebook = build_rulebook(
+        _index(_section(), _section(source="setup.md", title="Setting Up")),
+        rules_dir=rules_dir,
+    )
+
+    assert isinstance(rulebook, Rulebook)
+    assert rulebook.title == "Test Rulebook"
+    first, second = rulebook.sections
+    assert isinstance(first, Section)
+    assert first.kind == "markdown"
+    assert first.title == "The Round"
+    assert "Dropped" not in str(first.body)
+    assert "Body." in str(first.body)
+    assert second.title == "Setting Up"
+
+
+def test_build_rulebook_slugs_the_title_into_an_anchor(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(tmp_path, round_md="Body.\n")
+
+    rulebook = build_rulebook(
+        _index(_section(title="Fire & Movement, Part 2")), rules_dir=rules_dir
+    )
+
+    (section,) = rulebook.sections
+    assert section.anchor == "fire-movement-part-2"
+
+
+def test_build_rulebook_gives_duplicate_titles_distinct_anchors(tmp_path: Path) -> None:
+    # Two same-named sections would otherwise both answer to `#the-round`, and
+    # every link to the second would land on the first.
+    rules_dir = _rules_dir(tmp_path, round_md="Body.\n", setup_md="More.\n")
+
+    rulebook = build_rulebook(
+        _index(_section(), _section(source="setup.md")), rules_dir=rules_dir
+    )
+
+    first, second = rulebook.sections
+    assert first.anchor != second.anchor
+
+
+def test_build_rulebook_rejects_an_unknown_kind_by_position(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(tmp_path, round_md="Body.\n")
+
+    with pytest.raises(
+        ValueError, match=r"section 2: Unknown kind 'orders'"
+    ) as excinfo:
+        build_rulebook(
+            _index(_section(), _section(kind="orders", source="round.md")),
+            rules_dir=rules_dir,
+        )
+
+    assert "known kinds:" in str(excinfo.value)
+
+
+def test_build_rulebook_rejects_a_missing_source_by_position(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(tmp_path)
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        build_rulebook(_index(_section(source="absent.md")), rules_dir=rules_dir)
+
+    message = str(excinfo.value)
+    assert "section 1" in message
+    assert "absent.md" in message
+
+
+def test_build_rulebook_accepts_an_empty_index(tmp_path: Path) -> None:
+    rulebook = build_rulebook(_index(), rules_dir=tmp_path)
+
+    assert rulebook.sections == []

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -1,10 +1,17 @@
 """Tests for the Rulebook product: index, kind registry, view-model, CLI."""
 
+import shutil
 from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
+from spf.config import config
+from spf.frontends.cli.render import GENERAL_RULES, RenderOpts, render_general_rules
+from spf.frontends.cli.rules import list_rulebook
+from spf.render import render
+from spf.render.formats import get_format
+from spf.render.products import PRODUCTS
 from spf.render.rulebook import (
     KINDS,
     MARKDOWN,
@@ -18,6 +25,9 @@ from spf.render.rulebook import (
 )
 from spf.rules import get_rulebook
 from spf.schemas.rulebook import RulebookConfig, SectionConfig
+from tests.conftest import unwrapped
+
+ENGINE = config.render.latex.engine
 
 VALID_INDEX = """\
 title = "Test Rulebook"
@@ -142,6 +152,7 @@ def _section(
 
 
 def _rules_dir(tmp_path: Path, **files: str) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     for name, text in files.items():
         (tmp_path / name.replace("_", ".")).write_text(text, encoding="utf-8")
     return tmp_path
@@ -221,3 +232,178 @@ def test_build_rulebook_accepts_an_empty_index(tmp_path: Path) -> None:
     rulebook = build_rulebook(_index(), rules_dir=tmp_path)
 
     assert rulebook.sections == []
+
+
+# --- End-to-end rendering against the real templates ------------------------
+
+_SOURCE = """\
+# Dropped by the parser
+
+Intro prose with **bold**.
+
+## A Subheading
+
+- one
+- two
+"""
+
+
+@pytest.fixture
+def rulebook(tmp_path: Path) -> Rulebook:
+    rules_dir = _rules_dir(tmp_path / "rules", round_md=_SOURCE)
+    return build_rulebook(_index(_section()), rules_dir=rules_dir)
+
+
+def test_render_markdown_links_the_contents_to_an_anchor(
+    tmp_path: Path, rulebook: Rulebook
+) -> None:
+    out = render(
+        GENERAL_RULES,
+        rulebook,
+        fmt=get_format("markdown"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert out == tmp_path / "general-rules" / "rulebook.md"
+    assert "# Test Rulebook" in text
+    assert "- [The Round](#the-round)" in text
+    # `md_to_html` emits no heading ids, so the anchor has to be explicit.
+    assert '<a id="the-round"></a>' in text
+    assert "## The Round" in text
+
+
+def test_render_markdown_shifts_source_headings_below_the_section(
+    tmp_path: Path, rulebook: Rulebook
+) -> None:
+    out = render(
+        GENERAL_RULES,
+        rulebook,
+        fmt=get_format("markdown"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert "### A Subheading" in text
+    assert "\n## A Subheading" not in text
+    assert "Dropped by the parser" not in text
+
+
+def test_render_html_resolves_the_contents_link(
+    tmp_path: Path, rulebook: Rulebook
+) -> None:
+    out = render(
+        GENERAL_RULES,
+        rulebook,
+        fmt=get_format("html"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+
+    html = out.read_text(encoding="utf-8")
+    assert 'href="#the-round"' in html
+    assert 'id="the-round"' in html
+
+
+def test_render_latex_has_furniture_and_converted_body(
+    tmp_path: Path, rulebook: Rulebook
+) -> None:
+    out = render(
+        GENERAL_RULES,
+        rulebook,
+        fmt=get_format("latex"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+
+    text = out.read_text(encoding="utf-8")
+    assert r"\title{Test Rulebook}" in text
+    assert r"\tableofcontents" in text
+    assert r"\section{The Round}" in text
+    assert r"\subsection{A Subheading}" in text
+    assert r"\textbf{bold}" in text
+    assert r"\begin{itemize}" in text
+    assert "Dropped by the parser" not in text
+
+
+@pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
+def test_render_the_committed_rulebook_compiles_to_pdf(tmp_path: Path) -> None:
+    # The real index over the real sources: the check that authored rules prose
+    # actually survives the converter and the engine.
+    real = build_rulebook(get_rulebook(), rules_dir=config.paths.rules)
+
+    out = render(
+        GENERAL_RULES,
+        real,
+        fmt=get_format("pdf"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+
+    assert out.stat().st_size > 0
+
+
+# --- The CLI ----------------------------------------------------------------
+
+
+def test_cli_writes_the_rulebook(tmp_path: Path) -> None:
+    out = tmp_path / "rulebook.md"
+
+    render_general_rules(opts=RenderOpts(format="markdown", out=out))
+
+    assert "SteamPunkFantasy Rulebook" in out.read_text(encoding="utf-8")
+
+
+def test_cli_honours_an_alternate_index(tmp_path: Path) -> None:
+    _rules_dir(tmp_path, round_md=_SOURCE)
+    index = tmp_path / "alternate.toml"
+    index.write_text(VALID_INDEX, encoding="utf-8")
+    out = tmp_path / "rulebook.md"
+
+    render_general_rules(index=index, opts=RenderOpts(format="markdown", out=out))
+
+    assert "# Test Rulebook" in out.read_text(encoding="utf-8")
+
+
+def test_cli_reports_a_missing_index_on_stderr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        render_general_rules(index=tmp_path / "absent.toml")
+
+    assert excinfo.value.code == 1
+    assert "Error:" in unwrapped(capsys.readouterr().err)
+
+
+def test_cli_reports_an_unknown_kind_on_stderr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    index = tmp_path / "bad.toml"
+    index.write_text(
+        'title = "Bad"\n\n[[sections]]\nkind = "orders"\n'
+        'source = "round.md"\ntitle = "Orders"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        render_general_rules(index=index)
+
+    assert excinfo.value.code == 1
+    assert "Unknown kind 'orders'" in unwrapped(capsys.readouterr().err)
+
+
+def test_general_rules_product_is_registered() -> None:
+    assert PRODUCTS["general-rules"] is GENERAL_RULES
+
+
+def test_rules_rulebook_lists_the_committed_sections(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # What `just validate` runs: resolving the Index is what validates it.
+    list_rulebook()
+
+    out = unwrapped(capsys.readouterr().out)
+    assert "SteamPunkFantasy Rulebook" in out
+    assert "1. The Round (markdown)" in out


### PR DESCRIPTION
Implements **Plan 1** of issue #21 (part of #16): a working `spf render general-rules` end to end, with exactly one Section Kind — `markdown`. Plan 2 adds `specials`, `tokens` and `hexes` as pure registrations against the seam this proves.

Plan: `.scratch/20260725-issue-21-rulebook-1-foundation.md`.

## What's here

- **`rules/rulebook.toml`** — the authored Rulebook Index: what the Rulebook contains, in order. The Rulebook is *not* "every file in `rules/`" (ADR 0018).
- **`rules/round.md`** — the first free-text Section. Ported from the legacy `rules.md` phase list with invented connective prose, in Round/Phase vocabulary. **Accuracy was explicitly not the goal here** — it's there so there's something real to look at; fix it by hand later.
- **Section Kind registry** (`spf/render/rulebook.py`) — mirrors the Product/Format registries deliberately: same record-plus-dict shape, same `Unknown x; known xs` failure. One parser per Kind, one template partial per Kind per family, bound by name.
- **`md_to_latex`** (`spf/render/md_latex.py`) — a small markdown-it token walk, registered as a LaTeX Jinja filter, plus `shift_headings` on the Markdown side.
- **`spf render general-rules`** with `--index`, and **`spf rules rulebook`** wired into `just validate` so a broken Index fails `just check`.
- ADR 0018, an addendum to ADR 0005, and three new CONTEXT.md terms.

## Verified

`just check` green (493 tests). All four formats rendered from the real index; the **PDF was opened and eyeballed** — title page, nested TOC, the Round section with working subsections, bullets, an `\hrulefill`, and a nested `enumerate`. The Markdown TOC link and its `<a id>` match, so the link resolves in the derived HTML (this is the check that matters — `md_to_html` emits no heading ids of its own).

## Assumptions and limitations, flagged for review

- **A1.** Variable placeholders (`{N}`, `{version}`) render literally — `latex_escape` turns the braces into `\{`/`\}`, which prints as `{N}`. Now pinned by a test.
- **A2.** The Markdown TOC lists index Sections only, one level; LaTeX's `\tableofcontents` naturally goes deeper. Accepted asymmetry.
- **A3.** `RenderOpts` is reused as-is, so `--no-images` is accepted and ignored by `general-rules`. Its help text already scopes itself to `army-rules`.

**Converter limitations**, documented in the module docstring: tables are not converted (stock `commonmark` has no table rule, so a pipe table prints as literal text); images are dropped; a link keeps its text and loses its URL; block quotes flow as ordinary paragraphs. And the sharp edge: **raw LaTeX in a Markdown source is escaped, not passed through** — do not put `\pagebreak` in a rules `.md`. A passthrough escape hatch is deliberate future work.

## Choices made beyond the plan, worth a look

- **`--index` resolves a Section's sources beside its own Index**, not always under `rules/`. The plan specified `--index` but not this; it makes an alternate Index self-contained, and for the committed one the two are the same directory.
- **`spf/render/latex_text.py` is new** — `latex_escape` moved out of `environments.py` to break the `environments → md_latex → environments` import cycle. No behaviour change.
- **Anchors are de-duplicated** (`the-round`, `the-round-2`). Two Sections may share a title; every link to the second would otherwise land on the first.
- **`\usepackage[T1]{fontenc}`** in the LaTeX template — the rules prose carries em dashes, which the default font encoding cannot set.
- **Error prefix reads `Rulebook Index section 3: Unknown kind 'orders'; known kinds: markdown`**, rather than the plan's literal `rulebook.toml section 3:`. The Index is no longer necessarily that file, and the capitalisation follows decision 10's stated house style (`get_format`'s `Unknown x 'y'; known xs: …`).

Reviewed with `/code-review` against the plan on both the Standards and Spec axes; findings worth acting on are folded into the last commit.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
