### PR TITLE
Reword Poison Fog[N] as fog + poison cloud composite

### DIFF
--- a/v3/races/abomination.toml
+++ b/v3/races/abomination.toml
@@ -1009,7 +1009,7 @@ damage = "N/A"
 ap = "N/A"
 
 [equipment.multipurpose_mortar.range.special]
-"Multipurpose" = "Either place two fog[4] tokens in two different hexes, or give two different units one minor acid each. All targets must be within normal range."
+"Multipurpose" = "Either place two fog tokens in one hex and two fog tokens in another hex, or give two different units one minor acid each. All targets must be within normal range."
 
 [equipment.double_barreled_oversized_musket]
 name = "Double Barreled Oversized Musket"
@@ -1071,13 +1071,13 @@ damage = "N/A"
 ap = "N/A"
 
 [equipment.fog_poisonizer.range.special]
-"Cloud" = "Make a fog within normal range into a poison fog[4]"
+"Cloud" = "Add poison cloud[4] to a hex with fog within normal range"
 "Ammo" = "Always treated as loaded"
 "Order" = "May be used in both gunnery phases"
 
 
 [equipment.greater_fog_poisonizer]
-name = "Fog Poisonizer"
+name = "Greater Fog Poisonizer"
 race = "abomination"
 
 [equipment.greater_fog_poisonizer.range]
@@ -1087,7 +1087,7 @@ damage = "N/A"
 ap = "N/A"
 
 [equipment.greater_fog_poisonizer.range.special]
-"Cloud" = "Make a fog within normal range into a poison fog[4]"
+"Cloud" = "Add poison cloud[4] to a hex with fog within normal range"
 "Ammo" = "Always treated as loaded"
 
 

--- a/v3/races/gnome.toml
+++ b/v3/races/gnome.toml
@@ -302,7 +302,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
+	"5: Place fog and poison cloud[8] in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 
@@ -361,7 +361,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
+	"5: Place fog and poison cloud[8] in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 
@@ -423,7 +423,7 @@ rows = [
 	"1-2: +3 to future damage",
 	"3: +1 to be hit, -1 to hit",
 	"4: Rotate unit 180°",
-	"5: Place Poison Cloud[8] and Fog in this and all adjacent hexes.",
+	"5: Place fog and poison cloud[8] in this and all adjacent hexes.",
 	"6: set on fire",
 ]
 


### PR DESCRIPTION
Closes #85

Per the designer's rulings on the issue: `Poison Fog[N]` = `Poison Cloud[N]` + `Fog`. Fog has no strength value, and Poison Fog is not a hex type — it is a name for two co-located tokens. So no `[hexes.poison_fog]` entry; instead the composite is spelled out longhand at call sites, darkelf-style (lowercase).

## Changes

- **`races/gnome.toml:305, 364, 426`** — three identical damage-table rows: `Place Poison Cloud[8] and Fog` → `Place fog and poison cloud[8]`. Casing and order only; **no token count added** — count is duration, and this line fires on seven hexes and can retrigger, so hard-coding a count would silently buff Gnome.
- **`races/abomination.toml:1012`** — designer's verbatim replacement for the multipurpose mortar's fog branch; the `[4]` was a typo, it is plain fog.
- **`races/abomination.toml:1074, :1090`** — both poisonizers: `Make a fog … into a poison fog[4]` → `Add poison cloud[4] to a hex with fog within normal range`. The weapon *converts* existing fog by adding the poison half, so the darkelf "place both" template doesn't transfer.
- **`races/abomination.toml:1080`** — `greater_fog_poisonizer` renamed to `Greater Fog Poisonizer` (copy-paste slip).

## Deliberately not done

- **No changelog rows** — per `CONTEXT.md`, corrections that change no intent aren't changelog material. The rename fixes a typo, the `fog[4]` fix restores intent, and the rewordings are the same effect in clearer words.
- **The greater poisonizer's missing `"Order"` special is untouched** — the designer is handling that himself so unit orders stay correct.
- **Plain poison-cloud strings in `dwarf`/`goblin`/`darkelf` are untouched** — narrow scope; that's the Q4 consistency follow-up on the issue.
- Equipment *names* containing "Poison Fog" (e.g. Poison Fog Grenade) are flavour, not rules terms, and are unaffected.

## Verification

`just check` passes: fmt-check, lint, spell, validate (all eight races + rules), lint-races, 586 tests, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FuLfFKrEj36w141YcEUXt