### PR TITLE
Show the common Model Type of a Unit in army-rules

### DIFF
--- a/v3/CONTEXT.md
+++ b/v3/CONTEXT.md
@@ -120,6 +120,11 @@ A Unit's physical scale, Tiny through Enormous.
 A Model's classification (Infantry, Cavalry, Vehicle, Mechanical, …), used by
 Equipment requirements and rules.
 
+**Common Type**:
+The Types shared by *every* Model in a Unit — the intersection of the Models'
+Types. Summarises a Unit's classification when its Models differ; empty when
+they share nothing.
+
 ### Board and state
 
 **Hex**:

--- a/v3/src/spf/armies/unit.py
+++ b/v3/src/spf/armies/unit.py
@@ -10,6 +10,11 @@ from spf.schemas.race import OrdersConfig, UnitConfig
 # Canonical Speed ordering for stable merged-order output.
 _SPEED_ORDER: list[t.Speed] = list(get_args(t.Speed.__value__))
 
+# Canonical Model Type ordering for stable common-type output. The order of the
+# `ModelType` literal is meaningful: it is what the army-rules Type line is
+# sorted by.
+_MODEL_TYPE_ORDER: list[t.ModelType] = list(get_args(t.ModelType.__value__))
+
 
 @dataclass(frozen=True)
 class Unit:
@@ -35,6 +40,19 @@ class Unit:
         for model in self.models:
             result |= model.unit_specials
         return result
+
+    @property
+    def common_types(self) -> list[t.ModelType]:
+        """Types shared by every Model in the unit, in canonical ModelType order.
+
+        Empty when the unit has no models, or when its models share no type.
+        """
+        if not self.models:
+            return []
+        shared = set(self.models[0].config.type)
+        for model in self.models[1:]:
+            shared &= set(model.config.type)
+        return [model_type for model_type in _MODEL_TYPE_ORDER if model_type in shared]
 
     def cost(self) -> t.Cost:
         """Full unit cost: base + upgrade model costs + equipment costs.

--- a/v3/src/spf/render/army_rules.py
+++ b/v3/src/spf/render/army_rules.py
@@ -86,6 +86,7 @@ class UnitEntry:
     count: int
     size: t.Size
     model_summary: list[str]
+    types: list[t.ModelType]
     armor: list[int] | None
     points: int
     shaken_speed: t.Speed
@@ -156,6 +157,7 @@ def _unit_entry(unit: Unit, *, race: t.RaceName, image_for: ImageLookup) -> Unit
         count=1,
         size=unit.config.size,
         model_summary=_count_summary(unit.models, lambda m: m.display_name),
+        types=unit.common_types,
         armor=list(unit.config.armor) if unit.config.armor is not None else None,
         points=unit.cost().to_points(),
         shaken_speed=unit.config.shaken.speed,

--- a/v3/src/spf/schemas/type_aliases.py
+++ b/v3/src/spf/schemas/type_aliases.py
@@ -232,6 +232,9 @@ type RangeSpecial = Literal[
     "LoS",
 ]
 
+# The order of this literal is meaningful: it is the canonical order a Unit's
+# common Types are printed in (see `Unit.common_types`). Re-ordering it changes
+# rendered output.
 type ModelType = Literal[
     "Elite",
     "SuperElite",

--- a/v3/templates/latex/army-rules/main.tex.jinja
+++ b/v3/templates/latex/army-rules/main.tex.jinja
@@ -30,6 +30,9 @@
 \BLOCK{endif}
 \textbf{Size:} \VAR{unit.size | latex_escape} \\
 \textbf{Models:} \VAR{unit.model_summary | join(', ') | latex_escape} \\
+\BLOCK{if unit.types}
+\textbf{Type:} \VAR{unit.types | join(', ') | latex_escape} \\
+\BLOCK{endif}
 \BLOCK{if unit.armor}
 \textbf{Armor:} \VAR{unit.armor | join(', ')} \\
 \BLOCK{endif}

--- a/v3/templates/markdown/army-rules/main.md.jinja
+++ b/v3/templates/markdown/army-rules/main.md.jinja
@@ -9,6 +9,9 @@
 {% endif %}
 - Size: {{ unit.size }}
 - Models: {{ unit.model_summary | join(', ') }}
+{%- if unit.types %}
+- Type: {{ unit.types | join(', ') }}
+{%- endif %}
 {%- if unit.armor %}
 - Armor: {{ unit.armor | join('/') }}
 {%- endif %}

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -1967,15 +1967,15 @@ def _typed_model(*types: t.ModelType, name: str = "Trooper") -> Model:
     )
 
 
-def _typed_unit(*models: Model, simple_race: RaceConfig) -> Unit:
-    return Unit(name="squad", config=simple_race.units["squad"], models=list(models))
+def _typed_unit(*models: Model, race: RaceConfig) -> Unit:
+    return Unit(name="squad", config=race.units["squad"], models=list(models))
 
 
 def test_common_types_identical_models(simple_race: RaceConfig) -> None:
     unit = _typed_unit(
         _typed_model("Bio", "Infantry", "Walking"),
         _typed_model("Bio", "Infantry", "Walking"),
-        simple_race=simple_race,
+        race=simple_race,
     )
     assert unit.common_types == ["Bio", "Infantry", "Walking"]
 
@@ -1984,7 +1984,7 @@ def test_common_types_partial_overlap_drops_the_extra(simple_race: RaceConfig) -
     unit = _typed_unit(
         _typed_model("Bio", "Infantry", "Walking"),
         _typed_model("Bio", "Infantry", "Walking", "Elite", name="Elite Trooper"),
-        simple_race=simple_race,
+        race=simple_race,
     )
     assert unit.common_types == ["Bio", "Infantry", "Walking"]
 
@@ -1992,19 +1992,22 @@ def test_common_types_partial_overlap_drops_the_extra(simple_race: RaceConfig) -
 def test_common_types_uses_canonical_order_not_declaration_order(
     simple_race: RaceConfig,
 ) -> None:
+    # Mechanical/Infantry/Cavalry are canonically in that order, which is
+    # neither the declaration order below nor alphabetical order — so this
+    # pins the ModelType literal as the sort key and nothing else.
     unit = _typed_unit(
-        _typed_model("Walking", "Bio", "Infantry"),
-        _typed_model("Infantry", "Walking", "Bio"),
-        simple_race=simple_race,
+        _typed_model("Cavalry", "Infantry", "Mechanical", name="Rider"),
+        _typed_model("Infantry", "Mechanical", "Cavalry", name="Other Rider"),
+        race=simple_race,
     )
-    assert unit.common_types == ["Bio", "Infantry", "Walking"]
+    assert unit.common_types == ["Mechanical", "Infantry", "Cavalry"]
 
 
 def test_common_types_zero_overlap_is_empty(simple_race: RaceConfig) -> None:
     unit = _typed_unit(
         _typed_model("Vehicle", "Mechanical", "Bio Crew", "Tracked", name="Wagon"),
         _typed_model("Bio", "Infantry", "Walking"),
-        simple_race=simple_race,
+        race=simple_race,
     )
     assert unit.common_types == []
 
@@ -2012,4 +2015,4 @@ def test_common_types_zero_overlap_is_empty(simple_race: RaceConfig) -> None:
 def test_common_types_of_a_unit_with_no_models_is_empty(
     simple_race: RaceConfig,
 ) -> None:
-    assert _typed_unit(simple_race=simple_race).common_types == []
+    assert _typed_unit(race=simple_race).common_types == []

--- a/v3/tests/armies/test_data.py
+++ b/v3/tests/armies/test_data.py
@@ -16,6 +16,8 @@ from spf.armies.build import (
     _satisfies_requires,
     _unsatisfied_groups,
 )
+from spf.armies.model import Model
+from spf.armies.unit import Unit
 from spf.races import get_race
 from spf.schemas import type_aliases as t
 from spf.schemas.race import (
@@ -1940,3 +1942,74 @@ def test_display_name_uses_the_nick(
     unit = nicked_army.resolve(simple_race).units[0]
     assert unit.display_name == "Da Lads"
     assert unit.models[0].display_name == "Grubnak"
+
+
+# ---------------------------------------------------------------------------
+# Unit.common_types
+# ---------------------------------------------------------------------------
+
+
+def _typed_model(*types: t.ModelType, name: str = "Trooper") -> Model:
+    """Build a resolved Model whose only interesting property is its type list."""
+    return Model(
+        name=name.lower().replace(" ", "_"),
+        config=ModelConfig(
+            race="goblin",
+            name=name,  # pyright: ignore[reportArgumentType]
+            equipment_limit=[],  # pyright: ignore[reportArgumentType]
+            equipment=[],
+            type=list(types),
+            assault=_ASSAULT,
+            cost=None,
+        ),
+        default_equipment=[],
+        upgrade_equipment=[],
+    )
+
+
+def _typed_unit(*models: Model, simple_race: RaceConfig) -> Unit:
+    return Unit(name="squad", config=simple_race.units["squad"], models=list(models))
+
+
+def test_common_types_identical_models(simple_race: RaceConfig) -> None:
+    unit = _typed_unit(
+        _typed_model("Bio", "Infantry", "Walking"),
+        _typed_model("Bio", "Infantry", "Walking"),
+        simple_race=simple_race,
+    )
+    assert unit.common_types == ["Bio", "Infantry", "Walking"]
+
+
+def test_common_types_partial_overlap_drops_the_extra(simple_race: RaceConfig) -> None:
+    unit = _typed_unit(
+        _typed_model("Bio", "Infantry", "Walking"),
+        _typed_model("Bio", "Infantry", "Walking", "Elite", name="Elite Trooper"),
+        simple_race=simple_race,
+    )
+    assert unit.common_types == ["Bio", "Infantry", "Walking"]
+
+
+def test_common_types_uses_canonical_order_not_declaration_order(
+    simple_race: RaceConfig,
+) -> None:
+    unit = _typed_unit(
+        _typed_model("Walking", "Bio", "Infantry"),
+        _typed_model("Infantry", "Walking", "Bio"),
+        simple_race=simple_race,
+    )
+    assert unit.common_types == ["Bio", "Infantry", "Walking"]
+
+
+def test_common_types_zero_overlap_is_empty(simple_race: RaceConfig) -> None:
+    unit = _typed_unit(
+        _typed_model("Vehicle", "Mechanical", "Bio Crew", "Tracked", name="Wagon"),
+        _typed_model("Bio", "Infantry", "Walking"),
+        simple_race=simple_race,
+    )
+    assert unit.common_types == []
+
+
+def test_common_types_of_a_unit_with_no_models_is_empty(
+    simple_race: RaceConfig,
+) -> None:
+    assert _typed_unit(simple_race=simple_race).common_types == []

--- a/v3/tests/render/test_army_rules.py
+++ b/v3/tests/render/test_army_rules.py
@@ -26,7 +26,7 @@ from spf.schemas.race import (
 from spf.schemas.race import (
     EquipmentRangeConfig as RangeConfig,
 )
-from spf.schemas.type_aliases import AtLeastRoll, ExactRoll, RangeRoll
+from spf.schemas.type_aliases import AtLeastRoll, ExactRoll, ModelType, RangeRoll
 from tests.render.conftest import ART, FakeLookup
 
 ENGINE = config.render.latex.engine
@@ -41,20 +41,21 @@ _ASSAULT = AssaultConfig(
 )
 
 
-def _model(
+def _model(  # noqa: PLR0913  test fixture covers every ModelConfig field under test
     *,
     name: str = "Soldier",
     equipment: list[EquipmentConfig] | None = None,
     assault: AssaultConfig = _ASSAULT,
     model_special: dict[str, str] | None = None,
     nick: str | None = None,
+    types: list[ModelType] | None = None,
 ) -> Model:
     config = ModelConfig(
         race="elf",
         name=name,  # pyright: ignore[reportArgumentType]
         equipment_limit=[],  # pyright: ignore[reportArgumentType]
         equipment=[],
-        type=["Infantry"],
+        type=types or ["Infantry"],
         assault=assault,
         cost=None,
         special=model_special or {},  # pyright: ignore[reportArgumentType]
@@ -133,6 +134,7 @@ def test_build_reference_basic_unit_and_model_fields() -> None:
     assert unit_entry.count == 1
     assert unit_entry.size == "Small"
     assert unit_entry.model_summary == ["1x Soldier"]
+    assert unit_entry.types == ["Infantry"]
     assert unit_entry.armor == [10, 8, 6, 4]
     assert unit_entry.points == unit.cost().to_points()
     assert unit_entry.shaken_speed == "slow"
@@ -232,7 +234,7 @@ def test_build_reference_dedups_identical_ranged_equipment_within_a_model() -> N
 
 
 def test_build_reference_collapses_identical_models_within_a_unit() -> None:
-    elite = _model(name="Elite Infantry")
+    elite = _model(name="Elite Infantry", types=["Infantry", "Elite"])
     grunt = _model(name="Infantry")
     unit = _unit(models=[elite, grunt, grunt, elite])
 
@@ -240,7 +242,18 @@ def test_build_reference_collapses_identical_models_within_a_unit() -> None:
 
     (unit_entry,) = reference.units
     assert unit_entry.model_summary == ["2x Elite Infantry", "2x Infantry"]
+    assert unit_entry.types == ["Infantry"]
     assert [m.name for m in unit_entry.models] == ["Elite Infantry", "Infantry"]
+
+
+def test_build_reference_types_is_empty_when_models_share_nothing() -> None:
+    walker = _model(name="Trooper", types=["Bio", "Infantry", "Walking"])
+    wagon = _model(name="Wagon", types=["Vehicle", "Mechanical", "Tracked"])
+
+    reference = build_reference(_army(_unit(models=[walker, wagon])), stem="test")
+
+    (unit_entry,) = reference.units
+    assert unit_entry.types == []
 
 
 def test_build_reference_keeps_distinct_model_upgrades_separate() -> None:


### PR DESCRIPTION
Closes #83.

Adds a `Type:` line to the army-rules unit block listing the Types that **every**
Model in the Unit has in common.

## What changed

- `Unit.common_types` — the intersection of the Models' Types, returned in the
  canonical `ModelType` literal order (derived with `get_args`, never a second
  hand-maintained list). A Unit with no Models yields `[]`.
- `UnitEntry.types` on the render view model, populated from `unit.common_types`.
- The `Type:` line in **both** the LaTeX and Markdown army-rules templates,
  omitted entirely when the intersection is empty.
- A **Common Type** entry in the `CONTEXT.md` glossary.
- A note beside the `ModelType` literal that its order is now meaningful. The
  literal itself is **not** re-ordered — re-ordering it into semantic groups is a
  separate editorial decision.

## Manual verification

The army-rules templates have no golden/snapshot tests, so they were checked by
rendering real armies.

The issue's acceptance example, from `showcase/goblin`:

```
- Models: 4x Goblin Infantry
- Type: Bio, Infantry, Walking
```

A mixed unit shows the intersection, not the union (`2025/geir_arne`):

```
- Models: 1x Elite Ork Infantry, 3x Ork Infantry
- Type: Infantry, Walking
```

Both `Bio` and `Elite` correctly drop out — `Elite Ork Infantry` is
`["Elite", "Infantry", "Walking"]` in `races/ork.toml:676`, so it genuinely has
no `Bio`.

Canonical ordering is visible in the vehicle entries, which do not print
alphabetically:

```
- Models: 1x Goblin Infantry Carrier
- Type: Mechanical, Vehicle, Tracked
```

No real army has a zero-overlap unit, so that case was driven through the real
templates with a synthetic `types=[]`: the line is omitted in both formats, with
no stray blank line and no dangling `\\` in the LaTeX. The PDF compiles.

## Tests

Domain tests in `tests/armies/test_data.py` cover identical models, partial
overlap, canonical ordering, zero overlap, and the no-models guard; view-model
assertions extended in `tests/render/test_army_rules.py`.

The ordering test deliberately uses `Mechanical`/`Infantry`/`Cavalry`, whose
canonical order is neither the declaration order nor alphabetical — verified by
mutation: it fails if the implementation is swapped for `sorted()`.

`just check` clean: 592 passed, pyright 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKuKwSjaZV3hNVWAtr8wLC
