### PR TITLE
Rulebook, plan 2: the specials, tokens and hexes section kinds

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -95,6 +95,11 @@ an exact value, a range, or an "at least" threshold.
 **Special** (special rule):
 A named rule that modifies a Unit, Model, Equipment, Assault, or Range beyond
 the base stats. Defined in `rules/special.toml` and referenced by name.
+
+A Special may name the Token it places (`token = "minor_acid"`). The key is a
+Token key in `rules/tokens.toml`, and the Rulebook resolves it to that Token's
+display name — strictly, so a reference to a Token that does not exist fails the
+build rather than rendering as nothing.
 _Avoid_: ability, trait, perk
 
 **Spawn**:
@@ -212,9 +217,11 @@ _Avoid_: chapter, part
 
 **Section Kind**:
 The shape of a Section's source, declared by the Section and bound to one parser
-and one template partial per family (`markdown`, and in future `specials`,
-`tokens`, `hexes`). The extension point for a new rules file: adding one is a
-registration, never a change to the pipeline.
+and one template partial per family (`markdown`, `specials`, `tokens`, `hexes`).
+The extension point for a new rules file: adding one is a registration, never a
+change to the pipeline. A parser is also handed a shared context over the
+sibling rules files, so a Kind can resolve cross-references (a Special's Token)
+whether or not the Index renders what it points at.
 _Avoid_: type, format (Format is the output syntax)
 
 ### Generated assets (AI-authored color & atmosphere)

--- a/v3/docs/adr/0018-rulebook-driven-by-an-authored-index.md
+++ b/v3/docs/adr/0018-rulebook-driven-by-an-authored-index.md
@@ -23,6 +23,14 @@ Nothing about a partial is registered — the convention *is* the binding, which
 keeps `main.<ext>.jinja` dumb, per ADR 0005: it loops over Sections, emits the
 heading, and includes.
 
+A parser is handed the source path *and* a context over the sibling rules
+files, because **the index controls what is rendered, not what is loaded**. A
+Special names the Token it places, and that reference has to resolve whether or
+not the index happens to contain a Tokens Section. The context loads lazily, so
+a Rulebook with no cross-references still touches no file its index did not
+name; resolution is strict, because a reference that renders as nothing is a
+rule the reader never learns about.
+
 The index lives in `rules/` and not in `configs/spf.toml` because it is game
 data — an editorial statement about the game — not developer configuration. It
 is TOML because every other authored data file is, so it loads through the

--- a/v3/rules/rulebook.toml
+++ b/v3/rules/rulebook.toml
@@ -8,3 +8,20 @@ title = "SteamPunkFantasy Rulebook"
 kind = "markdown"
 source = "round.md"
 title = "The Round"
+
+# Hexes and Tokens come before Specials so that a Special's `token` reference
+# points at something the reader has already met.
+[[sections]]
+kind = "hexes"
+source = "hexes.toml"
+title = "Hex Effects"
+
+[[sections]]
+kind = "tokens"
+source = "tokens.toml"
+title = "Tokens"
+
+[[sections]]
+kind = "specials"
+source = "special.toml"
+title = "Special Rules"

--- a/v3/rules/special.toml
+++ b/v3/rules/special.toml
@@ -24,7 +24,7 @@ explanation = "Roll {N} dice, for each die at {M}+, the unit gets one less +1 to
 name = "Assault minor acid"
 short = "[1 for {N}]"
 explanation = "Targets gets one minor token for each {N} hits."
-token = "minor acid"
+token = "minor_acid"
 
 [assault.minor_acid.variables]
 N = { type = "int", min = 1, max = 4 }

--- a/v3/rules/special.toml
+++ b/v3/rules/special.toml
@@ -101,7 +101,7 @@ phase  = {type = "str", values=["1st Healing", "2nd Healing"]}
 
 [unit.immunity]
 name = "Immunity"
-short = "Immunity [feature]"
+short = "[feature]"
 explanation = ""
 description = "Unit is completely immmune to given feature"
 
@@ -200,7 +200,7 @@ token = "minor_acid"
 
 [weapon.poison]
 name = "Poison"
-short = "Poison {N}"
+short = "{N}"
 explanation = "Target gets a poison[{N}] token"
 token = "poison"
 

--- a/v3/rules/tokens.toml
+++ b/v3/rules/tokens.toml
@@ -6,15 +6,11 @@ phases = []
 effect = "Get -1 to hit and -1 on all assault dice. In addition, psychic damage now causes crew damage instead"
 remove = "Only by healing ability"
 
-
 [tokens.plus_minus_one]
 name = "-1 to hit, +1 to be hit "
 phases = []
 effect = "Get -1 to hit and -1 on all assault dice, while enemy gets +1 to hit this unit with by range and assaults. Enemy also gets to add or subtract one to critical effects"
 remove = "Only by repair ability"
-
-
-
 
 [tokens.minor_acid]
 name = "Minor Acid"
@@ -22,33 +18,32 @@ phases = ["Agony 1"]
 remove = "Only as part of effect"
 effect = "Role a die, at 3+, unit gets +1 on future damage. Otherwise, remove minor acid"
 
-
 [tokens.acid]
 name = "Acid"
 phases = ["Agony 0"]
-effect = """Roll a d8 on the following damage table:,
+effect = """Roll a d8 on the following damage table:
 
-			 1 : Downgrade from acid to minor acid.
-			 2 : +1 to future damage
-			 3 : As 2, and if unit has armor, it is reduced by 1 (all directions)
-			 4 : As 3, and place a poison cloud [4] at hex.
-			   : and all units in this hex gets a minor acid token.
-			 5 : As 4, and in addition all units within range=2 gets a minor acid token
-			 6 : As 5, and unit gains a terror token.
-			 7 : As 6 and unit is set on fire.
-			 8 : Roll three times on this table.,
+1. Downgrade from acid to minor acid.
+2. +1 to future damage
+3. As 2, and if unit has armor, it is reduced by 1 (all directions)
+4. As 3, and place a poison cloud [4] at hex, and all units in this hex gets a minor acid token.
+5. As 4, and in addition all units within range=2 gets a minor acid token
+6. As 5, and unit gains a terror token.
+7. As 6 and unit is set on fire.
+8. Roll three times on this table.,
 """
 
 [tokens.terror]
 name = "Terror"
 phases = ["Agony 0"]
-effect = "Acts as if unit has Terror[6](range=2) but effects only units of the same team"
+effect = "Acts as if unit has Terror[6] (range=2) but effects only units of the same team"
 
 [tokens.poison]
 name = "Poison"
 short = "[N]"
 phases = ["Agony 3"]
 effect = """Roll a d{N}.
+
 - Ignore armor and regular damage resistances
 - Reduce damage by poison resistances of target
 - Apply bonus to damage based on the number +future damage tokens
@@ -64,10 +59,10 @@ N = { type = "int", values = [2, 4, 6, 8, 10, 12] }
 name = "Bleed"
 short = "[N]"
 phases = ["Agony 4"]
-effect = """Roll a d{N}.
-At 1, remove bleed token.
+effect = """Roll a d{N}. At 1, remove bleed token.
 
-Otherwise
+Otherwise:
+
 - Ignore armor and regular damage resistances
 - Apply bonus to damage based on the number +future damage tokens
 - Apply damage to the regular damage table, with the exception that bleed does not cause more bleed.

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -21,10 +21,53 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from spf import rules
 from spf.schemas.rulebook import RulebookConfig
 
 _H1 = re.compile(r"^#\s")
 _NON_SLUG = re.compile(r"[^a-z0-9]+")
+
+TOKENS_SOURCE = "tokens.toml"
+
+
+class RulesContext:
+    """Access to sibling rules files, for cross-referencing parsers.
+
+    A Special names the Token it places, but the Index decides only what is
+    *rendered* — a Rulebook may resolve that reference without a Tokens Section
+    in it at all. So the context loads what a parser asks for, from beside the
+    Index, rather than from what the Index happens to name.
+
+    Loading is lazy and cached: a Rulebook with no cross-references touches no
+    file its Index did not name.
+    """
+
+    def __init__(self, rules_dir: Path) -> None:
+        """Resolve sibling rules files against `rules_dir`."""
+        self.rules_dir = rules_dir
+        self._tokens: dict[str, str] | None = None
+
+    def _token_names(self) -> dict[str, str]:
+        """Token key -> display name, read once from `tokens.toml`."""
+        if self._tokens is None:
+            config = rules.get_tokens(self.rules_dir / TOKENS_SOURCE)
+            self._tokens = {key: token.name for key, token in config.tokens.items()}
+        return self._tokens
+
+    def token_name(self, key: str) -> str:
+        """Display name of Token `key`.
+
+        Raises `ValueError` listing the known keys when there is no such Token:
+        a reference that silently renders as nothing is a rule the reader never
+        learns about.
+        """
+        names = self._token_names()
+        try:
+            return names[key]
+        except KeyError:
+            known = ", ".join(names) or "(none)"
+            msg = f"unknown token {key!r}; known tokens: {known}"
+            raise ValueError(msg) from None
 
 
 @dataclass(frozen=True)

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from spf import rules
 from spf.schemas.rulebook import RulebookConfig
+from spf.schemas.rules import IntVariableConfig, StringVariableConfig
 
 _H1 = re.compile(r"^#\s")
 _NON_SLUG = re.compile(r"[^a-z0-9]+")
@@ -75,11 +76,11 @@ class SectionKind:
     """A registered kind of Rulebook Section: how its source is read."""
 
     name: str
-    parse: Callable[[Path], object]
-    """Source path -> the Section's body, in whatever shape the Kind's partials
-    expect. Plan 2 widens this to also take a shared rules context, so that a
-    Kind can resolve cross-references; keeping the type here makes that a
-    one-line change."""
+    parse: Callable[[Path, RulesContext], object]
+    """Source path and the build's shared `RulesContext` -> the Section's body,
+    in whatever shape the Kind's partials expect. Every parser is handed the
+    context whether or not it cross-references anything; the context is lazy,
+    so ignoring it costs nothing."""
 
 
 KINDS: dict[str, SectionKind] = {}
@@ -101,7 +102,30 @@ def get_kind(name: str) -> SectionKind:
         raise ValueError(msg) from None
 
 
-def parse_markdown(path: Path) -> str:
+def constraint_text(variable: IntVariableConfig | StringVariableConfig) -> str:
+    """Describe what `variable` may be, as a reader-facing phrase.
+
+    The schema states a constraint as bounds or an enumeration; a rulebook
+    states it as English. Enumerated values win over bounds when both are
+    given: the list is the stricter, and more useful, statement.
+    """
+    if variable.values:
+        listed = ", ".join(str(value) for value in variable.values)
+        return f"one of {listed}"
+    if not isinstance(variable, IntVariableConfig):
+        return "text"
+    match variable.min, variable.max:
+        case None, None:
+            return "integer"
+        case low, None:
+            return f"integer, at least {low}"
+        case None, high:
+            return f"integer, at most {high}"
+        case low, high:
+            return f"integer, {low}-{high}"
+
+
+def parse_markdown(path: Path, context: RulesContext) -> str:  # noqa: ARG001  every parser takes the context; free text cross-references nothing
     """Read a free-text Markdown Section, dropping its H1 lines.
 
     A Section's heading always comes from the Index's `title`, so an H1 in the
@@ -169,6 +193,7 @@ def build_rulebook(index: RulebookConfig, *, rules_dir: Path) -> Rulebook:
     """
     sections: list[Section] = []
     taken: set[str] = set()
+    context = RulesContext(rules_dir)
     for position, config in enumerate(index.sections, start=1):
         where = f"Rulebook Index section {position}"
         try:
@@ -187,7 +212,7 @@ def build_rulebook(index: RulebookConfig, *, rules_dir: Path) -> Rulebook:
                 kind=kind.name,
                 title=config.title,
                 anchor=_anchor(config.title, taken),
-                body=kind.parse(source),
+                body=kind.parse(source, context),
             )
         )
     return Rulebook(title=index.title, sections=sections)

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -211,11 +211,21 @@ def _variables(
     return [(name, constraint_text(spec)) for name, spec in (variables or {}).items()]
 
 
+def _short(name: str, short: str | None) -> str | None:
+    """Return the heading's suffix: `short`, unless it is the name over again.
+
+    `short` is the compact form the Army Reference prints in place of the full
+    rule; some rules simply repeat their name there, and a Rulebook heading
+    reading "Fumble Fumble" is noise the reader has to look past.
+    """
+    return None if not short or short == name else short
+
+
 def _token_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
     """Build the entry for a Token or Hex rule — structurally the same shape."""
     return RuleEntry(
         name=config.name,
-        short=config.short,
+        short=_short(config.name, config.short),
         body=config.effect,
         description=None,
         example=None,
@@ -269,7 +279,7 @@ def _special_entry(
 
     return RuleEntry(
         name=config.name,
-        short=config.short,
+        short=_short(config.name, config.short),
         body=config.explanation,
         description=config.description,
         example=config.example,

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -23,7 +23,13 @@ from pathlib import Path
 
 from spf import rules
 from spf.schemas.rulebook import RulebookConfig
-from spf.schemas.rules import IntVariableConfig, StringVariableConfig
+from spf.schemas.rules import (
+    HexRuleConfig,
+    IntVariableConfig,
+    SpecialRuleConfig,
+    StringVariableConfig,
+    TokenRuleConfig,
+)
 
 _H1 = re.compile(r"^#\s")
 _NON_SLUG = re.compile(r"[^a-z0-9]+")
@@ -138,6 +144,169 @@ def parse_markdown(path: Path, context: RulesContext) -> str:  # noqa: ARG001  e
 
 
 MARKDOWN = register_kind(SectionKind(name="markdown", parse=parse_markdown))
+
+
+@dataclass(frozen=True)
+class RuleEntry:
+    """One Special, Token, or Hex rule, as the Rulebook shows it.
+
+    Every field the three schemas hold, flattened into one shape: the Army
+    Reference carries a Special's `short` override text, while the *full* rule
+    text belongs here (CONTEXT.md). A field the source leaves out is `None` or
+    empty, and the partials emit nothing for it.
+    """
+
+    name: str
+    short: str | None
+    body: str
+    """The rule itself — a Special's `explanation`, a Token's or Hex's
+    `effect`. Markdown."""
+
+    description: str | None
+    """Markdown: what the rule represents, rather than what it does."""
+
+    example: str | None
+    """Markdown."""
+
+    phases: list[str]
+    remove: str | None
+    token: str | None
+    """The **display name** of the Token this rule places, already resolved
+    from the source's key (decision 17), or None."""
+
+    variables: list[tuple[str, str]]
+    """(name, constraint phrase), in the order the source declares them."""
+
+    versions: list[tuple[str, str]]
+    """(version, rule text) — a rule that reads differently per damage type."""
+
+
+@dataclass(frozen=True)
+class RuleGroup:
+    """A titled run of rules: a Specials group, or a whole Tokens file.
+
+    `title` is None when the source has no grouping of its own, which is what
+    the partials key their heading depth off — a group heading is a level the
+    reader only pays for when it carries information.
+    """
+
+    title: str | None
+    rules: list[RuleEntry]
+
+
+@dataclass(frozen=True)
+class RulesBody:
+    """The body of a structured Section: optional prose plus grouped rules."""
+
+    explanation: str | None
+    """Markdown prose above the rules; only `hexes.toml` has any."""
+
+    groups: list[RuleGroup]
+
+
+def _variables(
+    variables: dict[str, IntVariableConfig | StringVariableConfig] | None,
+) -> list[tuple[str, str]]:
+    """Render a rule's variable constraints as (name, phrase) pairs."""
+    return [(name, constraint_text(spec)) for name, spec in (variables or {}).items()]
+
+
+def _token_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
+    """Build the entry for a Token or Hex rule — structurally the same shape."""
+    return RuleEntry(
+        name=config.name,
+        short=config.short,
+        body=config.effect,
+        description=None,
+        example=None,
+        phases=list(config.phases),
+        remove=config.remove,
+        token=None,
+        variables=_variables(config.variables),
+        versions=[],
+    )
+
+
+def parse_tokens(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001  a Token names no other rule
+    """Read `tokens.toml` as one untitled group of rules, in file order."""
+    config = rules.get_tokens(path)
+    entries = [_token_entry(token) for token in config.tokens.values()]
+    return RulesBody(explanation=None, groups=[RuleGroup(title=None, rules=entries)])
+
+
+TOKENS = register_kind(SectionKind(name="tokens", parse=parse_tokens))
+
+
+def parse_hexes(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001  a Hex names no other rule
+    """Read `hexes.toml`: its document-level prose, then one untitled group."""
+    config = rules.get_hexes(path)
+    entries = [_token_entry(hex_rule) for hex_rule in config.hexes.values()]
+    return RulesBody(
+        explanation=config.explanation,
+        groups=[RuleGroup(title=None, rules=entries)],
+    )
+
+
+HEXES = register_kind(SectionKind(name="hexes", parse=parse_hexes))
+
+
+def _special_entry(
+    key: str, config: SpecialRuleConfig, context: RulesContext, source: Path
+) -> RuleEntry:
+    """Build the entry for one Special, resolving the Token it places.
+
+    Resolution is strict: an unknown Token names the offending rule and its
+    file, because a reference that quietly renders as nothing is how
+    `token = "minor acid"` survived in the data for as long as it did.
+    """
+    token = None
+    if config.token is not None:
+        try:
+            token = context.token_name(config.token)
+        except ValueError as err:
+            msg = f"{source.name}: rule {key!r} references {err}"
+            raise ValueError(msg) from None
+
+    return RuleEntry(
+        name=config.name,
+        short=config.short,
+        body=config.explanation,
+        description=config.description,
+        example=config.example,
+        phases=[],
+        remove=None,
+        token=token,
+        variables=_variables(config.variables),
+        versions=list((config.versions or {}).items()),
+    )
+
+
+def parse_specials(path: Path, context: RulesContext) -> RulesBody:
+    """Read `special.toml` as one titled group per group in the schema.
+
+    Where a Special applies — in an Assault, on a Unit, on a Weapon — is
+    information the reader needs, so the groups stay groups rather than being
+    flattened into one alphabetical list (decision 15).
+    """
+    config = rules.get_specials(path)
+    groups = [
+        RuleGroup(
+            title=title,
+            rules=[
+                _special_entry(key, special, context, path)
+                for key, special in specials.items()
+            ],
+        )
+        for title, specials in (
+            ("Assault", config.assault),
+            ("Unit", config.unit),
+            ("Weapon", config.weapon),
+        )
+    ]
+    return RulesBody(explanation=None, groups=groups)
+
+
+SPECIALS = register_kind(SectionKind(name="specials", parse=parse_specials))
 
 
 @dataclass(frozen=True)

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -180,18 +180,32 @@ class RuleEntry:
     versions: list[tuple[str, str]]
     """(version, rule text) — a rule that reads differently per damage type."""
 
+    @property
+    def has_facts(self) -> bool:
+        """Whether the rule has anything for the facts list under its prose."""
+        return bool(self.token or self.phases or self.remove or self.variables)
+
 
 @dataclass(frozen=True)
 class RuleGroup:
     """A titled run of rules: a Specials group, or a whole Tokens file.
 
-    `title` is None when the source has no grouping of its own, which is what
-    the partials key their heading depth off — a group heading is a level the
-    reader only pays for when it carries information.
+    `title` is None when the source has no grouping of its own — a group
+    heading is a level the reader only pays for when it carries information.
     """
 
     title: str | None
     rules: list[RuleEntry]
+
+    @property
+    def nested(self) -> bool:
+        r"""Whether this group's rules sit one heading level deeper.
+
+        The decision is the view-model's, so both families make it the same
+        way; mapping the depth to `####` or `\\subsubsection` is each family's
+        own business, and stays in its partial (ADR 0005).
+        """
+        return self.title is not None
 
 
 @dataclass(frozen=True)
@@ -221,7 +235,7 @@ def _short(name: str, short: str | None) -> str | None:
     return None if not short or short == name else short
 
 
-def _token_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
+def _effect_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
     """Build the entry for a Token or Hex rule — structurally the same shape."""
     return RuleEntry(
         name=config.name,
@@ -240,7 +254,7 @@ def _token_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
 def parse_tokens(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001  a Token names no other rule
     """Read `tokens.toml` as one untitled group of rules, in file order."""
     config = rules.get_tokens(path)
-    entries = [_token_entry(token) for token in config.tokens.values()]
+    entries = [_effect_entry(token) for token in config.tokens.values()]
     return RulesBody(explanation=None, groups=[RuleGroup(title=None, rules=entries)])
 
 
@@ -250,7 +264,7 @@ TOKENS = register_kind(SectionKind(name="tokens", parse=parse_tokens))
 def parse_hexes(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001  a Hex names no other rule
     """Read `hexes.toml`: its document-level prose, then one untitled group."""
     config = rules.get_hexes(path)
-    entries = [_token_entry(hex_rule) for hex_rule in config.hexes.values()]
+    entries = [_effect_entry(hex_rule) for hex_rule in config.hexes.values()]
     return RulesBody(
         explanation=config.explanation,
         groups=[RuleGroup(title=None, rules=entries)],
@@ -260,23 +274,26 @@ def parse_hexes(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001
 HEXES = register_kind(SectionKind(name="hexes", parse=parse_hexes))
 
 
-def _special_entry(
+def _resolve_token(
     key: str, config: SpecialRuleConfig, context: RulesContext, source: Path
-) -> RuleEntry:
-    """Build the entry for one Special, resolving the Token it places.
+) -> str | None:
+    """Resolve the Token a Special places, to the display name the reader sees.
 
-    Resolution is strict: an unknown Token names the offending rule and its
+    Strict: an unknown Token fails the build, naming the offending rule and its
     file, because a reference that quietly renders as nothing is how
     `token = "minor acid"` survived in the data for as long as it did.
     """
-    token = None
-    if config.token is not None:
-        try:
-            token = context.token_name(config.token)
-        except ValueError as err:
-            msg = f"{source.name}: rule {key!r} references {err}"
-            raise ValueError(msg) from None
+    if config.token is None:
+        return None
+    try:
+        return context.token_name(config.token)
+    except ValueError as err:
+        msg = f"{source.name}: rule {key!r} references {err}"
+        raise ValueError(msg) from None
 
+
+def _special_entry(config: SpecialRuleConfig, token: str | None) -> RuleEntry:
+    """Build the entry for one Special, given its already-resolved Token."""
     return RuleEntry(
         name=config.name,
         short=_short(config.name, config.short),
@@ -303,7 +320,7 @@ def parse_specials(path: Path, context: RulesContext) -> RulesBody:
         RuleGroup(
             title=title,
             rules=[
-                _special_entry(key, special, context, path)
+                _special_entry(special, _resolve_token(key, special, context, path))
                 for key, special in specials.items()
             ],
         )

--- a/v3/src/spf/rules.py
+++ b/v3/src/spf/rules.py
@@ -16,24 +16,29 @@ def _read(path: Path) -> Configuration:
     return Configuration.from_file(path).add_envs({}, prefix="SPF_").parse_dynamic()
 
 
-def _get_rules(file_name: str) -> Configuration:
-    """Read one rules file from the configured rules directory."""
-    return _read(config.paths.rules / file_name)
+def _get_rules(path: Path | None, file_name: str) -> Configuration:
+    """Read one rules file: `path` if given, else `file_name` beside the rest.
+
+    The Rulebook Index names each Section's source file, so a Rulebook parser
+    has a path in hand and must be able to hand it over; every other caller
+    wants the committed file and passes nothing.
+    """
+    return _read(path if path is not None else config.paths.rules / file_name)
 
 
-def get_specials() -> r.SpecialRulesConfig:
+def get_specials(path: Path | None = None) -> r.SpecialRulesConfig:
     """Get rules for specials."""
-    return _get_rules("special.toml").convert_model(r.SpecialRulesConfig)
+    return _get_rules(path, "special.toml").convert_model(r.SpecialRulesConfig)
 
 
-def get_tokens() -> r.TokenRulesConfig:
+def get_tokens(path: Path | None = None) -> r.TokenRulesConfig:
     """Get rules for tokens."""
-    return _get_rules("tokens.toml").convert_model(r.TokenRulesConfig)
+    return _get_rules(path, "tokens.toml").convert_model(r.TokenRulesConfig)
 
 
-def get_hexes() -> r.HexRulesConfig:
+def get_hexes(path: Path | None = None) -> r.HexRulesConfig:
     """Get rules for hexes."""
-    return _get_rules("hexes.toml").convert_model(r.HexRulesConfig)
+    return _get_rules(path, "hexes.toml").convert_model(r.HexRulesConfig)
 
 
 def rulebook_index_path(path: Path | None = None) -> Path:

--- a/v3/templates/latex/general-rules/hexes.tex.jinja
+++ b/v3/templates/latex/general-rules/hexes.tex.jinja
@@ -1,0 +1,3 @@
+% A structured rules Section: hexes render through the shared body partial,
+% which keys its sectioning depth off whether the Kind groups its rules.
+\BLOCK{include "general-rules/rules-body.tex.jinja"}

--- a/v3/templates/latex/general-rules/main.tex.jinja
+++ b/v3/templates/latex/general-rules/main.tex.jinja
@@ -8,6 +8,7 @@
 \usepackage[margin=2cm]{geometry}
 \usepackage[T1]{fontenc}
 \usepackage{textcomp}
+\usepackage{parskip}
 
 \title{\VAR{source.title | latex_escape}}
 \date{}

--- a/v3/templates/latex/general-rules/rules-body.tex.jinja
+++ b/v3/templates/latex/general-rules/rules-body.tex.jinja
@@ -1,0 +1,56 @@
+% The shared body of a structured Section — specials, tokens, hexes. All three
+% Kinds parse to one `RulesBody`, so all three render through here; each Kind
+% keeps its own partial as the seam where the shapes will diverge.
+%
+% A rule sits one sectioning level below its group, and a group only exists
+% when the source groups its rules — so an ungrouped file does not spend a
+% level on a heading it has no title for.
+%
+% Prose fields are Markdown and go through `md_to_latex`; short strings (names,
+% phases, removal conditions) are plain text and only need escaping.
+\BLOCK{set body = section.body}
+\BLOCK{if body.explanation}
+\VAR{body.explanation | md_to_latex}
+\BLOCK{endif}
+\BLOCK{for group in body.groups}
+\BLOCK{if group.title}
+\subsection{\VAR{group.title | latex_escape}}
+\BLOCK{endif}
+\BLOCK{set heading = "\\subsubsection" if group.title else "\\subsection"}
+\BLOCK{for rule in group.rules}
+\VAR{heading}{\VAR{rule.name | latex_escape}\BLOCK{if rule.short} \VAR{rule.short | latex_escape}\BLOCK{endif}}
+\BLOCK{if rule.body}
+\VAR{rule.body | md_to_latex}
+\BLOCK{endif}
+\BLOCK{if rule.description}
+\textbf{Represents:} \VAR{rule.description | md_to_latex}
+\BLOCK{endif}
+\BLOCK{if rule.example}
+\textbf{Example:} \VAR{rule.example | md_to_latex}
+\BLOCK{endif}
+\BLOCK{if rule.token or rule.phases or rule.remove or rule.variables}
+\begin{itemize}
+\BLOCK{if rule.token}
+  \item \textbf{Places:} \VAR{rule.token | latex_escape}
+\BLOCK{endif}
+\BLOCK{if rule.phases}
+  \item \textbf{Phases:} \VAR{rule.phases | join(", ") | latex_escape}
+\BLOCK{endif}
+\BLOCK{if rule.remove}
+  \item \textbf{Removed:} \VAR{rule.remove | latex_escape}
+\BLOCK{endif}
+\BLOCK{for name, constraint in rule.variables}
+  \item \textbf{\VAR{name | latex_escape}:} \VAR{constraint | latex_escape}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endif}
+\BLOCK{if rule.versions}
+\textbf{Versions}
+\begin{itemize}
+\BLOCK{for version, text in rule.versions}
+  \item \textbf{\VAR{version | latex_escape}:} \VAR{text | md_to_latex}
+\BLOCK{endfor}
+\end{itemize}
+\BLOCK{endif}
+\BLOCK{endfor}
+\BLOCK{endfor}

--- a/v3/templates/latex/general-rules/rules-body.tex.jinja
+++ b/v3/templates/latex/general-rules/rules-body.tex.jinja
@@ -16,7 +16,7 @@
 \BLOCK{if group.title}
 \subsection{\VAR{group.title | latex_escape}}
 \BLOCK{endif}
-\BLOCK{set heading = "\\subsubsection" if group.title else "\\subsection"}
+\BLOCK{set heading = "\\subsubsection" if group.nested else "\\subsection"}
 \BLOCK{for rule in group.rules}
 \VAR{heading}{\VAR{rule.name | latex_escape}\BLOCK{if rule.short} \VAR{rule.short | latex_escape}\BLOCK{endif}}
 \BLOCK{if rule.body}
@@ -28,7 +28,7 @@
 \BLOCK{if rule.example}
 \textbf{Example:} \VAR{rule.example | md_to_latex}
 \BLOCK{endif}
-\BLOCK{if rule.token or rule.phases or rule.remove or rule.variables}
+\BLOCK{if rule.has_facts}
 \begin{itemize}
 \BLOCK{if rule.token}
   \item \textbf{Places:} \VAR{rule.token | latex_escape}

--- a/v3/templates/latex/general-rules/rules-body.tex.jinja
+++ b/v3/templates/latex/general-rules/rules-body.tex.jinja
@@ -28,23 +28,21 @@
 \BLOCK{if rule.example}
 \textbf{Example:} \VAR{rule.example | md_to_latex}
 \BLOCK{endif}
-\BLOCK{if rule.has_facts}
-\begin{itemize}
 \BLOCK{if rule.token}
-  \item \textbf{Places:} \VAR{rule.token | latex_escape}
+\textbf{Places:} \VAR{rule.token | latex_escape}
 \BLOCK{endif}
 \BLOCK{if rule.phases}
-  \item \textbf{Phases:} \VAR{rule.phases | join(", ") | latex_escape}
+\textbf{Phases:} \VAR{rule.phases | join(", ") | latex_escape}
 \BLOCK{endif}
 \BLOCK{if rule.remove}
-  \item \textbf{Removed:} \VAR{rule.remove | latex_escape}
+\textbf{Removed:} \VAR{rule.remove | latex_escape}
 \BLOCK{endif}
 \BLOCK{for name, constraint in rule.variables}
-  \item \textbf{\VAR{name | latex_escape}:} \VAR{constraint | latex_escape}
+
+\textbf{\VAR{name | latex_escape}:} \VAR{constraint | latex_escape}
 \BLOCK{endfor}
-\end{itemize}
-\BLOCK{endif}
 \BLOCK{if rule.versions}
+
 \textbf{Versions}
 \begin{itemize}
 \BLOCK{for version, text in rule.versions}

--- a/v3/templates/latex/general-rules/specials.tex.jinja
+++ b/v3/templates/latex/general-rules/specials.tex.jinja
@@ -1,0 +1,3 @@
+% A structured rules Section: specials render through the shared body partial,
+% which keys its sectioning depth off whether the Kind groups its rules.
+\BLOCK{include "general-rules/rules-body.tex.jinja"}

--- a/v3/templates/latex/general-rules/tokens.tex.jinja
+++ b/v3/templates/latex/general-rules/tokens.tex.jinja
@@ -1,0 +1,3 @@
+% A structured rules Section: tokens render through the shared body partial,
+% which keys its sectioning depth off whether the Kind groups its rules.
+\BLOCK{include "general-rules/rules-body.tex.jinja"}

--- a/v3/templates/markdown/general-rules/hexes.md.jinja
+++ b/v3/templates/markdown/general-rules/hexes.md.jinja
@@ -1,0 +1,3 @@
+{#- A structured rules Section: hexes render through the shared body partial,
+   which keys its heading depth off whether the Kind groups its rules. -#}
+{% include "general-rules/rules-body.md.jinja" %}

--- a/v3/templates/markdown/general-rules/rules-body.md.jinja
+++ b/v3/templates/markdown/general-rules/rules-body.md.jinja
@@ -20,7 +20,7 @@
 {%- if group.title %}
 ### {{ group.title }}
 {% endif -%}
-{%- set hashes = "####" if group.title else "###" -%}
+{%- set hashes = "####" if group.nested else "###" -%}
 
 {%- for rule in group.rules %}
 {{ hashes }} {{ rule.name }}{% if rule.short %} {{ rule.short }}{% endif %}
@@ -34,7 +34,7 @@
 **Example:** {{ rule.example }}
 {% endif -%}
 
-{%- if rule.token or rule.phases or rule.remove or rule.variables %}
+{%- if rule.has_facts %}
 {% if rule.token %}- **Places:** {{ rule.token }}
 {% endif -%}
 {%- if rule.phases %}- **Phases:** {{ rule.phases | join(", ") }}

--- a/v3/templates/markdown/general-rules/rules-body.md.jinja
+++ b/v3/templates/markdown/general-rules/rules-body.md.jinja
@@ -1,0 +1,55 @@
+{#
+  The shared body of a structured Section — specials, tokens, hexes. All three
+  Kinds parse to one `RulesBody`, so all three render through here; each Kind
+  keeps its own partial as the seam where the shapes will diverge.
+
+  A rule sits one heading level below its group, and a group only exists when
+  the source groups its rules — so an ungrouped file does not spend a heading
+  level on a heading it has no title for.
+
+  Every prose field is already Markdown and passes through untouched. Labels
+  lead the first line rather than wrapping the field, so a multi-paragraph
+  field still renders as prose instead of breaking an emphasis span.
+#}
+{%- set body = section.body -%}
+{%- if body.explanation %}
+{{ body.explanation }}
+{% endif -%}
+
+{%- for group in body.groups -%}
+{%- if group.title %}
+### {{ group.title }}
+{% endif -%}
+{%- set hashes = "####" if group.title else "###" -%}
+
+{%- for rule in group.rules %}
+{{ hashes }} {{ rule.name }}{% if rule.short %} {{ rule.short }}{% endif %}
+{% if rule.body %}
+{{ rule.body }}
+{% endif -%}
+{%- if rule.description %}
+**Represents:** {{ rule.description }}
+{% endif -%}
+{%- if rule.example %}
+**Example:** {{ rule.example }}
+{% endif -%}
+
+{%- if rule.token or rule.phases or rule.remove or rule.variables %}
+{% if rule.token %}- **Places:** {{ rule.token }}
+{% endif -%}
+{%- if rule.phases %}- **Phases:** {{ rule.phases | join(", ") }}
+{% endif -%}
+{%- if rule.remove %}- **Removed:** {{ rule.remove }}
+{% endif -%}
+{%- for name, constraint in rule.variables %}- **{{ name }}:** {{ constraint }}
+{% endfor -%}
+{% endif -%}
+
+{%- if rule.versions %}
+**Versions**
+
+{% for version, text in rule.versions %}- **{{ version }}:** {{ text }}
+{% endfor -%}
+{% endif -%}
+{%- endfor -%}
+{%- endfor -%}

--- a/v3/templates/markdown/general-rules/rules-body.md.jinja
+++ b/v3/templates/markdown/general-rules/rules-body.md.jinja
@@ -35,13 +35,17 @@
 {% endif -%}
 
 {%- if rule.has_facts %}
-{% if rule.token %}- **Places:** {{ rule.token }}
+{% if rule.token %}
+**Places:** {{ rule.token }}
 {% endif -%}
-{%- if rule.phases %}- **Phases:** {{ rule.phases | join(", ") }}
+{%- if rule.phases %}
+**Phases:** {{ rule.phases | join(", ") }}
 {% endif -%}
-{%- if rule.remove %}- **Removed:** {{ rule.remove }}
+{%- if rule.remove %}
+**Removed:** {{ rule.remove }}
 {% endif -%}
-{%- for name, constraint in rule.variables %}- **{{ name }}:** {{ constraint }}
+{%- for name, constraint in rule.variables %}
+**{{ name }}:** {{ constraint }}
 {% endfor -%}
 {% endif -%}
 

--- a/v3/templates/markdown/general-rules/specials.md.jinja
+++ b/v3/templates/markdown/general-rules/specials.md.jinja
@@ -1,0 +1,3 @@
+{#- A structured rules Section: specials render through the shared body partial,
+   which keys its heading depth off whether the Kind groups its rules. -#}
+{% include "general-rules/rules-body.md.jinja" %}

--- a/v3/templates/markdown/general-rules/tokens.md.jinja
+++ b/v3/templates/markdown/general-rules/tokens.md.jinja
@@ -1,0 +1,3 @@
+{#- A structured rules Section: tokens render through the shared body partial,
+   which keys its heading depth off whether the Kind groups its rules. -#}
+{% include "general-rules/rules-body.md.jinja" %}

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -20,12 +20,14 @@ from spf.render.rulebook import (
     Section,
     SectionKind,
     build_rulebook,
+    constraint_text,
     get_kind,
     parse_markdown,
     register_kind,
 )
 from spf.rules import get_rulebook
 from spf.schemas.rulebook import RulebookConfig, SectionConfig
+from spf.schemas.rules import IntVariableConfig, StringVariableConfig
 from tests.conftest import unwrapped
 
 ENGINE = config.render.latex.engine
@@ -103,7 +105,7 @@ def test_markdown_kind_is_registered() -> None:
 
 
 def test_registry_registers_and_looks_up() -> None:
-    kind = SectionKind(name="_probe", parse=lambda path: path.read_text())
+    kind = SectionKind(name="_probe", parse=lambda path, _context: path.read_text())
     try:
         assert register_kind(kind) is kind
         assert get_kind("_probe") is kind
@@ -173,6 +175,30 @@ def test_rules_context_loads_the_tokens_file_once(tmp_path: Path) -> None:
     assert context.token_name("minor_acid") == "Minor Acid"
 
 
+# --- The constraint formatter -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("variable", "expected"),
+    [
+        (IntVariableConfig(type="int", min=1, max=4), "integer, 1-4"),
+        (IntVariableConfig(type="int", values=[2, 4, 6]), "one of 2, 4, 6"),
+        (IntVariableConfig(type="int", min=1), "integer, at least 1"),
+        (IntVariableConfig(type="int", max=6), "integer, at most 6"),
+        (IntVariableConfig(type="int"), "integer"),
+        (
+            StringVariableConfig(type="str", values=["regular", "psychic"]),
+            "one of regular, psychic",
+        ),
+        (StringVariableConfig(type="str"), "text"),
+    ],
+)
+def test_constraint_text_describes_a_variable(
+    variable: IntVariableConfig | StringVariableConfig, expected: str
+) -> None:
+    assert constraint_text(variable) == expected
+
+
 # --- The markdown kind's parser ---------------------------------------------
 
 
@@ -180,7 +206,7 @@ def test_markdown_kind_drops_h1_lines(tmp_path: Path) -> None:
     source = tmp_path / "round.md"
     source.write_text("# The Round\n\nBody text.\n\n## Phases\n", encoding="utf-8")
 
-    body = parse_markdown(source)
+    body = parse_markdown(source, RulesContext(tmp_path))
 
     assert "# The Round" not in body
     assert "Body text." in body
@@ -191,7 +217,7 @@ def test_markdown_kind_keeps_a_hash_that_is_not_a_heading(tmp_path: Path) -> Non
     source = tmp_path / "round.md"
     source.write_text("Roll #1 on the table.\n", encoding="utf-8")
 
-    assert parse_markdown(source) == "Roll #1 on the table.\n"
+    assert parse_markdown(source, RulesContext(tmp_path)) == "Roll #1 on the table.\n"
 
 
 # --- build_rulebook ---------------------------------------------------------
@@ -283,6 +309,26 @@ def test_build_rulebook_rejects_a_missing_source_by_position(tmp_path: Path) -> 
     message = str(excinfo.value)
     assert "section 1" in message
     assert "absent.md" in message
+
+
+def test_build_rulebook_gives_every_parser_a_shared_context(tmp_path: Path) -> None:
+    # One context per build, so a file read for section 1 is not read again for
+    # section 4 — and rooted where the sources are.
+    rules_dir = _rules_dir(tmp_path, {"round.md": "Body.\n", "setup.md": "More.\n"})
+    seen: list[RulesContext] = []
+    kind = SectionKind(name="_probe", parse=lambda _path, context: seen.append(context))
+    register_kind(kind)
+    try:
+        build_rulebook(
+            _index(_section(kind="_probe"), _section(kind="_probe", source="setup.md")),
+            rules_dir=rules_dir,
+        )
+    finally:
+        KINDS.pop("_probe", None)
+
+    first, second = seen
+    assert first is second
+    assert first.rules_dir == rules_dir
 
 
 def test_build_rulebook_accepts_an_empty_index(tmp_path: Path) -> None:

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -411,6 +411,22 @@ def test_specials_kind_resolves_a_token_to_its_display_name(tmp_path: Path) -> N
     assert cunning.description == "Any cunning way to take out armoured units."
 
 
+def test_specials_kind_drops_a_short_that_only_repeats_the_name(
+    tmp_path: Path,
+) -> None:
+    # `short` is the Army Reference's compact override; when it is just the
+    # name again, the Rulebook heading would read "Fumble Fumble".
+    rules_dir = _rules_dir(
+        tmp_path, {"special.toml": SPECIALS_SOURCE, "tokens.toml": TOKENS_SOURCE}
+    )
+
+    body = parse_specials(rules_dir / "special.toml", RulesContext(rules_dir))
+
+    (fumble,) = body.groups[2].rules
+    assert fumble.name == "Fumble"
+    assert fumble.short is None
+
+
 def test_specials_kind_carries_the_versions_map(tmp_path: Path) -> None:
     rules_dir = _rules_dir(
         tmp_path, {"special.toml": SPECIALS_SOURCE, "tokens.toml": TOKENS_SOURCE}

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -665,6 +665,95 @@ def test_render_latex_has_furniture_and_converted_body(
     assert "Dropped by the parser" not in text
 
 
+# --- The structured Kinds' partials, over the real rules files --------------
+
+
+@pytest.fixture
+def real_rulebook() -> Rulebook:
+    """Build the committed Index over the committed sources."""
+    return build_rulebook(get_rulebook(), rules_dir=config.paths.rules)
+
+
+@pytest.fixture
+def real_markdown(tmp_path: Path, real_rulebook: Rulebook) -> str:
+    out = render(
+        GENERAL_RULES,
+        real_rulebook,
+        fmt=get_format("markdown"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+    return out.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def real_latex(tmp_path: Path, real_rulebook: Rulebook) -> str:
+    out = render(
+        GENERAL_RULES,
+        real_rulebook,
+        fmt=get_format("latex"),
+        name="rulebook",
+        output_root=tmp_path,
+    )
+    return out.read_text(encoding="utf-8")
+
+
+def test_markdown_partials_nest_specials_below_their_group(real_markdown: str) -> None:
+    assert "### Assault\n" in real_markdown
+    assert "### Unit\n" in real_markdown
+    assert "### Weapon\n" in real_markdown
+    assert "#### Cunning Assault [{N}]" in real_markdown
+    # Tokens have no groups, so a token rule keeps the shallower level.
+    assert "### Minor Acid\n" in real_markdown
+
+
+def test_markdown_partials_render_the_structured_details(real_markdown: str) -> None:
+    assert "- **Places:** Minor Acid" in real_markdown
+    assert "- **N:** integer, 1-4" in real_markdown
+    assert "- **Phases:** Agony 1" in real_markdown
+    assert "**Example:** If you hit" in real_markdown
+    assert "**Versions**" in real_markdown
+    assert "- **psychic:**" in real_markdown
+    # `hexes.toml`'s document-level prose leads its Section.
+    assert "Hex based effects are triggered" in real_markdown
+
+
+def test_markdown_partials_keep_a_prose_bullet_list_a_list(real_markdown: str) -> None:
+    # `unit.heal`'s explanation is Markdown; its bullets must stay bullets.
+    assert "\n- Extinguish one fire. Cost 3." in real_markdown
+
+
+def test_latex_partials_nest_specials_below_their_group(real_latex: str) -> None:
+    assert r"\section{Special Rules}" in real_latex
+    assert r"\subsection{Assault}" in real_latex
+    assert r"\subsubsection{Cunning Assault [\{N\}]}" in real_latex
+    # Tokens have no groups, so a token rule is a subsection, not a deeper one.
+    assert r"\subsection{Minor Acid}" in real_latex
+
+
+def test_latex_partials_render_the_structured_details(real_latex: str) -> None:
+    assert r"\textbf{Places:} Minor Acid" in real_latex
+    assert r"\textbf{N:} integer, 1-4" in real_latex
+    assert r"\textbf{Phases:} Agony 1" in real_latex
+    assert r"\textbf{Example:} If you hit" in real_latex
+    assert r"\textbf{Versions}" in real_latex
+    assert r"\textbf{psychic:}" in real_latex
+
+
+def test_latex_partials_convert_a_prose_bullet_list(real_latex: str) -> None:
+    assert r"\item Extinguish one fire. Cost 3." in real_latex
+
+
+def test_latex_partials_keep_the_acid_damage_table_verbatim(real_latex: str) -> None:
+    # `tokens.acid.effect` is a tab-indented block, so CommonMark reads it as a
+    # code block and it reaches `verbatim` — which is what preserves its
+    # column alignment. The likeliest place for this output to look wrong.
+    after = real_latex.split(r"\begin{verbatim}", maxsplit=1)[1]
+    table = after.split(r"\end{verbatim}", maxsplit=1)[0]
+    assert "1 : Downgrade from acid to minor acid." in table
+    assert "8 : Roll three times on this table." in table
+
+
 @pytest.mark.skipif(shutil.which(ENGINE) is None, reason=f"{ENGINE} not installed")
 def test_render_the_committed_rulebook_compiles_to_pdf(tmp_path: Path) -> None:
     # The real index over the real sources: the check that authored rules prose

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -13,16 +13,25 @@ from spf.render import render
 from spf.render.formats import get_format
 from spf.render.products import PRODUCTS
 from spf.render.rulebook import (
+    HEXES,
     KINDS,
     MARKDOWN,
+    SPECIALS,
+    TOKENS,
     Rulebook,
+    RuleEntry,
+    RuleGroup,
+    RulesBody,
     RulesContext,
     Section,
     SectionKind,
     build_rulebook,
     constraint_text,
     get_kind,
+    parse_hexes,
     parse_markdown,
+    parse_specials,
+    parse_tokens,
     register_kind,
 )
 from spf.rules import get_rulebook
@@ -218,6 +227,231 @@ def test_markdown_kind_keeps_a_hash_that_is_not_a_heading(tmp_path: Path) -> Non
     source.write_text("Roll #1 on the table.\n", encoding="utf-8")
 
     assert parse_markdown(source, RulesContext(tmp_path)) == "Roll #1 on the table.\n"
+
+
+# --- The tokens kind's parser -----------------------------------------------
+
+FULL_TOKENS_SOURCE = """\
+[tokens]
+
+[tokens.poison]
+name = "Poison"
+short = "[N]"
+phases = ["Agony 3"]
+remove = "When it kills a model"
+effect = \"\"\"Roll a d{N}.
+- Ignore armour
+- Apply the damage
+\"\"\"
+
+[tokens.poison.variables]
+N = { type = "int", values = [2, 4, 6] }
+
+[tokens.terror]
+name = "Terror"
+phases = ["Agony 0"]
+effect = "Acts as if the unit has Terror."
+"""
+
+
+def test_tokens_kind_is_registered() -> None:
+    assert KINDS["tokens"] is TOKENS
+    assert TOKENS.parse is parse_tokens
+
+
+def test_tokens_kind_yields_one_untitled_group_in_file_order(tmp_path: Path) -> None:
+    source = tmp_path / "tokens.toml"
+    source.write_text(FULL_TOKENS_SOURCE, encoding="utf-8")
+
+    body = parse_tokens(source, RulesContext(tmp_path))
+
+    assert isinstance(body, RulesBody)
+    assert body.explanation is None
+    (group,) = body.groups
+    assert isinstance(group, RuleGroup)
+    assert group.title is None
+    assert [rule.name for rule in group.rules] == ["Poison", "Terror"]
+
+
+def test_tokens_kind_carries_every_field_across(tmp_path: Path) -> None:
+    source = tmp_path / "tokens.toml"
+    source.write_text(FULL_TOKENS_SOURCE, encoding="utf-8")
+
+    (group,) = parse_tokens(source, RulesContext(tmp_path)).groups
+    poison, terror = group.rules
+
+    assert isinstance(poison, RuleEntry)
+    assert poison.short == "[N]"
+    assert poison.phases == ["Agony 3"]
+    assert poison.remove == "When it kills a model"
+    assert poison.variables == [("N", "one of 2, 4, 6")]
+    # The effect is Markdown and stays Markdown: its bullets are a real list.
+    assert poison.body.splitlines()[1] == "- Ignore armour"
+    assert poison.token is None
+    assert poison.versions == []
+    assert terror.short is None
+    assert terror.remove is None
+    assert terror.variables == []
+
+
+# --- The hexes kind's parser ------------------------------------------------
+
+HEXES_SOURCE = """\
+explanation = "Hex effects trigger during movement."
+
+[hexes]
+
+[hexes.fog]
+name = "Fog"
+effect = "Blocks line of sight."
+remove = "Remove one Fog per hex in the aftermath phase"
+"""
+
+
+def test_hexes_kind_is_registered() -> None:
+    assert KINDS["hexes"] is HEXES
+    assert HEXES.parse is parse_hexes
+
+
+def test_hexes_kind_keeps_the_document_level_explanation(tmp_path: Path) -> None:
+    # The only one of the three sources with prose above its table.
+    source = tmp_path / "hexes.toml"
+    source.write_text(HEXES_SOURCE, encoding="utf-8")
+
+    body = parse_hexes(source, RulesContext(tmp_path))
+
+    assert body.explanation == "Hex effects trigger during movement."
+    (group,) = body.groups
+    assert group.title is None
+    (fog,) = group.rules
+    assert fog.name == "Fog"
+    assert fog.body == "Blocks line of sight."
+    assert fog.remove == "Remove one Fog per hex in the aftermath phase"
+
+
+# --- The specials kind's parser ---------------------------------------------
+
+SPECIALS_SOURCE = """\
+[assault]
+
+[assault.minor_acid]
+name = "Assault Minor Acid"
+short = "[1 for {N}]"
+explanation = "Targets get one minor acid token for each {N} hits."
+token = "minor_acid"
+
+[assault.minor_acid.variables]
+N = { type = "int", min = 1, max = 4 }
+
+[assault.cunning_assault]
+name = "Cunning Assault"
+short = "[{N}]"
+explanation = "Add +1 to all future damage tokens."
+example = "Hit four times and you add two tokens."
+description = "Any cunning way to take out armoured units."
+
+[unit]
+
+[unit.resistance]
+name = "Resistance"
+short = "{version}[{N}]"
+explanation = "Improved resilience versus {version} damage."
+
+[unit.resistance.versions]
+regular = "Regular damage is reduced by {N}."
+psychic = "Psychic damage is reduced by {N}."
+
+[weapon]
+
+[weapon.fumble]
+name = "Fumble"
+short = "Fumble"
+explanation = "A natural 1 to hit is a fumble."
+"""
+
+
+def test_specials_kind_is_registered() -> None:
+    assert KINDS["specials"] is SPECIALS
+    assert SPECIALS.parse is parse_specials
+
+
+def test_specials_kind_yields_one_titled_group_per_schema_group(
+    tmp_path: Path,
+) -> None:
+    # Where a rule applies is information, so the groups stay groups rather
+    # than being flattened into one alphabetical list.
+    rules_dir = _rules_dir(
+        tmp_path, {"special.toml": SPECIALS_SOURCE, "tokens.toml": TOKENS_SOURCE}
+    )
+
+    body = parse_specials(rules_dir / "special.toml", RulesContext(rules_dir))
+
+    assert body.explanation is None
+    assert [group.title for group in body.groups] == ["Assault", "Unit", "Weapon"]
+    assault, unit, weapon = body.groups
+    assert [rule.name for rule in assault.rules] == [
+        "Assault Minor Acid",
+        "Cunning Assault",
+    ]
+    assert [rule.name for rule in unit.rules] == ["Resistance"]
+    assert [rule.name for rule in weapon.rules] == ["Fumble"]
+
+
+def test_specials_kind_resolves_a_token_to_its_display_name(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(
+        tmp_path, {"special.toml": SPECIALS_SOURCE, "tokens.toml": TOKENS_SOURCE}
+    )
+
+    body = parse_specials(rules_dir / "special.toml", RulesContext(rules_dir))
+
+    acid, cunning = body.groups[0].rules
+    assert acid.token == "Minor Acid"  # noqa: S105  a game Token's name, not a credential
+    assert cunning.token is None
+    assert cunning.example == "Hit four times and you add two tokens."
+    assert cunning.description == "Any cunning way to take out armoured units."
+
+
+def test_specials_kind_carries_the_versions_map(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(
+        tmp_path, {"special.toml": SPECIALS_SOURCE, "tokens.toml": TOKENS_SOURCE}
+    )
+
+    body = parse_specials(rules_dir / "special.toml", RulesContext(rules_dir))
+
+    (resistance,) = body.groups[1].rules
+    assert resistance.versions == [
+        ("regular", "Regular damage is reduced by {N}."),
+        ("psychic", "Psychic damage is reduced by {N}."),
+    ]
+
+
+def test_specials_kind_rejects_an_unresolvable_token(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(
+        tmp_path,
+        {
+            "special.toml": SPECIALS_SOURCE.replace('"minor_acid"', '"minor acid"'),
+            "tokens.toml": TOKENS_SOURCE,
+        },
+    )
+
+    with pytest.raises(ValueError, match=r"unknown token 'minor acid'") as excinfo:
+        parse_specials(rules_dir / "special.toml", RulesContext(rules_dir))
+
+    message = str(excinfo.value)
+    assert "special.toml" in message
+    assert "'minor_acid'" in message  # the rule that carries the bad reference
+    assert "known tokens:" in message
+
+
+def test_specials_kind_parses_the_committed_file() -> None:
+    # The real data: strict resolution means every committed `token =` has to
+    # name a Token that actually exists.
+    body = parse_specials(
+        config.paths.rules / "special.toml", RulesContext(config.paths.rules)
+    )
+
+    tokens = {rule.token for group in body.groups for rule in group.rules if rule.token}
+    assert tokens == {"Minor Acid", "Poison"}
 
 
 # --- build_rulebook ---------------------------------------------------------

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -16,6 +16,7 @@ from spf.render.rulebook import (
     KINDS,
     MARKDOWN,
     Rulebook,
+    RulesContext,
     Section,
     SectionKind,
     build_rulebook,
@@ -115,6 +116,61 @@ def test_unknown_kind_lists_the_known_kinds() -> None:
         ValueError, match=r"Unknown kind 'orders'; known kinds: .*markdown"
     ):
         get_kind("orders")
+
+
+# --- RulesContext -----------------------------------------------------------
+
+TOKENS_SOURCE = """\
+[tokens]
+
+[tokens.minor_acid]
+name = "Minor Acid"
+effect = "Roll a die."
+
+[tokens.poison]
+name = "Poison"
+short = "[N]"
+effect = "Roll a d{N}."
+"""
+
+
+def test_rules_context_resolves_a_token_to_its_display_name(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(tmp_path, {"tokens.toml": TOKENS_SOURCE})
+
+    assert RulesContext(rules_dir).token_name("minor_acid") == "Minor Acid"
+
+
+def test_rules_context_rejects_an_unknown_token_listing_the_known_ones(
+    tmp_path: Path,
+) -> None:
+    rules_dir = _rules_dir(tmp_path, {"tokens.toml": TOKENS_SOURCE})
+
+    with pytest.raises(ValueError, match=r"unknown token 'minor acid'") as excinfo:
+        RulesContext(rules_dir).token_name("minor acid")
+
+    message = str(excinfo.value)
+    assert "known tokens:" in message
+    assert "minor_acid" in message
+    assert "poison" in message
+
+
+def test_rules_context_touches_no_file_until_asked(tmp_path: Path) -> None:
+    # The Index controls what is *rendered*; a Rulebook with no cross-reference
+    # must not need a tokens file to exist at all.
+    context = RulesContext(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        context.token_name("minor_acid")
+
+
+def test_rules_context_loads_the_tokens_file_once(tmp_path: Path) -> None:
+    rules_dir = _rules_dir(tmp_path, {"tokens.toml": TOKENS_SOURCE})
+    context = RulesContext(rules_dir)
+
+    assert context.token_name("poison") == "Poison"
+    (rules_dir / "tokens.toml").unlink()
+
+    assert context.token_name("minor_acid") == "Minor Acid"
 
 
 # --- The markdown kind's parser ---------------------------------------------

--- a/v3/tests/test_rules.py
+++ b/v3/tests/test_rules.py
@@ -1,0 +1,72 @@
+"""Tests for the rules data-access functions."""
+
+from pathlib import Path
+
+from spf import rules
+
+SPECIALS = """\
+[assault]
+
+[assault.probe]
+name = "Probe"
+short = "[N]"
+explanation = "A probe."
+
+[unit]
+
+[weapon]
+"""
+
+TOKENS = """\
+[tokens]
+
+[tokens.probe]
+name = "Probe Token"
+effect = "Nothing happens."
+"""
+
+HEXES = """\
+explanation = "How hexes work."
+
+[hexes]
+
+[hexes.probe]
+name = "Probe Hex"
+effect = "Nothing happens here either."
+"""
+
+
+def test_get_specials_defaults_to_the_committed_file() -> None:
+    assert rules.get_specials().assault
+
+
+def test_get_specials_reads_an_explicit_path(tmp_path: Path) -> None:
+    path = tmp_path / "special.toml"
+    path.write_text(SPECIALS, encoding="utf-8")
+
+    assert rules.get_specials(path).assault["probe"].name == "Probe"
+
+
+def test_get_tokens_defaults_to_the_committed_file() -> None:
+    assert rules.get_tokens().tokens
+
+
+def test_get_tokens_reads_an_explicit_path(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.toml"
+    path.write_text(TOKENS, encoding="utf-8")
+
+    assert rules.get_tokens(path).tokens["probe"].name == "Probe Token"
+
+
+def test_get_hexes_defaults_to_the_committed_file() -> None:
+    assert rules.get_hexes().hexes
+
+
+def test_get_hexes_reads_an_explicit_path(tmp_path: Path) -> None:
+    path = tmp_path / "hexes.toml"
+    path.write_text(HEXES, encoding="utf-8")
+
+    index = rules.get_hexes(path)
+
+    assert index.explanation == "How hexes work."
+    assert index.hexes["probe"].name == "Probe Hex"


### PR DESCRIPTION
Part of #16, continues #21. Implements Plan 2 of the Rulebook work: the three structured Section Kinds — `specials`, `tokens`, `hexes` — against the seam Plan 1 (#75) proved. **No pipeline code changed** beyond one deliberate widening of the parser signature.

## What's here

- **`RulesContext`** — a lazy, cached view over sibling rules files. `SectionKind.parse` widens from `(Path)` to `(Path, RulesContext)`, because **the Index controls what is *rendered*, not what is *loaded***: a Special's `token` has to resolve whether or not a Tokens Section is in the Index. A Rulebook with no cross-references still touches no file its Index did not name.
- **One view-model for all three Kinds** — `RulesBody` → `RuleGroup` → `RuleEntry`. Specials get three titled groups (Assault / Unit / Weapon); tokens and hexes get one untitled group, and hexes carry their file's top-level prose. Entry order is TOML insertion order, so the designer controls it by editing the file.
- **Strict cross-references.** A Special's `token` is resolved to the Token's display name, and an unknown key fails the build naming the rule and listing the known Tokens. This immediately caught `rules/special.toml`'s `token = "minor acid"` (a space) — fixed to `minor_acid`. Spelling fix, no intent change, so **no `rules/changelog.md` entry** per CONTEXT.md.
- **Six partials**, each a one-line include of a shared `rules-body` partial per family — the per-Kind file stays as the seam where the shapes will diverge.
- Index grows three sections; `spf rules rulebook` lists all four. ADR 0018 and CONTEXT.md updated.
- `rules.get_specials/get_tokens/get_hexes` gain an optional `path`.

## Things to look at

**1. `tokens.acid`'s damage table renders as `verbatim`.** It is tab-indented, so CommonMark reads it as a code block. That *preserves the column alignment*, which is why it looks right, but it is monospace in a proseface document and pdflatex reports no overfull boxes:

```
Roll a d8 on the following damage table:,

\begin{verbatim}
		 1 : Downgrade from acid to minor acid.
		 2 : +1 to future damage
		 ...
		 8 : Roll three times on this table.,
\end{verbatim}
```

Worth deciding whether this wants to become a real table (a `table` Kind, or a tabular damage-table shape) rather than preformatted text.

**2. ⚠️ `Terror[6](range=2)` in `tokens.toml` is being eaten as a Markdown link.** One occurrence repo-wide. CommonMark reads `[6](range=2)` as a link, so:
- LaTeX prints **`Acts as if unit has Terror6 but effects only…`** — `(range=2)` silently gone
- HTML makes it `Terror<a href="range=2">6</a>`
- plain Markdown keeps the literal text

I did not touch it: it is rule content, not a broken reference, and the fix is a design call — escape it in the data (`Terror\[6\](range=2)`), or stop `md_to_latex`/`md_to_html` treating rules prose as full Markdown. Flagging rather than choosing.

**3. Two layout choices that differ from the plan**, both visible in the output:
- The plan sketched *italic* for `description` and a *blockquote* for `example`. Both partials use bold run-in labels instead (`**Represents:** …`, `**Example:** …`), because wrapping arbitrary multi-paragraph Markdown in an emphasis span breaks it. Easy to change if you prefer the italic/quote look.
- A `short` that only repeats the name is dropped, so headings read "Fumble", not "Fumble Fumble". Not asked for; revert if you'd rather see the raw data. Note this does *not* catch `unit.immunity`, whose `short = "Immunity [feature]"` still renders as **"Immunity Immunity [feature]"** — that one is data worth cleaning.

**4. Section ordering** is Hexes → Tokens → Special Rules, so a Special's token reference points at something the reader has already met. One-line edit in `rules/rulebook.toml` if you want it otherwise.

**5. I could not open the PDF.** No poppler in this environment, so I verified against the Markdown, the HTML, the generated LaTeX, and a clean pdflatex run (12 pages, zero overfull boxes) rather than by eye. The bullet lists in `unit.heal`/`unit.repair` do become real `itemize` lists, and the four `token =` references print display names. Please give the PDF a look.

## Checks

`just check` green (539 tests, ruff, pyright, typos, `spf rules rulebook`). Reviewed with `/code-review`; acted on its two substantive findings — heading depth and the "has facts" predicate moved out of the templates into the view-model (ADR 0005 keeps templates dumb), and the token-resolution parameter clump split out of `_special_entry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
