### PR TITLE
Give tokens a general first-placement rule

### DIFF
--- a/v3/rules/changelog.md
+++ b/v3/rules/changelog.md
@@ -5,7 +5,7 @@ captures *why* a rule was changed.
 
 | Date | Description | Why |
 | ---------- | ------------------------------ | ------------------------------ |
-| 06.08.2026 | Aim and Shaken now follow one general first-placement rule; re-aiming an already-aimed unit adds a token instead of nothing | Aim restated the rule with different wording and different meaning; unified so every token behaves alike |
+| 06.08.2026 | Aim and Shaken now follow one general first-placement rule; re-aiming an already-aimed unit adds a token instead of nothing | Aim stated the rule in its own words and meant something different; unified so Aim and Shaken behave alike |
 | 05.08.2026 | added aim, and added orders    | Completing the rules           |
 | 28.07.2026 | Bugfix and added missing       | Bugfix                         |
 | 28.07.2026 | Added no command and no repair | Abomination flagship need them |

--- a/v3/rules/changelog.md
+++ b/v3/rules/changelog.md
@@ -5,6 +5,7 @@ captures *why* a rule was changed.
 
 | Date | Description | Why |
 | ---------- | ------------------------------ | ------------------------------ |
+| 06.08.2026 | Aim and Shaken now follow one general first-placement rule; re-aiming an already-aimed unit adds a token instead of nothing | Aim restated the rule with different wording and different meaning; unified so every token behaves alike |
 | 05.08.2026 | added aim, and added orders    | Completing the rules           |
 | 28.07.2026 | Bugfix and added missing       | Bugfix                         |
 | 28.07.2026 | Added no command and no repair | Abomination flagship need them |

--- a/v3/rules/tokens.toml
+++ b/v3/rules/tokens.toml
@@ -1,6 +1,6 @@
 explanation = """When placing Aim or Shaken on a unit for the first time, place two tokens of the given type. Otherwise, place only one.
 
-This rule covers Aim and Shaken. Confused is an exception: follow the instructions in its own entry.
+No other token is placed this way. Confused in particular is an exception: it works differently, and this rule does not cover it.
 
 Follow the instructions for each token.
 """
@@ -17,7 +17,7 @@ remove = "Remove one each aftermath phase. Can also be removed by appropriate re
 name = "Aim"
 phases = ["Gunnery 1", "Gunnery 2"]
 effect = "Get +2 to hit an enemy. Only valid for units in line of sight of the hex where the aim was given. Last for only 1 round."
-remove = "Either remove them both when you fire, or remove one each aftermath phase. Also remove both if you enter an assault (regardless of whether you win or not)"
+remove = "Either remove all aim tokens when you fire, or remove one each aftermath phase. Also remove all of them if you enter an assault (regardless of whether you win or not)"
 
 [tokens.crippled_crew]
 name = "Crippled Crew"

--- a/v3/rules/tokens.toml
+++ b/v3/rules/tokens.toml
@@ -1,16 +1,23 @@
+explanation = """When placing Aim or Shaken on a unit for the first time, place two tokens of the given type. Otherwise, place only one.
+
+This rule covers Aim and Shaken. Confused is an exception: follow the instructions in its own entry.
+
+Follow the instructions for each token.
+"""
+
 [tokens]
 
 [tokens.shaken]
 name = "Shaken"
 phases = ["Gunnery 1", "Movement 1", "Movement 2", "Movement 3", "Gunnery 2"]
 effect = "While shaken set unit speed to the spefied speed, and how a unit behaves is described by each unit. Disregard the original orders and replace them with the order(s) described by the unit"
-remove = "First time a unit is shaken, place two shaken tokens. If it is already shaken place only one. Remove one each aftermath phase. Can also be removed by appropriate repair or healing abilities"
+remove = "Remove one each aftermath phase. Can also be removed by appropriate repair or healing abilities"
 
 [tokens.aim]
 name = "Aim"
 phases = ["Gunnery 1", "Gunnery 2"]
 effect = "Get +2 to hit an enemy. Only valid for units in line of sight of the hex where the aim was given. Last for only 1 round."
-remove = "Place two aim tokens (unless the unit already have one). Either remove them both when you fire, or remove one each aftermath phase. Also remove both if you enter an assault (regardless of whether you win or not)"
+remove = "Either remove them both when you fire, or remove one each aftermath phase. Also remove both if you enter an assault (regardless of whether you win or not)"
 
 [tokens.crippled_crew]
 name = "Crippled Crew"

--- a/v3/src/spf/render/rulebook.py
+++ b/v3/src/spf/render/rulebook.py
@@ -252,10 +252,13 @@ def _effect_entry(config: TokenRuleConfig | HexRuleConfig) -> RuleEntry:
 
 
 def parse_tokens(path: Path, context: RulesContext) -> RulesBody:  # noqa: ARG001  a Token names no other rule
-    """Read `tokens.toml` as one untitled group of rules, in file order."""
+    """Read `tokens.toml`: its document-level prose, then one untitled group."""
     config = rules.get_tokens(path)
     entries = [_effect_entry(token) for token in config.tokens.values()]
-    return RulesBody(explanation=None, groups=[RuleGroup(title=None, rules=entries)])
+    return RulesBody(
+        explanation=config.explanation,
+        groups=[RuleGroup(title=None, rules=entries)],
+    )
 
 
 TOKENS = register_kind(SectionKind(name="tokens", parse=parse_tokens))

--- a/v3/src/spf/schemas/rules.py
+++ b/v3/src/spf/schemas/rules.py
@@ -72,6 +72,7 @@ class TokenRuleConfig(StrictModel):
 
 
 class TokenRulesConfig(StrictModel):
+    explanation: str
     tokens: dict[str, TokenRuleConfig]
 
 

--- a/v3/templates/latex/general-rules/rules-body.tex.jinja
+++ b/v3/templates/latex/general-rules/rules-body.tex.jinja
@@ -22,18 +22,23 @@
 \BLOCK{if rule.body}
 \VAR{rule.body | md_to_latex}
 \BLOCK{endif}
+
 \BLOCK{if rule.description}
 \textbf{Represents:} \VAR{rule.description | md_to_latex}
 \BLOCK{endif}
+
 \BLOCK{if rule.example}
 \textbf{Example:} \VAR{rule.example | md_to_latex}
 \BLOCK{endif}
+
 \BLOCK{if rule.token}
 \textbf{Places:} \VAR{rule.token | latex_escape}
 \BLOCK{endif}
+
 \BLOCK{if rule.phases}
 \textbf{Phases:} \VAR{rule.phases | join(", ") | latex_escape}
 \BLOCK{endif}
+
 \BLOCK{if rule.remove}
 \textbf{Removed:} \VAR{rule.remove | latex_escape}
 \BLOCK{endif}

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -132,6 +132,8 @@ def test_unknown_kind_lists_the_known_kinds() -> None:
 # --- RulesContext -----------------------------------------------------------
 
 TOKENS_SOURCE = """\
+explanation = "How tokens work."
+
 [tokens]
 
 [tokens.minor_acid]
@@ -232,6 +234,8 @@ def test_markdown_kind_keeps_a_hash_that_is_not_a_heading(tmp_path: Path) -> Non
 # --- The tokens kind's parser -----------------------------------------------
 
 FULL_TOKENS_SOURCE = """\
+explanation = "Place two of a token the first time, one thereafter."
+
 [tokens]
 
 [tokens.poison]
@@ -266,7 +270,7 @@ def test_tokens_kind_yields_one_untitled_group_in_file_order(tmp_path: Path) -> 
     body = parse_tokens(source, RulesContext(tmp_path))
 
     assert isinstance(body, RulesBody)
-    assert body.explanation is None
+    assert body.explanation == "Place two of a token the first time, one thereafter."
     (group,) = body.groups
     assert isinstance(group, RuleGroup)
     assert group.title is None
@@ -314,7 +318,7 @@ def test_hexes_kind_is_registered() -> None:
 
 
 def test_hexes_kind_keeps_the_document_level_explanation(tmp_path: Path) -> None:
-    # The only one of the three sources with prose above its table.
+    # One of the two sources with prose above its table; tokens.toml is the other.
     source = tmp_path / "hexes.toml"
     source.write_text(HEXES_SOURCE, encoding="utf-8")
 

--- a/v3/tests/render/test_rulebook.py
+++ b/v3/tests/render/test_rulebook.py
@@ -277,6 +277,16 @@ def test_tokens_kind_yields_one_untitled_group_in_file_order(tmp_path: Path) -> 
     assert [rule.name for rule in group.rules] == ["Poison", "Terror"]
 
 
+def test_tokens_kind_keeps_the_document_level_explanation(tmp_path: Path) -> None:
+    # The twin of the hexes case: both sources carry prose above their table.
+    source = tmp_path / "tokens.toml"
+    source.write_text(FULL_TOKENS_SOURCE, encoding="utf-8")
+
+    body = parse_tokens(source, RulesContext(tmp_path))
+
+    assert body.explanation == "Place two of a token the first time, one thereafter."
+
+
 def test_tokens_kind_carries_every_field_across(tmp_path: Path) -> None:
     source = tmp_path / "tokens.toml"
     source.write_text(FULL_TOKENS_SOURCE, encoding="utf-8")

--- a/v3/tests/test_rules.py
+++ b/v3/tests/test_rules.py
@@ -18,6 +18,8 @@ explanation = "A probe."
 """
 
 TOKENS = """\
+explanation = "How tokens work."
+
 [tokens]
 
 [tokens.probe]
@@ -55,7 +57,10 @@ def test_get_tokens_reads_an_explicit_path(tmp_path: Path) -> None:
     path = tmp_path / "tokens.toml"
     path.write_text(TOKENS, encoding="utf-8")
 
-    assert rules.get_tokens(path).tokens["probe"].name == "Probe Token"
+    index = rules.get_tokens(path)
+
+    assert index.explanation == "How tokens work."
+    assert index.tokens["probe"].name == "Probe Token"
 
 
 def test_get_hexes_defaults_to_the_committed_file() -> None:


### PR DESCRIPTION
Closes #91. Implements your answers to Q1–Q5, and does for tokens what #89 did for hex effects.

## What changed

`rules/tokens.toml` gains a top-level `explanation`, mirroring the one `rules/hexes.toml` already has:

> When placing Aim or Shaken on a unit for the first time, place two tokens of the given type. Otherwise, place only one.
>
> No other token is placed this way. Confused in particular is an exception: it works differently, and this rule does not cover it.
>
> Follow the instructions for each token.

The now-redundant restatements come out of both `remove` fields:

| Token | Before | After |
|---|---|---|
| Shaken | "First time a unit is shaken, place two shaken tokens. If it is already shaken place only one. Remove one each aftermath phase. …" | "Remove one each aftermath phase. …" |
| Aim | "Place two aim tokens (unless the unit already have one). Either remove them both when you fire, …" | "Either remove all aim tokens when you fire, …" |

**Q2 / option (b) is live in that Aim row.** Aim's old text capped the count — placing aim on an already-aimed unit added *nothing*. It now adds one, per the general rule.

Aim's placement wording also sat in the `remove` field, which is for removal instructions; that's fixed by the move.

## Q3 — you asked what I thought: two separate rules

I went with your lean. Reasons: the two `explanation` fields render into their own rulebook sections, so a player reading Tokens shouldn't have to cross-reference Hexes; the scopes aren't actually identical (hexes covers its types wholesale, tokens covers an enumerated pair with a carve-out), so one merged rule would be longer and harder to read; and there's no shared home in the schema or renderer to put a single rule in. The tokens sentence is written as a deliberate mirror of the hexes one so the parallel is visible.

## Code

`TokenRulesConfig` gains a **required** `explanation: str`, matching `HexRulesConfig` — after this change a tokens file always carries the rule, so a missing one is a data error worth catching. `parse_tokens` carries it through exactly as `parse_hexes` does.

Also on the branch: your LaTeX spacing tweak to `templates/latex/general-rules/rules-body.tex.jinja`, and your typo fixes merged in from master.

## Two things for you

1. **The count is no longer capped.** Under option (b), a unit aimed at twice in one round holds three tokens, and a hex fogged twice holds three. That follows from "Otherwise, place only one" and applies to hexes too (already merged in #89) — I have not tried to add a cap, since you said (b) is intended "for all future similar options as well". Flagging in case you want a "never more than two" clause; it'd be a one-line change to both rules.
2. **Confused still states no placement count.** The rule now explicitly excludes it, per Q1, so a reader learns Confused is different but not what it actually does. Out of scope here — say the word and I'll open an issue.

## Changelog

One row in `rules/changelog.md`. Q5 says play shouldn't change in practice, but Q2 (b) is a deliberate change to the rules text, which meets `CONTEXT.md`'s "intentional **and** alters rules" bar. Easy to drop if you'd rather not have it.

## Verification

`just check` passes clean — 593 tests, ruff/typos/pyright/race-lint all green. The rulebook renders the new prose in its Tokens section, and the Aim entry now reads correctly standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vrWVsagvioRnTLSS9DLUe
