### PR TITLE
Remove restated fog token counts from weapon text

### DIFF
--- a/v3/races/abomination.toml
+++ b/v3/races/abomination.toml
@@ -974,9 +974,9 @@ ap = "N/A"
 
 [equipment.fog_grenade_mortar.range.special]
 
-"Cloud" = "Place two fog tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
+"Cloud" = "Place fog in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
 
-"Ammo" = "May start the game without ammo, but instead place two fog tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
+"Ammo" = "May start the game without ammo, but instead place fog in 4 different hexes within range 3 of this unit at start of game (part of setup)"
 
 
 [equipment.long_range_fog_grenade_mortar]
@@ -994,9 +994,9 @@ ap = "N/A"
 
 [equipment.long_range_fog_grenade_mortar.range.special]
 
-"Cloud" = "Place two fog tokens in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
+"Cloud" = "Place fog in a hex within normal range. Note: choose one hex per model firing this weapon. Uses Ammo as normal."
 
-"Ammo" = "May start the game without ammo, but instead place two fog tokens in 4 different hexes within range 3 of this unit at start of game (part of setup)"
+"Ammo" = "May start the game without ammo, but instead place fog in 4 different hexes within range 3 of this unit at start of game (part of setup)"
 
 [equipment.multipurpose_mortar]
 name = "Multipurpose Mortar"
@@ -1009,7 +1009,7 @@ damage = "N/A"
 ap = "N/A"
 
 [equipment.multipurpose_mortar.range.special]
-"Multipurpose" = "Either place two fog tokens in one hex and two fog tokens in another hex, or give two different units one minor acid each. All targets must be within normal range."
+"Multipurpose" = "Either place fog in two different hexes, or give two different units one minor acid each. All targets must be within normal range."
 
 [equipment.double_barreled_oversized_musket]
 name = "Double Barreled Oversized Musket"

--- a/v3/races/darkelf.toml
+++ b/v3/races/darkelf.toml
@@ -1758,7 +1758,7 @@ requires = [
 ]
 
 [equipment.poison_fog_grenade.unit_special]
-"Fire Order" = "Use twice per game, use an throw fire order to place 2 fog tokens and 2 poison cloud[6] tokens in either an adjacent hex or the hex you are standing in. Note that this does not make you immune to the effect of your own grenade."
+"Fire Order" = "Use twice per game, use an throw fire order to place fog and poison cloud[6] in either an adjacent hex or the hex you are standing in. Note that this does not make you immune to the effect of your own grenade."
 
 [equipment.poison_fog_grenade.orders_gained.fire]
 still = [["-", "Throw"], ["Throw", "-"]]

--- a/v3/races/ork.toml
+++ b/v3/races/ork.toml
@@ -1293,7 +1293,7 @@ damage = "d12"
 ap = 5
 
 [equipment.big_gun.range.special]
-"Cloud" = "Place two fog tokens in the hex directly ahead of this unit"
+"Cloud" = "Place fog in the hex directly ahead of this unit"
 
 [equipment.spear_shooter]
 race = "ork"

--- a/v3/rules/hexes.toml
+++ b/v3/rules/hexes.toml
@@ -1,7 +1,7 @@
 #Til Geir Arne: er dette fornuftig???
 explanation = """Hex based effects are triggered in all 'trigger hex based effects part of movement.
 
-When placing Clouds on a hex for the first time, place two tokens of the given type. Otherwise, place only one.
+When placing Clouds or Fog on a hex for the first time, place two tokens of the given type. Otherwise, place only one.
 Hex based effects are not cumulative. However the effect of acid, fire and poison on units are cumulative with both itself and each other.
 In case of poison clouds with different strength, apply the strongest if overlapping.
 


### PR DESCRIPTION
Closes #88. Background: [Q4 on #85](https://github.com/hssmalo/steampunkfantasy/issues/85#issuecomment-5202229104).

Q4 ruled that the flat "two fog tokens" counts in weapon text are **restatements** of the general rule in `rules/hexes.toml`, not weapon-specific overrides. As restatements they are wrong whenever fog overlaps: the count is *duration*, and a literal reading stacks fog to 3–4 rounds where the general rule tops it up to 2. This deletes the counts and lets the general rule speak.

**All open questions are now answered — see [the designer's comment on #88](https://github.com/hssmalo/steampunkfantasy/issues/88#issuecomment-5202229104). Ready to merge as-is.**

## Part A — 7 lines, 3 races ✅ approved

> "The new wording align more with how the game should be played and balanced."

| File | Line | After |
|---|---|---|
| `races/abomination.toml` | 977, 997 | `Place fog in a hex within normal range. …` |
| `races/abomination.toml` | 979, 999 | `… instead place fog in 4 different hexes …` |
| `races/abomination.toml` | 1012 | `Either place fog in two different hexes, or give two different units one minor acid each. …` |
| `races/darkelf.toml` | 1761 | `… to place fog and poison cloud[6] in either an adjacent hex …` |
| `races/ork.toml` | 1296 | `Place fog in the hex directly ahead of this unit` |

- Line 979/999 also resolves a pre-existing ambiguity — "two fog tokens in 4 different hexes" could be read as two tokens *spread over* four hexes.
- **Line 1012 was reworded by #87** to its current form on verbatim instruction, before Q4 was answered. Q4 supersedes it — flagging so it does not read as churn. The new wording restores symmetry with the other branch ("two different **units** one minor acid each").
- `darkelf.toml:1761` now matches the composite form #87 established in `gnome.toml`.

This is a **nerf** in the overlap case — fog no longer stacks beyond 2 rounds from repeat placements. Confirmed as the intended balance, not a regression to tolerate.

## Part B — `rules/hexes.toml` ✅ approved

> "The proposed wording is fine, and includes Fog."

Part A leaves `rules/hexes.toml` line 4 as the **only** statement anywhere of how many fog tokens to place, and `[hexes.fog]` is named `"Fog"`, not a Cloud. Shipped exactly as proposed in #88:

> When placing Clouds **or Fog** on a hex for the first time, place two tokens of the given type. Otherwise, place only one.

## Changelog ✅ no rows, confirmed

Per #85 decision 9 — the Q4 answer is that these lines always meant the general rule, so removing them preserves intent, and `CONTEXT.md` excludes intent-preserving corrections. Raised in review as arguable for the Part B hunk; the designer confirmed no rows.

## Follow-up filed

#91 — whether the same first-placement doubling rule generalises from hex effects to tokens. `aim` restates it inline the way fog used to, but with different semantics (*place nothing* vs *top up to two*), so it carries a balance decision rather than being a repeat of this PR. That issue also covers the missing `[tokens.shaken]` entry — shaken exists in the game but is not defined in `rules/tokens.toml`.

## Verification

`just check` passes — 586 tests, ruff/typos/pyright clean. Both greps from the plan return empty:

```
git grep -nE "(two|2) (fog|poison cloud)" races/    # no output
git grep -n "fog tokens" races/                     # no output
```

Out of scope and untouched, per #88: the 9 lines that place a *single named effect* rather than stating a token count (`darkelf` 143/215/1344/1362/1529, `dwarf` 1205/1435, `goblin` 1100, `rules/tokens.toml` 78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vrWVsagvioRnTLSS9DLUe
