### PR TITLE
Replace remaining references to smoke with fog

### DIFF
--- a/v3/races/abomination.toml
+++ b/v3/races/abomination.toml
@@ -550,7 +550,7 @@ equipment = ["multipurpose_gun"]
 type = ["Bio", "Infantry", "Walking", "Amphibian"]
 
 [models.abomination_infantry.special]
-"Fog" = "Double to-hit penalties in smoke/fog and ignore to-hit penalty for enemies in smoke/fog. (however does not ignore line of sight through smoke/fog) hexes."
+"Fog" = "Double to-hit penalties in fog and ignore to-hit penalty for enemies in fog. (however does not ignore line of sight through fog hexes)"
 
 [models.abomination_infantry.assault]
 strength = [1, 1, 1, 1]
@@ -711,7 +711,7 @@ equipment_limit = ["Independent:∞"]
 type = ["Vehicle", "Mechanical", "Tracked", "Bio Crew"]
 
 [models.frost_88.special]
-"Fog" = "Double to-hit penalties in smoke/fog and ignore to-hit penalty for enemies in smoke/fog. (however does not ignore line of sight through smoke/fog hexes)"
+"Fog" = "Double to-hit penalties in fog and ignore to-hit penalty for enemies in fog. (however does not ignore line of sight through fog hexes)"
 "To Hit" = "Double to-hit bonuses and penalties for movement speed, both for you and the target"
 
 
@@ -974,9 +974,9 @@ ap = "N/A"
 
 [equipment.fog_grenade_mortar.range.special]
 
-"Cloud" = "Place two smoke tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
+"Cloud" = "Place two fog tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
 
-"Ammo" = "May start the game without ammo, but instead place two smoke tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
+"Ammo" = "May start the game without ammo, but instead place two fog tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
 
 
 [equipment.long_range_fog_grenade_mortar]
@@ -994,9 +994,9 @@ ap = "N/A"
 
 [equipment.long_range_fog_grenade_mortar.range.special]
 
-"Cloud" = "Place two smoke tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
+"Cloud" = "Place two fog tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
 
-"Ammo" = "May start the game without ammo, but instead place two smoke tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
+"Ammo" = "May start the game without ammo, but instead place two fog tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
 
 [equipment.multipurpose_mortar]
 name = "Multipurpose Mortar"

--- a/v3/races/changelog.md
+++ b/v3/races/changelog.md
@@ -5,6 +5,7 @@ A record of deliberate balance changes to the Race data in `races/`. It captures
 
 | Date       | Race         | Description                                                                 | Why                                                                                  |
 | ---------- | ------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 05.08.2026 | Abomination, Gnome | Replaced remaining references to smoke with fog                       | Smoke was never a hex type; fog is the only one that exists, so the references were dead |
 | 05.08.2026 | All          | Replaced Chase with Chs on all order cards                                  | To save space                                                                        |
 | 28.07.2026 | Ork          | Negative vpm to elite infantry, positive to champion                        | Moved victorypoints for elite in an infantry to killing the champion instead         |
 | 27.07.2026 | All          | Introduced optional order () in a lot of units, mostly tanks                | Reduced the number of order cards and makes it easier to find a specific card        |

--- a/v3/races/gnome.toml
+++ b/v3/races/gnome.toml
@@ -302,7 +302,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
+	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 
@@ -361,7 +361,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
+	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 
@@ -423,7 +423,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and smoke in this and all adjacent hexes.",
+	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 

--- a/v3/rules/round.md
+++ b/v3/rules/round.md
@@ -38,7 +38,7 @@ silently; you never lose a later Phase by skipping an earlier one.
 - **Agony 3** — poison. Apply damage.
 - **Agony 4** — bleeding. Apply damage.
 - **Healing and repair 2** — the second restoration window.
-- **Aftermath** — remove smoke, clear expired markers, reveal what the Round
+- **Aftermath** — remove fog, clear expired markers, reveal what the Round
   uncovered.
 
 ---


### PR DESCRIPTION
Closes #77

`smoke` was never a hex type — `rules/hexes.toml` declares `[hexes.fog]` and there is no `Smoke` type alias — so the 13 remaining occurrences were dangling references to a token that does not exist.

- `races/gnome.toml` (3 crew-damage rows) — `and smoke in this` → `and Fog in this`, matching the capitalised `Poison Cloud[8]` beside it.
- `races/abomination.toml` — the two `smoke/fog` model specials take the canonical wording already used by their twins at `:671`/`:768`, which also fixes a misplaced closing paren on `:553`. All four `"Fog"` specials are now byte-identical.
- `races/abomination.toml` — the fog grenade mortars now place `fog tokens`, matching the phrasing in `ork.toml:1296` and their own equipment names.
- `rules/round.md:41` — Aftermath now says "remove fog", agreeing with `detailed_view.md` and `overveiw_round.md`.
- One row in `races/changelog.md`.

No Python, schema, or rendered-artifact changes. `just check` passes (537 tests, pyright clean); `grep -rin smoke` over `*.toml` and `rules/` is empty.

Deliberately out of scope: the `fog[4]` strength inconsistency at `abomination.toml:1012,1074,1090` — a rules question, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ffq5XbjMhjHQ21R2feXpek