### PR TITLE
Nicks on Units and Models

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -131,7 +131,7 @@ A marker tracking transient state on a Unit or Model (bleeding, poison, +1
 future damage, …), placed and removed in specific Phases.
 
 **Nick**:
-The player-chosen name of an Army instance.
+The player-chosen name of an Army, Unit, or Model instance.
 _Avoid_: nickname, label, title
 
 ### Game-data maintenance

--- a/v3/docs/adr/0019-nick-participates-in-the-collapse-key.md
+++ b/v3/docs/adr/0019-nick-participates-in-the-collapse-key.md
@@ -1,0 +1,69 @@
+# A Nick participates in the collapse key, with no special-casing
+
+A Nick used to name one thing: an Army. Extending it to Unit and Model
+instances puts it in front of two pieces of machinery that already decide when
+two instances are "the same thing" — `_collapse_units` in
+`spf.render.army_rules`, which merges identical `UnitEntry`s into
+`Ork Infantry (3×)`, and the dedup key in `spf.render.cards.build_deck`, which
+stops a Unit from printing the same order card twice.
+
+Both keys are built from the rendered name. So the question is not *whether* a
+Nick reaches them — it does, the moment a nicked instance renders — but whether
+they should be taught to ignore it.
+
+## The Nick is part of the name, and the name is part of the key
+
+**Decision: the Nick enters `UnitEntry.name`, `ModelEntry.name`, and the
+`build_deck` dedup key through one `display_name` property — `self.nick or
+self.config.name` — and the collapse rules see it as they see any other name.
+No branch anywhere asks "is this a Nick?".**
+
+That single definition of the fallback is what makes the rest fall out:
+
+- Identical un-nicked Units still collapse to `Ork Infantry (3×)`. No
+  regression, and `_collapse_units` and `build_deck` are unchanged.
+- Differently-nicked Units each get their own entry and their own card set.
+  That is the point of having nicked them: you named them to tell them apart at
+  the table, so each one gets a card to put beside its models.
+- Identical Units sharing a Nick collapse to `Boyz (2×)` — a legitimate way to
+  name a pair as one formation.
+
+The same rule holds a level down: `model_summary` becomes
+`["1x Grubnak", "3x Ork Infantry"]`, and a nicked Model gets its own
+`ModelEntry` block even when its stats are identical to its squadmates'.
+
+A Nick **replaces** the catalogue name outright — there is no
+`Boyz (Ork Infantry)` parenthetical. The army-rules document is self-contained,
+and the model summary line still reveals what the Unit is made of.
+
+## Alternatives rejected
+
+**Collapse on catalogue identity and list the Nicks inside the merged entry.**
+Fewer pages, and the army-rules document would still name every Unit. But an
+order card carries one name, so under this rule a Nick could never appear on a
+card at all — and a card you cannot match to the models in front of you is the
+thing the Nick existed to fix.
+
+**Strip the Nick from the key but keep it in the rendered name.** Two entries
+that collapse to one would then disagree about what to print, and the merged
+entry would have to pick a winner. A key that ignores what it renders is a bug
+waiting for its first duplicate.
+
+## Consequences
+
+- **Nicking costs pages and cards.** An army with three differently-nicked
+  copies of one Unit prints three Unit entries and three card sets where it used
+  to print one. This is accepted: the player asked for the distinction.
+- **A Nick belongs to the slot, not the model type.** `upgrade_model` and
+  `upgrade_unit` both preserve it, so a nicked Model promoted to an upgrade
+  model keeps its Nick even though `upgrade_unit` resets `upgrades=[]` — that
+  reset exists for a rules reason, and a Nick carries no rules weight.
+- **A duplicate is un-nicked**, at Unit *and* Model level: a Nick names one
+  instance, so it does not travel with a copy. `duplicate_unit(nick=…)` names
+  the copy in the same call.
+- **Addressing is untouched.** Instances are still addressed by
+  `(toml_key, occurrence)`, and Image Assets are still looked up by TOML key.
+  Nicking changes what renders, never what resolves.
+- **Old army JSON needs no migration**: a Nick is omitted from the file when
+  unset and read back with `.get`, so the committed armies regenerate
+  byte-identically.

--- a/v3/src/spf/armies/build.py
+++ b/v3/src/spf/armies/build.py
@@ -51,12 +51,7 @@ class ArmyModel:
                 f" by model '{self.name}': {detail}"
             )
             raise ValueError(msg)
-        return self.__class__(
-            name=self.name,
-            config=self.config,
-            upgrades=[*self.upgrades, equipment_name],
-            nick=self.nick,
-        )
+        return replace(self, upgrades=[*self.upgrades, equipment_name])
 
 
 @dataclass(frozen=True)
@@ -83,9 +78,7 @@ class ArmyUnit:
             new_model,
             *self.models[model_idx + 1 :],
         ]
-        return self.__class__(
-            name=self.name, config=self.config, models=new_models, nick=self.nick
-        )
+        return replace(self, models=new_models)
 
     def upgrade_unit(
         self,
@@ -122,9 +115,7 @@ class ArmyUnit:
             new_model,
             *self.models[model_idx + 1 :],
         ]
-        return self.__class__(
-            name=self.name, config=self.config, models=new_models, nick=self.nick
-        )
+        return replace(self, models=new_models)
 
     def nick_model(
         self, model_key: tuple[t.ModelName, int], *, nick: str | None
@@ -137,9 +128,7 @@ class ArmyUnit:
             replace(model, nick=nick),
             *self.models[model_idx + 1 :],
         ]
-        return self.__class__(
-            name=self.name, config=self.config, models=new_models, nick=self.nick
-        )
+        return replace(self, models=new_models)
 
 
 @dataclass(frozen=True)
@@ -165,9 +154,7 @@ class ArmyList:
         new_unit = _make_default_army_unit(
             unit_name, nick=nick, race_config=race_config
         )
-        return self.__class__(
-            race=self.race, nick=self.nick, units=[*self.units, new_unit]
-        )
+        return replace(self, units=[*self.units, new_unit])
 
     def upgrade_unit(
         self,
@@ -185,7 +172,7 @@ class ArmyList:
             race_config=race_config,
         )
         new_units = [*self.units[:unit_idx], new_unit, *self.units[unit_idx + 1 :]]
-        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+        return replace(self, units=new_units)
 
     def upgrade_model(
         self,
@@ -201,7 +188,7 @@ class ArmyList:
             model_key=model_key, equipment_name=equipment_name, race_config=race_config
         )
         new_units = [*self.units[:unit_idx], new_unit, *self.units[unit_idx + 1 :]]
-        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+        return replace(self, units=new_units)
 
     def upgrade_full_unit(
         self,
@@ -266,7 +253,7 @@ class ArmyList:
             replace(unit, nick=nick),
             *self.units[unit_idx + 1 :],
         ]
-        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+        return replace(self, units=new_units)
 
     def nick_model(
         self,
@@ -276,10 +263,13 @@ class ArmyList:
         nick: str | None,
     ) -> Self:
         """Return a new ArmyList with one model slot's Nick set."""
+        # Checked before resolving, so a bad nick and a bad key raise the same
+        # way here as they do in `nick_unit`.
+        _check_nick(nick)
         unit_idx, unit = _resolve_unit(self, unit_key=unit_key)
         new_unit = unit.nick_model(model_key=model_key, nick=nick)
         new_units = [*self.units[:unit_idx], new_unit, *self.units[unit_idx + 1 :]]
-        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+        return replace(self, units=new_units)
 
     def duplicate_unit(
         self,
@@ -301,9 +291,7 @@ class ArmyList:
             models=[replace(model, nick=None) for model in unit.models],
             nick=nick,
         )
-        return self.__class__(
-            race=self.race, nick=self.nick, units=[*self.units, new_unit]
-        )
+        return replace(self, units=[*self.units, new_unit])
 
     def delete_unit(
         self,
@@ -312,7 +300,7 @@ class ArmyList:
         """Remove a unit from the army list."""
         unit_idx, _ = _resolve_unit(self, unit_key=unit_key)
         new_units = [*self.units[:unit_idx], *self.units[unit_idx + 1 :]]
-        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+        return replace(self, units=new_units)
 
     def resolve(self, race_config: RaceConfig) -> "Army":
         """Return a fully resolved Army with all equipment configs populated.
@@ -407,9 +395,18 @@ def _make_default_army_unit(
     return ArmyUnit(name=unit_name, config=unit_config, models=models, nick=nick)
 
 
+def is_empty_nick(nick: object) -> bool:
+    """Is this a present-but-empty Nick? Absent (`None`) means "no Nick" and is fine.
+
+    Takes `object` because the load path checks raw JSON values against the same
+    rule the builder API enforces.
+    """
+    return nick is not None and not str(nick).strip()
+
+
 def _check_nick(nick: str | None) -> None:
     """Reject an empty or whitespace-only Nick. `None` means "no Nick" and is fine."""
-    if nick is not None and not nick.strip():
+    if is_empty_nick(nick):
         msg = "Nick cannot be empty; use None for no nick"
         raise ValueError(msg)
 

--- a/v3/src/spf/armies/build.py
+++ b/v3/src/spf/armies/build.py
@@ -22,6 +22,7 @@ class ArmyModel:
     name: str
     config: ModelConfig = field(repr=False)
     upgrades: list[str]
+    nick: str | None = None
 
     def upgrade(self, equipment_name: str, *, race_config: RaceConfig) -> Self:
         """Return a new ArmyModel with the given equipment upgrade added.
@@ -54,6 +55,7 @@ class ArmyModel:
             name=self.name,
             config=self.config,
             upgrades=[*self.upgrades, equipment_name],
+            nick=self.nick,
         )
 
 
@@ -64,6 +66,7 @@ class ArmyUnit:
     name: str
     config: UnitConfig = field(repr=False)
     models: list[ArmyModel]
+    nick: str | None = None
 
     def upgrade_model(
         self,
@@ -80,7 +83,9 @@ class ArmyUnit:
             new_model,
             *self.models[model_idx + 1 :],
         ]
-        return self.__class__(name=self.name, config=self.config, models=new_models)
+        return self.__class__(
+            name=self.name, config=self.config, models=new_models, nick=self.nick
+        )
 
     def upgrade_unit(
         self,
@@ -103,15 +108,23 @@ class ArmyUnit:
                 f"not listed in its replaces field"
             )
             raise ValueError(msg)
+        # A Nick belongs to the slot, not the model type: the promoted model keeps
+        # it even though `upgrades` resets (that reset exists for a rules reason,
+        # and a Nick carries no rules weight).
         new_model = ArmyModel(
-            name=upgrade_model_name, config=upgrade_config, upgrades=[]
+            name=upgrade_model_name,
+            config=upgrade_config,
+            upgrades=[],
+            nick=existing.nick,
         )
         new_models = [
             *self.models[:model_idx],
             new_model,
             *self.models[model_idx + 1 :],
         ]
-        return self.__class__(name=self.name, config=self.config, models=new_models)
+        return self.__class__(
+            name=self.name, config=self.config, models=new_models, nick=self.nick
+        )
 
 
 @dataclass(frozen=True)
@@ -122,12 +135,21 @@ class ArmyList:
     nick: str
     units: list[ArmyUnit]
 
-    def add_unit(self, unit_name: t.UnitName, *, race_config: RaceConfig) -> Self:
+    def add_unit(
+        self,
+        unit_name: t.UnitName,
+        *,
+        nick: str | None = None,
+        race_config: RaceConfig,
+    ) -> Self:
         """Return a new ArmyList with the given unit appended at its default state."""
         if unit_name not in race_config.units:
             msg = f"Unknown unit '{unit_name}'"
             raise ValueError(msg)
-        new_unit = _make_default_army_unit(unit_name, race_config=race_config)
+        _check_nick(nick)
+        new_unit = _make_default_army_unit(
+            unit_name, nick=nick, race_config=race_config
+        )
         return self.__class__(
             race=self.race, nick=self.nick, units=[*self.units, new_unit]
         )
@@ -262,9 +284,11 @@ class ArmyList:
                         upgrade_equipment=[
                             race_config.equipment[eq] for eq in army_model.upgrades
                         ],
+                        nick=army_model.nick,
                     )
                     for army_model in army_unit.models
                 ],
+                nick=army_unit.nick,
             )
             for army_unit in self.units
         ]
@@ -317,14 +341,21 @@ def _make_default_army_model(
 
 
 def _make_default_army_unit(
-    unit_name: t.UnitName, *, race_config: RaceConfig
+    unit_name: t.UnitName, *, nick: str | None = None, race_config: RaceConfig
 ) -> ArmyUnit:
     unit_config = race_config.units[unit_name]
     models = [
         _make_default_army_model(model_name, race_config=race_config)
         for model_name in unit_config.models
     ]
-    return ArmyUnit(name=unit_name, config=unit_config, models=models)
+    return ArmyUnit(name=unit_name, config=unit_config, models=models, nick=nick)
+
+
+def _check_nick(nick: str | None) -> None:
+    """Reject an empty or whitespace-only Nick. `None` means "no Nick" and is fine."""
+    if nick is not None and not nick.strip():
+        msg = "Nick cannot be empty; use None for no nick"
+        raise ValueError(msg)
 
 
 def _remaining_slots(
@@ -484,6 +515,7 @@ def validate_army(army: ArmyList, *, race_config: RaceConfig) -> list[str]:
                         name=team_model.name,
                         config=team_model.config,
                         upgrades=team_model.upgrades[:j],
+                        nick=team_model.nick,
                     )
                     failed = _unsatisfied_groups(
                         equip.requires, model=partial_model, race_config=race_config

--- a/v3/src/spf/armies/build.py
+++ b/v3/src/spf/armies/build.py
@@ -121,7 +121,7 @@ class ArmyUnit:
         self, model_key: tuple[t.ModelName, int], *, nick: str | None
     ) -> Self:
         """Return a new ArmyUnit with the identified model slot's Nick set."""
-        _check_nick(nick)
+        check_nick(nick)
         model_idx, model = _resolve_model(self, model_key=model_key)
         new_models = [
             *self.models[:model_idx],
@@ -150,7 +150,7 @@ class ArmyList:
         if unit_name not in race_config.units:
             msg = f"Unknown unit '{unit_name}'"
             raise ValueError(msg)
-        _check_nick(nick)
+        check_nick(nick)
         new_unit = _make_default_army_unit(
             unit_name, nick=nick, race_config=race_config
         )
@@ -246,7 +246,7 @@ class ArmyList:
         Nicking never changes how anything is addressed: the unit keeps its
         `(toml_key, occurrence)` key.
         """
-        _check_nick(nick)
+        check_nick(nick)
         unit_idx, unit = _resolve_unit(self, unit_key=unit_key)
         new_units = [
             *self.units[:unit_idx],
@@ -265,7 +265,7 @@ class ArmyList:
         """Return a new ArmyList with one model slot's Nick set."""
         # Checked before resolving, so a bad nick and a bad key raise the same
         # way here as they do in `nick_unit`.
-        _check_nick(nick)
+        check_nick(nick)
         unit_idx, unit = _resolve_unit(self, unit_key=unit_key)
         new_unit = unit.nick_model(model_key=model_key, nick=nick)
         new_units = [*self.units[:unit_idx], new_unit, *self.units[unit_idx + 1 :]]
@@ -283,7 +283,7 @@ class ArmyList:
         instance, so it does not travel with a duplicate. Pass `nick=` to name
         the copy in the same call.
         """
-        _check_nick(nick)
+        check_nick(nick)
         _, unit = _resolve_unit(self, unit_key=unit_key)
         new_unit = ArmyUnit(
             name=unit.name,
@@ -395,19 +395,25 @@ def _make_default_army_unit(
     return ArmyUnit(name=unit_name, config=unit_config, models=models, nick=nick)
 
 
-def is_empty_nick(nick: object) -> bool:
-    """Is this a present-but-empty Nick? Absent (`None`) means "no Nick" and is fine.
+def nick_error(nick: object) -> str | None:
+    """Why this Nick is invalid, or `None` if it is fine.
+
+    The single authority on what makes a Nick valid. `check_nick` raises what this
+    returns; the load path folds it into its error list instead. A new rule added
+    here therefore reaches both callers, and phrases itself once.
 
     Takes `object` because the load path checks raw JSON values against the same
-    rule the builder API enforces.
+    rule the builder API enforces. An absent Nick (`None`) means "no Nick" and is
+    always fine.
     """
-    return nick is not None and not str(nick).strip()
+    if nick is not None and not str(nick).strip():
+        return "Nick cannot be empty or whitespace-only"
+    return None
 
 
-def _check_nick(nick: str | None) -> None:
-    """Reject an empty or whitespace-only Nick. `None` means "no Nick" and is fine."""
-    if is_empty_nick(nick):
-        msg = "Nick cannot be empty; use None for no nick"
+def check_nick(nick: str | None) -> None:
+    """Raise `ValueError` if the Nick is invalid. `None` means "no Nick" and is fine."""
+    if msg := nick_error(nick):
         raise ValueError(msg)
 
 

--- a/v3/src/spf/armies/build.py
+++ b/v3/src/spf/armies/build.py
@@ -5,7 +5,7 @@ They carry config references for validation but are not self-contained.
 Call ArmyList.resolve(race_config) to obtain a fully resolved Army.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Self
 
 from spf.schemas import type_aliases as t
@@ -126,6 +126,21 @@ class ArmyUnit:
             name=self.name, config=self.config, models=new_models, nick=self.nick
         )
 
+    def nick_model(
+        self, model_key: tuple[t.ModelName, int], *, nick: str | None
+    ) -> Self:
+        """Return a new ArmyUnit with the identified model slot's Nick set."""
+        _check_nick(nick)
+        model_idx, model = _resolve_model(self, model_key=model_key)
+        new_models = [
+            *self.models[:model_idx],
+            replace(model, nick=nick),
+            *self.models[model_idx + 1 :],
+        ]
+        return self.__class__(
+            name=self.name, config=self.config, models=new_models, nick=self.nick
+        )
+
 
 @dataclass(frozen=True)
 class ArmyList:
@@ -237,6 +252,34 @@ class ArmyList:
                 race_config=race_config,
             )
         return result
+
+    def nick_unit(self, unit_key: tuple[t.UnitName, int], *, nick: str | None) -> Self:
+        """Return a new ArmyList with the identified unit's Nick set.
+
+        Nicking never changes how anything is addressed: the unit keeps its
+        `(toml_key, occurrence)` key.
+        """
+        _check_nick(nick)
+        unit_idx, unit = _resolve_unit(self, unit_key=unit_key)
+        new_units = [
+            *self.units[:unit_idx],
+            replace(unit, nick=nick),
+            *self.units[unit_idx + 1 :],
+        ]
+        return self.__class__(race=self.race, nick=self.nick, units=new_units)
+
+    def nick_model(
+        self,
+        unit_key: tuple[t.UnitName, int],
+        *,
+        model_key: tuple[t.ModelName, int],
+        nick: str | None,
+    ) -> Self:
+        """Return a new ArmyList with one model slot's Nick set."""
+        unit_idx, unit = _resolve_unit(self, unit_key=unit_key)
+        new_unit = unit.nick_model(model_key=model_key, nick=nick)
+        new_units = [*self.units[:unit_idx], new_unit, *self.units[unit_idx + 1 :]]
+        return self.__class__(race=self.race, nick=self.nick, units=new_units)
 
     def duplicate_unit(
         self,

--- a/v3/src/spf/armies/build.py
+++ b/v3/src/spf/armies/build.py
@@ -284,10 +284,23 @@ class ArmyList:
     def duplicate_unit(
         self,
         unit_key: tuple[t.UnitName, int],
+        *,
+        nick: str | None = None,
     ) -> Self:
-        """Add a copy of an existing unit to the army list."""
+        """Add a copy of an existing unit to the army list.
+
+        The copy is un-nicked at unit *and* model level — a Nick names one
+        instance, so it does not travel with a duplicate. Pass `nick=` to name
+        the copy in the same call.
+        """
+        _check_nick(nick)
         _, unit = _resolve_unit(self, unit_key=unit_key)
-        new_unit = ArmyUnit(name=unit.name, config=unit.config, models=unit.models)
+        new_unit = ArmyUnit(
+            name=unit.name,
+            config=unit.config,
+            models=[replace(model, nick=None) for model in unit.models],
+            nick=nick,
+        )
         return self.__class__(
             race=self.race, nick=self.nick, units=[*self.units, new_unit]
         )

--- a/v3/src/spf/armies/io.py
+++ b/v3/src/spf/armies/io.py
@@ -75,13 +75,13 @@ def print_army(army: Army) -> None:
         cost = unit.cost()
         pts = cost.to_points()
         stdout.print(
-            f"[bold]{unit.config.name}[/] - {cost} [yellow]({pts} pts)[/]",
+            f"[bold]{unit.display_name}[/] - {cost} [yellow]({pts} pts)[/]",
             highlight=False,
         )
         for model in unit.models:
             equip_names = [e.name for e in model.equipment]
             equip_str = f" ({', '.join(equip_names)})" if equip_names else ""
-            stdout.print(f"  - {model.name}{equip_str}", highlight=False)
+            stdout.print(f"  - {model.display_name}{equip_str}", highlight=False)
     cost = army.cost()
     stdout.print(f"\n[dim]Total cost:[/]  {cost}", highlight=False)
 
@@ -91,7 +91,7 @@ def print_army_rules(army: Army) -> None:
     stdout.rule(f"{army.nick} — {army.race.title()} Army")
     for unit in army.units:
         stdout.print(
-            f"- [yellow]{unit.config.name}[/] - {unit.cost()}", highlight=False
+            f"- [yellow]{unit.display_name}[/] - {unit.cost()}", highlight=False
         )
         if unit.unit_specials:
             stdout.print("  - [dim]Specials:[/]", highlight=False)
@@ -100,7 +100,7 @@ def print_army_rules(army: Army) -> None:
         for model in unit.models:
             model_pts = model.cost().to_points()
             cost_str = f" ({model_pts} pts)" if model_pts else ""
-            stdout.print(f"  - {model.name}{cost_str}", highlight=False)
+            stdout.print(f"  - {model.display_name}{cost_str}", highlight=False)
             if model.model_specials:
                 stdout.print("    - [dim]Specials:[/]", highlight=False)
             for key, special in model.model_specials.items():

--- a/v3/src/spf/armies/io.py
+++ b/v3/src/spf/armies/io.py
@@ -9,7 +9,7 @@ from spf.armies.build import (
     ArmyList,
     ArmyModel,
     ArmyUnit,
-    is_empty_nick,
+    nick_error,
     validate_army,
 )
 from spf.config import config
@@ -30,8 +30,6 @@ def save_army(army: ArmyList, *, army_name: str, tournament: str | None = None) 
     data: dict[str, Any] = {
         "race": army.race,
         "nick": army.nick,
-        # A Nick is omitted entirely when unset, so army files written before
-        # nicks existed round-trip byte-identically.
         "units": [
             {
                 "name": unit.name,
@@ -48,7 +46,7 @@ def save_army(army: ArmyList, *, army_name: str, tournament: str | None = None) 
             for unit in army.units
         ],
     }
-    path.write_text(json.dumps(data, indent=2))
+    path.write_text(json.dumps(data, indent=2) + "\n")
 
 
 def load_army(
@@ -142,8 +140,8 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
         if unit_name not in cfg.units:
             errors.append(f"Unit #{unit_idx} (name {unit_name!r}): unknown unit name")
             continue
-        if is_empty_nick(unit_data.get("nick")):
-            errors.append(f"Unit #{unit_idx} ({unit_name!r}): empty nick")
+        if unit_nick_error := nick_error(unit_data.get("nick")):
+            errors.append(f"Unit #{unit_idx} ({unit_name!r}): {unit_nick_error}")
         for model_idx, model_data in enumerate(unit_data["models"]):
             model_name = model_data["name"]
             if model_name not in cfg.models:
@@ -152,10 +150,10 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
                     f" (name {model_name!r}): unknown model name"
                 )
                 continue
-            if is_empty_nick(model_data.get("nick")):
+            if model_nick_error := nick_error(model_data.get("nick")):
                 errors.append(
                     f"Unit #{unit_idx} ({unit_name!r}) / model #{model_idx}"
-                    f" ({model_name!r}): empty nick"
+                    f" ({model_name!r}): {model_nick_error}"
                 )
             errors.extend(
                 f"Unit #{unit_idx} ({unit_name!r}) / model #{model_idx}"

--- a/v3/src/spf/armies/io.py
+++ b/v3/src/spf/armies/io.py
@@ -24,11 +24,18 @@ def save_army(army: ArmyList, *, army_name: str, tournament: str | None = None) 
     data: dict[str, Any] = {
         "race": army.race,
         "nick": army.nick,
+        # A Nick is omitted entirely when unset, so army files written before
+        # nicks existed round-trip byte-identically.
         "units": [
             {
                 "name": unit.name,
+                **({"nick": unit.nick} if unit.nick is not None else {}),
                 "models": [
-                    {"name": model.name, "upgrades": list(model.upgrades)}
+                    {
+                        "name": model.name,
+                        "upgrades": list(model.upgrades),
+                        **({"nick": model.nick} if model.nick is not None else {}),
+                    }
                     for model in unit.models
                 ],
             }
@@ -129,6 +136,8 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
         if unit_name not in cfg.units:
             errors.append(f"Unit #{unit_idx} (name {unit_name!r}): unknown unit name")
             continue
+        if _is_empty_nick(unit_data.get("nick")):
+            errors.append(f"Unit #{unit_idx} ({unit_name!r}): empty nick")
         for model_idx, model_data in enumerate(unit_data["models"]):
             model_name = model_data["name"]
             if model_name not in cfg.models:
@@ -137,6 +146,11 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
                     f" (name {model_name!r}): unknown model name"
                 )
                 continue
+            if _is_empty_nick(model_data.get("nick")):
+                errors.append(
+                    f"Unit #{unit_idx} ({unit_name!r}) / model #{model_idx}"
+                    f" ({model_name!r}): empty nick"
+                )
             errors.extend(
                 f"Unit #{unit_idx} ({unit_name!r}) / model #{model_idx}"
                 f" ({model_name!r}): unknown equipment {upgrade!r}"
@@ -144,6 +158,15 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
                 if upgrade not in cfg.equipment
             )
     return errors
+
+
+def _is_empty_nick(nick: object) -> bool:
+    """Is this a present-but-empty Nick? Absent (`None`) means "no Nick" and is fine.
+
+    Load is strict (ADR 0004), so `""` is rejected here as it is in the builder
+    API rather than silently loading as a Nick that renders as nothing.
+    """
+    return nick is not None and not str(nick).strip()
 
 
 def _build_army_list(data: dict[str, Any], *, cfg: RaceConfig) -> ArmyList:
@@ -161,9 +184,11 @@ def _build_army_list(data: dict[str, Any], *, cfg: RaceConfig) -> ArmyList:
                     name=model_data["name"],
                     config=cfg.models[model_data["name"]],
                     upgrades=list(model_data["upgrades"]),
+                    nick=model_data.get("nick"),
                 )
                 for model_data in unit_data["models"]
             ],
+            nick=unit_data.get("nick"),
         )
         for unit_data in data["units"]
     ]

--- a/v3/src/spf/armies/io.py
+++ b/v3/src/spf/armies/io.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import Any
 
 from spf.armies.army import Army
-from spf.armies.build import ArmyList, ArmyModel, ArmyUnit, validate_army
+from spf.armies.build import (
+    ArmyList,
+    ArmyModel,
+    ArmyUnit,
+    is_empty_nick,
+    validate_army,
+)
 from spf.config import config
 from spf.console import stdout
 from spf.races import get_race
@@ -136,7 +142,7 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
         if unit_name not in cfg.units:
             errors.append(f"Unit #{unit_idx} (name {unit_name!r}): unknown unit name")
             continue
-        if _is_empty_nick(unit_data.get("nick")):
+        if is_empty_nick(unit_data.get("nick")):
             errors.append(f"Unit #{unit_idx} ({unit_name!r}): empty nick")
         for model_idx, model_data in enumerate(unit_data["models"]):
             model_name = model_data["name"]
@@ -146,7 +152,7 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
                     f" (name {model_name!r}): unknown model name"
                 )
                 continue
-            if _is_empty_nick(model_data.get("nick")):
+            if is_empty_nick(model_data.get("nick")):
                 errors.append(
                     f"Unit #{unit_idx} ({unit_name!r}) / model #{model_idx}"
                     f" ({model_name!r}): empty nick"
@@ -158,15 +164,6 @@ def _validate_army_data(data: dict[str, Any], *, cfg: RaceConfig) -> list[str]:
                 if upgrade not in cfg.equipment
             )
     return errors
-
-
-def _is_empty_nick(nick: object) -> bool:
-    """Is this a present-but-empty Nick? Absent (`None`) means "no Nick" and is fine.
-
-    Load is strict (ADR 0004), so `""` is rejected here as it is in the builder
-    API rather than silently loading as a Nick that renders as nothing.
-    """
-    return nick is not None and not str(nick).strip()
 
 
 def _build_army_list(data: dict[str, Any], *, cfg: RaceConfig) -> ArmyList:

--- a/v3/src/spf/armies/model.py
+++ b/v3/src/spf/armies/model.py
@@ -20,6 +20,11 @@ class Model:
     nick: str | None = None
 
     @property
+    def display_name(self) -> str:
+        """The name to render: the player's Nick if set, else the catalogue name."""
+        return self.nick or self.config.name
+
+    @property
     def equipment(self) -> list[EquipmentConfig]:
         """Effective equipment.
 

--- a/v3/src/spf/armies/model.py
+++ b/v3/src/spf/armies/model.py
@@ -17,6 +17,7 @@ class Model:
     config: ModelConfig = field(repr=False)
     default_equipment: list[EquipmentConfig] = field(repr=False)
     upgrade_equipment: list[EquipmentConfig] = field(repr=False)
+    nick: str | None = None
 
     @property
     def equipment(self) -> list[EquipmentConfig]:

--- a/v3/src/spf/armies/unit.py
+++ b/v3/src/spf/armies/unit.py
@@ -21,6 +21,7 @@ class Unit:
     name: str
     config: UnitConfig = field(repr=False)
     models: list[Model]
+    nick: str | None = None
 
     @property
     def unit_specials(self) -> dict[t.UnitSpecial, str]:

--- a/v3/src/spf/armies/unit.py
+++ b/v3/src/spf/armies/unit.py
@@ -24,6 +24,11 @@ class Unit:
     nick: str | None = None
 
     @property
+    def display_name(self) -> str:
+        """The name to render: the player's Nick if set, else the catalogue name."""
+        return self.nick or self.config.name
+
+    @property
     def unit_specials(self) -> dict[t.UnitSpecial, str]:
         """Stacked unit-level specials: unit config then each model's unit_specials."""
         result: dict[t.UnitSpecial, str] = dict(self.config.special)

--- a/v3/src/spf/render/army_rules.py
+++ b/v3/src/spf/render/army_rules.py
@@ -133,7 +133,7 @@ def _model_entry(model: Model) -> ModelEntry:
     ranged_equipment = [equip for equip in model.equipment if equip.range is not None]
     assault = model.assault()
     return ModelEntry(
-        name=model.config.name,
+        name=model.display_name,
         equipment_summary=_count_summary(model.equipment, lambda e: e.name),
         specials=list(model.model_specials.items()),
         assault_strength=list(assault.strength),
@@ -149,13 +149,13 @@ def _model_entry(model: Model) -> ModelEntry:
 
 def _unit_entry(unit: Unit, *, race: t.RaceName, image_for: ImageLookup) -> UnitEntry:
     return UnitEntry(
-        name=unit.config.name,
+        name=unit.display_name,
         # `unit.name` is the TOML key, which is what addresses an Asset;
-        # `unit.config.name` above is the display name.
+        # `unit.display_name` above is the player's Nick or the catalogue name.
         image=image_for(race, unit.name),
         count=1,
         size=unit.config.size,
-        model_summary=_count_summary(unit.models, lambda m: m.config.name),
+        model_summary=_count_summary(unit.models, lambda m: m.display_name),
         armor=list(unit.config.armor) if unit.config.armor is not None else None,
         points=unit.cost().to_points(),
         shaken_speed=unit.config.shaken.speed,

--- a/v3/src/spf/render/cards.py
+++ b/v3/src/spf/render/cards.py
@@ -95,14 +95,14 @@ def _unit_orders(
     """Build the flat table and card list for a single Unit.
 
     The Asset is addressed by `unit.name`, the TOML key, not by
-    `unit.config.name`, the display name. One lookup serves the flat table and
-    every card the Unit produces.
+    `unit.display_name`, the player's Nick or the catalogue name. One lookup
+    serves the flat table and every card the Unit produces.
     """
     merged = unit.orders()
     shaken = unit.config.shaken
     image = image_for(race, unit.name)
     unit_orders = UnitOrders(
-        name=unit.config.name,
+        name=unit.display_name,
         image=image,
         size=unit.config.size,
         movement_rows=_flat_rows(merged.movement),
@@ -111,8 +111,10 @@ def _unit_orders(
         shaken_fire=shaken.fire_order,
     )
     cards = [
-        *_cards(unit.config.name, image=image, kind="Movement", orders=merged.movement),
-        *_cards(unit.config.name, image=image, kind="Fire", orders=merged.fire),
+        *_cards(
+            unit.display_name, image=image, kind="Movement", orders=merged.movement
+        ),
+        *_cards(unit.display_name, image=image, kind="Fire", orders=merged.fire),
     ]
     return unit_orders, cards
 
@@ -124,10 +126,12 @@ def build_deck(
 
     Each Unit contributes a flat `UnitOrders` and its transposed
     `OrderCard` set. Units producing an identical flat view (same name and
-    merged movement/fire rows) collapse to one entry. That key is the *display*
-    name and deliberately ignores the art: an Asset is addressed by TOML key,
-    and no race has two Unit keys sharing a display name, so the "same name,
-    different art" collision cannot arise today.
+    merged movement/fire rows) collapse to one entry. That key is the
+    `display_name` — so a Nick participates in it with no special-casing, and
+    differently-nicked Units each get their own card set (ADR 0019). It
+    deliberately ignores the art: an Asset is addressed by TOML key, and no race
+    has two Unit keys sharing a display name, so the "same name, different art"
+    collision cannot arise today.
 
     `image_for` resolves Image Assets; it defaults to the committed store and
     is swapped for `no_image` by `--no-images`. A Unit with no committed art

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -1008,6 +1008,12 @@ def test_nick_model_empty_nick_raises(one_unit_army: ArmyList) -> None:
         one_unit_army.nick_model(("squad", 0), model_key=("soldier", 0), nick="")
 
 
+def test_nick_model_checks_the_nick_before_the_key(one_unit_army: ArmyList) -> None:
+    # Same order as nick_unit, so a bad nick reports as a bad nick either way.
+    with pytest.raises(ValueError, match="Nick cannot be empty"):
+        one_unit_army.nick_model(("nonexistent", 0), model_key=("soldier", 0), nick=" ")
+
+
 def test_nick_model_unknown_model_key_raises(one_unit_army: ArmyList) -> None:
     with pytest.raises(KeyError):
         one_unit_army.nick_model(

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -1905,3 +1905,32 @@ def test_resolve_populates_upgrade_equipment(
     model = resolved.units[0].models[0]
     assert len(model.upgrade_equipment) == 1
     assert model.upgrade_equipment[0].name == "Sword"
+
+
+# ---------------------------------------------------------------------------
+# display_name on the resolved tier
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_carries_nicks_across(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    resolved = nicked_army.resolve(simple_race)
+    assert resolved.units[0].nick == "Da Lads"
+    assert resolved.units[0].models[0].nick == "Grubnak"
+
+
+def test_display_name_falls_back_to_catalogue_name(
+    one_unit_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    unit = one_unit_army.resolve(simple_race).units[0]
+    assert unit.display_name == "Squad"
+    assert unit.models[0].display_name == "Soldier"
+
+
+def test_display_name_uses_the_nick(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    unit = nicked_army.resolve(simple_race).units[0]
+    assert unit.display_name == "Da Lads"
+    assert unit.models[0].display_name == "Grubnak"

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -917,6 +917,79 @@ def test_duplicate_unit_unknown_unit_key_raises(one_unit_army: ArmyList) -> None
 
 
 # ---------------------------------------------------------------------------
+# nick_unit / nick_model
+# ---------------------------------------------------------------------------
+
+
+def test_nick_unit_sets_nick(one_unit_army: ArmyList) -> None:
+    army = one_unit_army.nick_unit(("squad", 0), nick="Da Lads")
+    assert army.units[0].nick == "Da Lads"
+
+
+def test_nick_unit_addresses_the_right_occurrence(one_unit_army: ArmyList) -> None:
+    army = one_unit_army.duplicate_unit(("squad", 0)).nick_unit(
+        ("squad", 1), nick="Da Lads"
+    )
+    assert army.units[0].nick is None
+    assert army.units[1].nick == "Da Lads"
+
+
+def test_nick_unit_does_not_mutate_original(one_unit_army: ArmyList) -> None:
+    one_unit_army.nick_unit(("squad", 0), nick="Da Lads")
+    assert one_unit_army.units[0].nick is None
+
+
+def test_nick_unit_clears_with_none(one_unit_army: ArmyList) -> None:
+    army = one_unit_army.nick_unit(("squad", 0), nick="Da Lads")
+    assert army.nick_unit(("squad", 0), nick=None).units[0].nick is None
+
+
+def test_nick_unit_empty_nick_raises(one_unit_army: ArmyList) -> None:
+    with pytest.raises(ValueError, match="Nick cannot be empty"):
+        one_unit_army.nick_unit(("squad", 0), nick="   ")
+
+
+def test_nick_unit_unknown_unit_key_raises(one_unit_army: ArmyList) -> None:
+    with pytest.raises(KeyError):
+        one_unit_army.nick_unit(("nonexistent", 0), nick="Da Lads")
+
+
+def test_nick_model_sets_nick(one_unit_army: ArmyList) -> None:
+    army = one_unit_army.nick_model(
+        ("squad", 0), model_key=("soldier", 0), nick="Grubnak"
+    )
+    assert army.units[0].models[0].nick == "Grubnak"
+    assert army.units[0].nick is None
+
+
+def test_nick_model_leaves_squadmates_alone(simple_race: RaceConfig) -> None:
+    two_model_unit = ArmyUnit(
+        name="squad",
+        config=simple_race.units["squad"],
+        models=[
+            ArmyModel(name="soldier", config=simple_race.models["soldier"], upgrades=[])
+            for _ in range(2)
+        ],
+    )
+    army = ArmyList(race="goblin", nick="Test Army", units=[two_model_unit]).nick_model(
+        ("squad", 0), model_key=("soldier", 1), nick="Grubnak"
+    )
+    assert [m.nick for m in army.units[0].models] == [None, "Grubnak"]
+
+
+def test_nick_model_empty_nick_raises(one_unit_army: ArmyList) -> None:
+    with pytest.raises(ValueError, match="Nick cannot be empty"):
+        one_unit_army.nick_model(("squad", 0), model_key=("soldier", 0), nick="")
+
+
+def test_nick_model_unknown_model_key_raises(one_unit_army: ArmyList) -> None:
+    with pytest.raises(KeyError):
+        one_unit_army.nick_model(
+            ("squad", 0), model_key=("nonexistent", 0), nick="Grubnak"
+        )
+
+
+# ---------------------------------------------------------------------------
 # delete_unit
 # ---------------------------------------------------------------------------
 

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -911,6 +911,32 @@ def test_duplicate_unit_is_independent(
     assert upgraded.units[1].models[0].name == "elite_soldier"
 
 
+def test_duplicate_unit_drops_nicks(nicked_army: ArmyList) -> None:
+    army = nicked_army.duplicate_unit(("squad", 0))
+    assert army.units[1].nick is None
+    assert army.units[1].models[0].nick is None
+    # The original keeps both of its nicks.
+    assert army.units[0].nick == "Da Lads"
+    assert army.units[0].models[0].nick == "Grubnak"
+
+
+def test_duplicate_unit_can_re_nick_in_one_call(nicked_army: ArmyList) -> None:
+    army = nicked_army.duplicate_unit(("squad", 0), nick="Da Gals")
+    assert army.units[1].nick == "Da Gals"
+    # Only the unit is re-nicked; the copied model slots stay un-nicked.
+    assert army.units[1].models[0].nick is None
+
+
+def test_duplicate_unit_empty_nick_raises(nicked_army: ArmyList) -> None:
+    with pytest.raises(ValueError, match="Nick cannot be empty"):
+        nicked_army.duplicate_unit(("squad", 0), nick=" ")
+
+
+def test_duplicate_unit_does_not_share_model_list(nicked_army: ArmyList) -> None:
+    army = nicked_army.duplicate_unit(("squad", 0))
+    assert army.units[0].models is not army.units[1].models
+
+
 def test_duplicate_unit_unknown_unit_key_raises(one_unit_army: ArmyList) -> None:
     with pytest.raises(KeyError):
         one_unit_army.duplicate_unit(("nonexistent", 0))
@@ -987,6 +1013,82 @@ def test_nick_model_unknown_model_key_raises(one_unit_army: ArmyList) -> None:
         one_unit_army.nick_model(
             ("squad", 0), model_key=("nonexistent", 0), nick="Grubnak"
         )
+
+
+# ---------------------------------------------------------------------------
+# Nick survives every upgrade path
+#
+# Every upgrade_* method rebuilds its dataclass, so each reconstruction site
+# has to thread `nick` through or upgrading silently drops it. One test per
+# method, deliberately.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def nicked_army(simple_race: RaceConfig) -> ArmyList:
+    """One nicked unit whose single model slot is nicked too."""
+    return (
+        ArmyList(race="goblin", nick="Test Army", units=[])
+        .add_unit("squad", nick="Da Lads", race_config=simple_race)
+        .nick_model(("squad", 0), model_key=("soldier", 0), nick="Grubnak")
+    )
+
+
+def test_upgrade_model_preserves_nicks(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    army = nicked_army.upgrade_model(
+        ("squad", 0),
+        model_key=("soldier", 0),
+        equipment_name="sword",
+        race_config=simple_race,
+    )
+    assert army.units[0].nick == "Da Lads"
+    assert army.units[0].models[0].nick == "Grubnak"
+
+
+def test_upgrade_unit_preserves_nicks_across_promotion(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    army = nicked_army.upgrade_unit(
+        ("squad", 0),
+        model_key=("soldier", 0),
+        upgrade_model_name="elite_soldier",
+        race_config=simple_race,
+    )
+    assert army.units[0].models[0].name == "elite_soldier"
+    assert army.units[0].nick == "Da Lads"
+    # A Nick belongs to the slot, not the model type.
+    assert army.units[0].models[0].nick == "Grubnak"
+
+
+def test_upgrade_full_unit_preserves_nicks(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    army = nicked_army.upgrade_full_unit(
+        ("squad", 0), upgrade_model_name="elite_soldier", race_config=simple_race
+    )
+    assert army.units[0].nick == "Da Lads"
+    assert army.units[0].models[0].nick == "Grubnak"
+
+
+def test_upgrade_all_models_preserves_nicks(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    army = nicked_army.upgrade_all_models(
+        ("squad", 0), equipment_name="sword", race_config=simple_race
+    )
+    assert army.units[0].nick == "Da Lads"
+    assert army.units[0].models[0].nick == "Grubnak"
+
+
+def test_delete_unit_leaves_other_nicks_intact(
+    nicked_army: ArmyList, *, simple_race: RaceConfig
+) -> None:
+    army = nicked_army.add_unit("squad", race_config=simple_race).delete_unit(
+        ("squad", 1)
+    )
+    assert [u.nick for u in army.units] == ["Da Lads"]
 
 
 # ---------------------------------------------------------------------------

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -592,6 +592,29 @@ def test_add_unit_unknown_name_raises(simple_race: RaceConfig) -> None:
         )
 
 
+def test_add_unit_defaults_to_no_nick(simple_race: RaceConfig) -> None:
+    army = ArmyList(race="goblin", nick="Test Army", units=[]).add_unit(
+        "squad", race_config=simple_race
+    )
+    assert army.units[0].nick is None
+    assert army.units[0].models[0].nick is None
+
+
+def test_add_unit_stores_nick(simple_race: RaceConfig) -> None:
+    army = ArmyList(race="goblin", nick="Test Army", units=[]).add_unit(
+        "squad", nick="Boyz", race_config=simple_race
+    )
+    assert army.units[0].nick == "Boyz"
+    assert army.units[0].name == "squad"
+
+
+def test_add_unit_empty_nick_raises(simple_race: RaceConfig) -> None:
+    with pytest.raises(ValueError, match="Nick cannot be empty"):
+        ArmyList(race="goblin", nick="Test Army", units=[]).add_unit(
+            "squad", nick="  ", race_config=simple_race
+        )
+
+
 # ---------------------------------------------------------------------------
 # upgrade_unit
 # ---------------------------------------------------------------------------

--- a/v3/tests/armies/test_io.py
+++ b/v3/tests/armies/test_io.py
@@ -153,6 +153,103 @@ def test_save_json_contains_race(armies_dir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Nick serialization
+# ---------------------------------------------------------------------------
+
+
+def test_save_omits_nick_when_unset(armies_dir: Path) -> None:
+    army_list = ArmyList(race="goblin", nick="Test Army", units=[]).add_unit(
+        "goblin_infantry", race_config=get_race("goblin")
+    )
+    save_army(army_list, army_name="no-nicks")
+    data = json.loads((armies_dir / "no-nicks.json").read_text())
+    assert "nick" not in data["units"][0]
+    assert "nick" not in data["units"][0]["models"][0]
+
+
+def test_save_writes_nicks_when_set(armies_dir: Path) -> None:
+    race_config = get_race("goblin")
+    army_list = (
+        ArmyList(race="goblin", nick="Test Army", units=[])
+        .add_unit("goblin_infantry", nick="Da Lads", race_config=race_config)
+        .nick_model(
+            ("goblin_infantry", 0),
+            model_key=("goblin_infantry", 0),
+            nick="Grubnak",
+        )
+    )
+    save_army(army_list, army_name="with-nicks")
+    data = json.loads((armies_dir / "with-nicks.json").read_text())
+    assert data["units"][0]["nick"] == "Da Lads"
+    assert data["units"][0]["models"][0]["nick"] == "Grubnak"
+
+
+def test_round_trip_preserves_nicks(armies_dir: Path) -> None:  # noqa: ARG001
+    race_config = get_race("goblin")
+    army_list = (
+        ArmyList(race="goblin", nick="Test Army", units=[])
+        .add_unit("goblin_infantry", nick="Da Lads", race_config=race_config)
+        .nick_model(
+            ("goblin_infantry", 0),
+            model_key=("goblin_infantry", 0),
+            nick="Grubnak",
+        )
+    )
+    save_army(army_list, army_name="nick-round-trip")
+    loaded = load_army("nick-round-trip")
+    assert loaded.units[0].nick == "Da Lads"
+    assert loaded.units[0].models[0].nick == "Grubnak"
+
+
+def test_load_army_without_nick_keys_needs_no_migration(armies_dir: Path) -> None:
+    data = {
+        "race": "goblin",
+        "nick": "Test",
+        "units": [
+            {
+                "name": "goblin_infantry",
+                "models": [{"name": "goblin_infantry", "upgrades": []}],
+            }
+        ],
+    }
+    (armies_dir / "legacy.json").write_text(json.dumps(data))
+    loaded = load_army("legacy")
+    assert loaded.units[0].nick is None
+    assert loaded.units[0].models[0].nick is None
+
+
+def test_load_blank_unit_nick_raises_value_error(armies_dir: Path) -> None:
+    data = {
+        "race": "goblin",
+        "nick": "Test",
+        "units": [{"name": "goblin_infantry", "nick": "  ", "models": []}],
+    }
+    (armies_dir / "blank-unit-nick.json").write_text(json.dumps(data))
+    with pytest.raises(ValueError, match=r"Unit #0 \('goblin_infantry'\): empty nick"):
+        load_army("blank-unit-nick")
+
+
+def test_load_blank_model_nick_raises_value_error(armies_dir: Path) -> None:
+    data = {
+        "race": "goblin",
+        "nick": "Test",
+        "units": [
+            {
+                "name": "goblin_infantry",
+                "models": [{"name": "goblin_infantry", "upgrades": [], "nick": ""}],
+            }
+        ],
+    }
+    (armies_dir / "blank-model-nick.json").write_text(json.dumps(data))
+    with pytest.raises(
+        ValueError,
+        match=r"Unit #0 \('goblin_infantry'\) / model #0 \('goblin_infantry'\):"
+        r" empty nick",
+    ):
+        load_army("blank-model-nick")
+
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 

--- a/v3/tests/armies/test_io.py
+++ b/v3/tests/armies/test_io.py
@@ -152,6 +152,13 @@ def test_save_json_contains_race(armies_dir: Path) -> None:
     assert data["race"] == "goblin"
 
 
+def test_save_ends_file_with_a_newline(armies_dir: Path) -> None:
+    """Otherwise every saved army is dirty the moment end-of-file-fixer sees it."""
+    army_list = ArmyList(race="goblin", nick="Test Army", units=[])
+    save_army(army_list, army_name="trailing-newline")
+    assert (armies_dir / "trailing-newline.json").read_text().endswith("}\n")
+
+
 # ---------------------------------------------------------------------------
 # Nick serialization
 # ---------------------------------------------------------------------------
@@ -225,7 +232,10 @@ def test_load_blank_unit_nick_raises_value_error(armies_dir: Path) -> None:
         "units": [{"name": "goblin_infantry", "nick": "  ", "models": []}],
     }
     (armies_dir / "blank-unit-nick.json").write_text(json.dumps(data))
-    with pytest.raises(ValueError, match=r"Unit #0 \('goblin_infantry'\): empty nick"):
+    with pytest.raises(
+        ValueError,
+        match=r"Unit #0 \('goblin_infantry'\): Nick cannot be empty",
+    ):
         load_army("blank-unit-nick")
 
 
@@ -244,7 +254,7 @@ def test_load_blank_model_nick_raises_value_error(armies_dir: Path) -> None:
     with pytest.raises(
         ValueError,
         match=r"Unit #0 \('goblin_infantry'\) / model #0 \('goblin_infantry'\):"
-        r" empty nick",
+        r" Nick cannot be empty",
     ):
         load_army("blank-model-nick")
 

--- a/v3/tests/armies/test_rules_display.py
+++ b/v3/tests/armies/test_rules_display.py
@@ -176,10 +176,42 @@ def test_unit_with_no_specials_omits_specials_line(capture: Console) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_model_line_shows_name(simple_race: RaceConfig, *, capture: Console) -> None:
+def test_model_line_shows_display_name_not_toml_key(
+    simple_race: RaceConfig, *, capture: Console
+) -> None:
     army = _army(simple_race).resolve(simple_race)
     print_army_rules(army)
-    assert "soldier" in capture.export_text()
+    output = capture.export_text()
+    # Models print by display name, matching the unit lines beside them —
+    # not by the raw snake_case TOML key.
+    assert "Soldier" in output
+    assert "soldier" not in output
+
+
+def test_model_line_shows_nick_when_set(
+    simple_race: RaceConfig, *, capture: Console
+) -> None:
+    army = (
+        _army(simple_race)
+        .nick_model(("squad", 0), model_key=("soldier", 0), nick="Grubnak")
+        .resolve(simple_race)
+    )
+    print_army_rules(army)
+    output = capture.export_text()
+    assert "Grubnak" in output
+    assert "Soldier" not in output
+
+
+def test_unit_line_shows_nick_when_set(
+    simple_race: RaceConfig, *, capture: Console
+) -> None:
+    army = (
+        _army(simple_race).nick_unit(("squad", 0), nick="Da Lads").resolve(simple_race)
+    )
+    print_army_rules(army)
+    output = capture.export_text()
+    assert "Da Lads" in output
+    assert "Squad" not in output
 
 
 def test_model_line_omits_cost_when_zero(

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -47,6 +47,7 @@ def _model(
     equipment: list[EquipmentConfig] | None = None,
     assault: AssaultConfig = _ASSAULT,
     model_special: dict[str, str] | None = None,
+    nick: str | None = None,
 ) -> Model:
     config = ModelConfig(
         race="elf",
@@ -63,6 +64,7 @@ def _model(
         config=config,
         default_equipment=[],
         upgrade_equipment=equipment or [],
+        nick=nick,
     )
 
 
@@ -74,6 +76,7 @@ def _unit(  # noqa: PLR0913  test fixture covers every UnitConfig field under te
     shaken: ShakenConfig | None = None,
     armor: list[int] | None = None,
     unit_special: dict[str, str] | None = None,
+    nick: str | None = None,
 ) -> Unit:
     resolved_models = models or [_model()]
     config = UnitConfig(
@@ -95,7 +98,7 @@ def _unit(  # noqa: PLR0913  test fixture covers every UnitConfig field under te
             }
         },
     )
-    return Unit(name=name, config=config, models=resolved_models)
+    return Unit(name=name, config=config, models=resolved_models, nick=nick)
 
 
 def _army(*units: Unit, nick: str = "Test", race: str = "elf") -> Army:
@@ -283,6 +286,80 @@ def test_build_reference_army_points_counts_duplicate_units() -> None:
     reference = build_reference(_army(unit_a, unit_b, nick="Test"), stem="test")
 
     assert reference.points == unit_a.cost().to_points() + unit_b.cost().to_points()
+
+
+# --- build_reference: Nicks in the entry names and the collapse key ---------
+
+
+def test_build_reference_unit_nick_replaces_the_catalogue_name() -> None:
+    unit = _unit(name="Infantry", nick="Da Lads")
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    # A Nick replaces the catalogue name outright — no parenthetical.
+    assert unit_entry.name == "Da Lads"
+
+
+def test_build_reference_model_nick_replaces_the_catalogue_name() -> None:
+    unit = _unit(models=[_model(name="Infantry", nick="Grubnak")])
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.model_summary == ["1x Grubnak"]
+    assert [m.name for m in unit_entry.models] == ["Grubnak"]
+
+
+def test_build_reference_unit_image_still_addressed_by_toml_key() -> None:
+    lookup = FakeLookup(ART)
+
+    build_reference(
+        _army(_unit(name="infantry", nick="Da Lads")), stem="test", image_for=lookup
+    )
+
+    # Nicking never changes how an Asset is addressed.
+    assert ("elf", "infantry") in lookup.calls
+
+
+def test_build_reference_un_nicked_units_still_collapse() -> None:
+    units = [_unit(name="Infantry") for _ in range(3)]
+
+    reference = build_reference(_army(*units), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.count == 3
+
+
+def test_build_reference_differently_nicked_units_do_not_collapse() -> None:
+    units = [_unit(name="Infantry", nick=nick) for nick in ("A", "B", "C")]
+
+    reference = build_reference(_army(*units), stem="test")
+
+    assert [u.name for u in reference.units] == ["A", "B", "C"]
+    assert all(u.count == 1 for u in reference.units)
+
+
+def test_build_reference_same_nicked_units_collapse() -> None:
+    units = [_unit(name="Infantry", nick="Boyz") for _ in range(2)]
+
+    reference = build_reference(_army(*units), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.name == "Boyz"
+    assert unit_entry.count == 2
+
+
+def test_build_reference_nicked_model_splits_from_identical_squadmates() -> None:
+    grunt = _model(name="Infantry")
+    named = _model(name="Infantry", nick="Grubnak")
+    unit = _unit(models=[named, grunt, grunt])
+
+    reference = build_reference(_army(unit), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.model_summary == ["1x Grubnak", "2x Infantry"]
+    assert [m.name for m in unit_entry.models] == ["Grubnak", "Infantry"]
 
 
 # --- build_reference: resolved assault, not raw config ----------------------

--- a/v3/tests/render/test_cards.py
+++ b/v3/tests/render/test_cards.py
@@ -54,13 +54,14 @@ def _model(*, equipment: list[EquipmentConfig] | None = None) -> Model:
     )
 
 
-def _unit(
+def _unit(  # noqa: PLR0913  test fixture covers every Unit field under test
     *,
     orders: OrdersConfig,
     models: list[Model] | None = None,
     name: str = "Squad",
     size: t.Size = "Small",
     shaken: ShakenConfig | None = None,
+    nick: str | None = None,
 ) -> Unit:
     config = UnitConfig(
         race="elf",
@@ -71,7 +72,7 @@ def _unit(
         orders=orders,
         damage_tables={"Regular": {"rows": ["1: Fine", "2: Dead"]}},  # pyright: ignore[reportArgumentType]
     )
-    return Unit(name=name, config=config, models=models or [_model()])
+    return Unit(name=name, config=config, models=models or [_model()], nick=nick)
 
 
 def _equip(orders_gained: OrdersConfig, *, name: str = "SMG") -> EquipmentConfig:
@@ -244,6 +245,60 @@ def test_build_deck_keeps_distinct_units() -> None:
 
     assert len(deck.units) == 2
     assert len(deck.cards) == 2
+
+
+def test_build_deck_unit_nick_replaces_the_catalogue_name() -> None:
+    unit = _unit(orders=OrdersConfig(movement={"still": [["A"]]}), nick="Da Lads")
+
+    deck = build_deck(_army(unit), stem="test")
+
+    (unit_orders,) = deck.units
+    assert unit_orders.name == "Da Lads"
+    assert all(card.unit_name == "Da Lads" for card in deck.cards)
+
+
+def test_build_deck_un_nicked_units_still_collapse() -> None:
+    orders = OrdersConfig(movement={"still": [["A"]]})
+    units = [_unit(orders=orders, name="Infantry") for _ in range(3)]
+
+    deck = build_deck(_army(*units), stem="test")
+
+    assert len(deck.units) == 1
+    assert len(deck.cards) == 1
+
+
+def test_build_deck_differently_nicked_units_each_get_a_card_set() -> None:
+    orders = OrdersConfig(movement={"still": [["A"]]})
+    units = [_unit(orders=orders, name="Infantry", nick=n) for n in ("A", "B", "C")]
+
+    deck = build_deck(_army(*units), stem="test")
+
+    assert [u.name for u in deck.units] == ["A", "B", "C"]
+    # You nicked them to tell them apart, so each gets its own card.
+    assert [c.unit_name for c in deck.cards] == ["A", "B", "C"]
+
+
+def test_build_deck_same_nicked_units_collapse() -> None:
+    orders = OrdersConfig(movement={"still": [["A"]]})
+    units = [_unit(orders=orders, name="Infantry", nick="Boyz") for _ in range(2)]
+
+    deck = build_deck(_army(*units), stem="test")
+
+    assert [u.name for u in deck.units] == ["Boyz"]
+    assert len(deck.cards) == 1
+
+
+def test_build_deck_nicked_unit_image_still_addressed_by_toml_key() -> None:
+    lookup = FakeLookup(ART)
+    unit = _unit(
+        orders=OrdersConfig(movement={"still": [["A"]]}),
+        name="infantry",
+        nick="Da Lads",
+    )
+
+    build_deck(_army(unit), stem="test", image_for=lookup)
+
+    assert lookup.calls == [("elf", "infantry")]
 
 
 def test_build_deck_carries_shaken_to_units_not_cards() -> None:

--- a/v3/tests/test_display.py
+++ b/v3/tests/test_display.py
@@ -94,3 +94,42 @@ def test_print_army_unit_line_includes_points(
     # squad costs mp=3, points = 3
     assert "Squad" in output
     assert "(3 pts)" in output
+
+
+def test_print_army_model_line_shows_display_name_not_toml_key(
+    simple_race: RaceConfig, *, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture = Console(record=True)
+    monkeypatch.setattr(spf.armies.io, "stdout", capture)
+
+    army = (
+        ArmyList(race="goblin", nick="Test Army", units=[])
+        .add_unit("squad", race_config=simple_race)
+        .resolve(simple_race)
+    )
+    print_army(army)
+
+    output = capture.export_text()
+    assert "Soldier" in output
+    assert "soldier" not in output
+
+
+def test_print_army_shows_unit_and_model_nicks(
+    simple_race: RaceConfig, *, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    capture = Console(record=True)
+    monkeypatch.setattr(spf.armies.io, "stdout", capture)
+
+    army = (
+        ArmyList(race="goblin", nick="Test Army", units=[])
+        .add_unit("squad", nick="Da Lads", race_config=simple_race)
+        .nick_model(("squad", 0), model_key=("soldier", 0), nick="Grubnak")
+        .resolve(simple_race)
+    )
+    print_army(army)
+
+    output = capture.export_text()
+    assert "Da Lads" in output
+    assert "Grubnak" in output
+    assert "Squad" not in output
+    assert "Soldier" not in output

--- a/v3/typos.toml
+++ b/v3/typos.toml
@@ -10,6 +10,13 @@ extend-exclude = [
     "workflows/local.example.json",
     # An ADR about a typo will always contain that typo.
     "docs/adr/0011-coverage-survey-of-assets.md",
+    # Generated army data: the Nicks in here are player-chosen names, and
+    # `just spell-fix` would rewrite them in place, desyncing the JSON from the
+    # build script that generates it. The build scripts stay spell-checked.
+    # Both shapes are needed: `*` does not cross a `/`, and armies live both
+    # directly in `armies/` and one level down in `armies/<tournament>/`.
+    "armies/*.json",
+    "armies/**/*.json",
 ]
 
 [default]


### PR DESCRIPTION
Closes #82.

A **Nick** — until now the player-chosen name of an Army — now applies one level
down, to Unit instances and Model slots. It is stored as a separate `nick` field
beside the existing `name`, replaces the catalogue display name wherever an
instance is rendered, and participates in the collapse/dedup keys with no
special-casing.

Implemented per the settled design in the issue body, TDD, one commit per
red-green cycle.

## What's in it

- **Data model** — `nick: str | None = None` on `ArmyUnit`, `ArmyModel`, `Unit`,
  `Model`. `None` means no nick; empty or whitespace-only raises `ValueError`.
  `nick_error` is the one authority on that rule: `check_nick` raises what it
  returns, the load path folds it into its error list.
- **Authoring API** — `add_unit(key, nick=…)`, `duplicate_unit(unit_key, nick=…)`,
  and new `nick_unit` / `nick_model` mutators. Addressing is untouched: still
  `(toml_key, occurrence)`.
- **Lifecycle** — every `upgrade_*` path preserves nicks (a Nick belongs to the
  *slot*, not the model type, so promotion through `upgrade_unit` keeps it);
  `duplicate_unit` drops them at unit *and* model level.
- **Rendering** — one `display_name` property (`self.nick or self.config.name`)
  consumed by all six instance-render sites: `_unit_entry` / `_model_entry`
  (army-rules), `_unit_orders` and its two `_cards` calls, and `print_army` /
  `print_army_rules`. Templates are untouched — substitution happens in the
  view-model.
- **Collapse/dedup** — un-nicked units still collapse to `Ork Infantry (3×)`;
  differently-nicked ones each get their own entry and card set; same-nicked
  ones collapse to `Boyz (2×)`. Same rule at model level. `_collapse_units` and
  `build_deck`'s dedup logic are unchanged.
- **Serialization** — `nick` omitted when `None`, read via `.get`. Old army JSON
  loads with no migration.
- **Docs** — `CONTEXT.md` glossary widened; new ADR 0019.

## Collateral fix (deliberate)

`print_army` / `print_army_rules` used to print models by TOML key
(`elite_ork_infantry`) while printing units by display name. Both now use
`display_name`, so un-nicked models start showing `Elite Ork Infantry`.
Otherwise a nicked model would print its nick beside squadmates printing raw
snake_case keys.

## Notes for the reviewer

Three things worth your attention:

1. **`typos.toml` needed a wider glob than the issue specified.** The issue said
   add `"armies/*.json"` to `extend-exclude`; that pattern misses the real files,
   which live in `armies/2025/` and `armies/showcase/` (`*` doesn't cross a `/`).
   Both `armies/*.json` and `armies/**/*.json` are added. Verified against the
   failure mode: an army file containing `"Da Skarboyz of teh Nite"` fails
   `just spell` before the change and passes after.

2. **`save_army` now ends the file with a newline** (folded in on review
   request). It previously wrote none while the repo's pre-commit
   `end-of-file-fixer` added one to every committed army file, so any
   regeneration came out one byte different from what was committed.
   `git diff --exit-code armies/` is now literally clean after re-running the
   build scripts, not merely clean on content.

3. **A nick is not stripped.** `nick=" Boyz "` is accepted and renders padded.
   Rejecting empty/whitespace-only was specified; normalizing surrounding
   whitespace was not, so I left it alone rather than invent behaviour. Say the
   word if you want `.strip()` on the way in.

`nick_unit` / `nick_model` have no CLI caller by design — armies are authored by
the build scripts in `armies/build_scripts/`, which is the authoring surface the
issue named. No nicks were added to the existing build scripts; a clean
regeneration diff is the evidence that omit-when-`None` works.

## Verification

- `just check` green: ruff format + lint, pyright (0 errors), typos, `spf`
  validate, race lint, **586 tests passed**.
- Re-ran the army build scripts — `git status armies/` clean.
- End-to-end smoke through both view-models and both console printers:
  `UNIT ENTRIES: [('Da Skarboyz', 1), ('Ork Infantry', 2)]`,
  `MODEL SUMMARY: ['1x Grubnak', '3x Ork Infantry']`,
  `CARD NAMES: ['Da Skarboyz', 'Ork Infantry']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzGhuTgtSqptRubWfJnCqv
